### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Get started quickly, see [Configuration](#configuration) for more details:
 npx figma-developer-mcp --figma-api-key=<your-figma-api-key>
 ```
 
+<a href="https://glama.ai/mcp/servers/kcftotr525"><img width="380" height="200" src="https://glama.ai/mcp/servers/kcftotr525/badge" alt="Figma Server MCP server" /></a>
+
 ## Demo Video
 
 [Watch a demo of building a UI in Cursor with Figma design data](https://youtu.be/6G9yb-LrEqg)


### PR DESCRIPTION
This PR adds a badge for the [Figma MCP Server](https://glama.ai/mcp/servers/kcftotr525) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kcftotr525"><img width="380" height="200" src="https://glama.ai/mcp/servers/kcftotr525/badge" alt="Figma Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.