### PR TITLE
feat: Extracting global variables

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,10 +22,36 @@ export class FigmaMcpServer {
   }
 
   private registerTools(): void {
-    // Tool to get file information
     this.server.tool(
+      "get_image", 
+      "Get the icon file, Get images from Figma data based on the imageRef of image nodes",
+      {
+        fileKey: z.string().describe("The key of the Figma file containing the node"),
+        nodeId: z.string().describe("The ID of the node to fetch"),
+        fileName: z.string().describe("The name of the file to fetch"),
+        localPath: z.string().describe("The absolute path to the directory where images are stored in the project"),
+      },
+      async ({ fileKey, nodeId, fileName, localPath }) => {
+        try {
+          console.log(
+            `get image: ${nodeId} from file: ${fileKey}`,
+          );
+          const saveSuccess = await this.figmaService.getImage(fileKey, nodeId, fileName, localPath);
+          return {
+            content: [{ type: "text", text: saveSuccess ? "Success" : "Failed" }],
+          };
+        } catch (error) {
+          console.error(`Error download node ${nodeId} from file ${fileKey}:`, error);
+          return {
+            content: [{ type: "text", text: `Error fetching node: ${error}` }],
+          };
+        }
+      },
+    );  
+     // Tool to get file information
+     this.server.tool(
       "get_file",
-      "Get layout information about an entire Figma file",
+      "When the nodeId cannot be obtained, obtain the layout information about the entire Figma file",
       {
         fileKey: z.string().describe("The key of the Figma file to fetch"),
         depth: z.number().optional().describe("How many levels deep to traverse the node tree"),

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,20 +23,25 @@ export class FigmaMcpServer {
 
   private registerTools(): void {
     this.server.tool(
-      "get_image", 
+      "get_image",
       "Get the icon file, Get images from Figma data based on the imageRef of image nodes",
       {
         fileKey: z.string().describe("The key of the Figma file containing the node"),
         nodeId: z.string().describe("The ID of the node to fetch"),
         fileName: z.string().describe("The name of the file to fetch"),
-        localPath: z.string().describe("The absolute path to the directory where images are stored in the project"),
+        localPath: z
+          .string()
+          .describe("The absolute path to the directory where images are stored in the project"),
       },
       async ({ fileKey, nodeId, fileName, localPath }) => {
         try {
-          console.log(
-            `get image: ${nodeId} from file: ${fileKey}`,
+          console.log(`get image: ${nodeId} from file: ${fileKey}`);
+          const saveSuccess = await this.figmaService.getImage(
+            fileKey,
+            nodeId,
+            fileName,
+            localPath,
           );
-          const saveSuccess = await this.figmaService.getImage(fileKey, nodeId, fileName, localPath);
           return {
             content: [{ type: "text", text: saveSuccess ? "Success" : "Failed" }],
           };
@@ -47,14 +52,19 @@ export class FigmaMcpServer {
           };
         }
       },
-    );  
-     // Tool to get file information
-     this.server.tool(
+    );
+    // Tool to get file information
+    this.server.tool(
       "get_file",
       "When the nodeId cannot be obtained, obtain the layout information about the entire Figma file",
       {
         fileKey: z.string().describe("The key of the Figma file to fetch"),
-        depth: z.number().optional().describe("How many levels deep to traverse the node tree"),
+        depth: z
+          .number()
+          .optional()
+          .describe(
+            "How many levels deep to traverse the node tree, only use if explicitly requested by the user",
+          ),
       },
       async ({ fileKey, depth }) => {
         try {
@@ -85,8 +95,14 @@ export class FigmaMcpServer {
       "get_node",
       "Get layout information about a specific node in a Figma file",
       {
-        fileKey: z.string().describe("The key of the Figma file containing the node"),
-        nodeId: z.string().describe("The ID of the node to fetch"),
+        fileKey: z
+          .string()
+          .describe(
+            "The key of the Figma file containing the node, often found in a provided URL like figma.com/(file|design)/<fileKey>/...",
+          ),
+        nodeId: z
+          .string()
+          .describe("The ID of the node to fetch, often found as URL parameter node-id=<nodeId>"),
         depth: z.number().optional().describe("How many levels deep to traverse the node tree"),
       },
       async ({ fileKey, nodeId, depth }) => {

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -1,12 +1,12 @@
 import axios, { AxiosError } from "axios";
 import { FigmaError } from "~/types/figma";
 import fs from "fs";
-import {
-  parseFigmaFileResponse,
-  parseFigmaResponse,
-  SimplifiedDesign,
-} from "./simplify-node-response";
-import type { GetImagesResponse, GetFileResponse, GetFileNodesResponse } from "@figma/rest-api-spec";
+import { parseFigmaResponse, SimplifiedDesign } from "./simplify-node-response";
+import type {
+  GetImagesResponse,
+  GetFileResponse,
+  GetFileNodesResponse,
+} from "@figma/rest-api-spec";
 import { downloadFigmaImage } from "~/utils/common";
 
 export class FigmaService {
@@ -38,10 +38,15 @@ export class FigmaService {
     }
   }
 
-  async getImage(fileKey: string, nodeId: string, fileName: string, localPath: string): Promise<boolean> {
+  async getImage(
+    fileKey: string,
+    nodeId: string,
+    fileName: string,
+    localPath: string,
+  ): Promise<boolean> {
     const endpoint = `/images/${fileKey}?ids=${nodeId}&scale=2&format=png`;
     const file = await this.request<GetImagesResponse>(endpoint);
-    const {images = {}} = file
+    const { images = {} } = file;
     let success = false;
     if (images[nodeId]) {
       await downloadFigmaImage(fileName, localPath, images[nodeId]);
@@ -50,14 +55,14 @@ export class FigmaService {
     }
     return success;
   }
-  
+
   async getFile(fileKey: string, depth?: number): Promise<SimplifiedDesign> {
     try {
       const endpoint = `/files/${fileKey}${depth ? `?depth=${depth}` : ""}`;
       console.log(`Calling ${this.baseUrl}${endpoint}`);
       const response = await this.request<GetFileResponse>(endpoint);
       console.log("Got response");
-      const simplifiedResponse = parseFigmaFileResponse(response);
+      const simplifiedResponse = parseFigmaResponse(response);
       writeLogs("figma-raw.json", response);
       writeLogs("figma-simplified.json", simplifiedResponse);
       return simplifiedResponse;

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -6,7 +6,8 @@ import {
   parseFigmaResponse,
   SimplifiedDesign,
 } from "./simplify-node-response";
-import type { GetFileResponse, GetFileNodesResponse } from "@figma/rest-api-spec";
+import type { GetImagesResponse, GetFileResponse, GetFileNodesResponse } from "@figma/rest-api-spec";
+import { downloadFigmaImage } from "~/utils/common";
 
 export class FigmaService {
   private readonly apiKey: string;
@@ -37,6 +38,19 @@ export class FigmaService {
     }
   }
 
+  async getImage(fileKey: string, nodeId: string, fileName: string, localPath: string): Promise<boolean> {
+    const endpoint = `/images/${fileKey}?ids=${nodeId}&scale=2&format=png`;
+    const file = await this.request<GetImagesResponse>(endpoint);
+    const {images = {}} = file
+    let success = false;
+    if (images[nodeId]) {
+      await downloadFigmaImage(fileName, localPath, images[nodeId]);
+      console.log(`Successfully save image`, localPath, fileName);
+      success = true;
+    }
+    return success;
+  }
+  
   async getFile(fileKey: string, depth?: number): Promise<SimplifiedDesign> {
     try {
       const endpoint = `/files/${fileKey}${depth ? `?depth=${depth}` : ""}`;

--- a/src/services/simplify-node-response.ts
+++ b/src/services/simplify-node-response.ts
@@ -60,7 +60,6 @@ export interface SimplifiedNode {
   id: string;
   name: string;
   type: string; // e.g. FRAME, TEXT, INSTANCE, RECTANGLE, etc.
-  size?: {};
   // geometry
   boundingBox?: BoundingBox;
   // text
@@ -135,15 +134,13 @@ function parseGlobalVars(globalVars: GlobalVars, simplifiedNodes: SimplifiedNode
         // If parent node is found, modify it directly
         if (parentNode) {
           // Save original size information
-          const {id, size} = parentNode;
+          const {id} = parentNode;
           Object.keys(parentNode).forEach(key => {
             delete parentNode[key as keyof SimplifiedNode];
           })
           Object.assign(parentNode, {
             id,
-            name: "Image",
             type: "IMAGE",
-            size
           })
         }
       });
@@ -284,7 +281,7 @@ function parseNode(globalVars: Record<string, any>, n: FigmaDocumentNode, parent
     simplified.fills = findOrCreateVar(globalVars, fills, 'fill');
   }
   if (hasValue("styles", n)) {
-    simplified.styles = JSON.stringify(n.styles);
+    simplified.styles = findOrCreateVar(globalVars, n.styles, 'styles');
   }
   if (hasValue("strokes", n) && Array.isArray(n.strokes) && n.strokes.length) {
     const strokes = n.strokes.map(parsePaint);
@@ -338,14 +335,6 @@ function parseNode(globalVars: Record<string, any>, n: FigmaDocumentNode, parent
     let children =  n.children.map((child) => parseNode(globalVars, child, n)).filter((child) => child !== null && child !== undefined);
     if (children.length){
       simplified.children = children
-    }
-  }
-  
-  if (hasValue("absoluteBoundingBox", n)) {
-    const { width, height } = n.absoluteBoundingBox || {};
-    simplified.size = {
-      width,
-      height
     }
   }
 

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -39,9 +39,9 @@ export interface SimplifiedLayout {
 export function buildSimplifiedLayout(
   n: FigmaDocumentNode,
   parent?: FigmaDocumentNode,
-): SimplifiedLayout | undefined {
+): SimplifiedLayout {
   const frameValues = buildSimplifiedFrameValues(n);
-  const layoutValues = buildSimplifiedLayoutValues(n, parent, frameValues.mode);
+  const layoutValues = buildSimplifiedLayoutValues(n, parent, frameValues.mode) || {};
 
   return { ...frameValues, ...layoutValues };
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,189 @@
+import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
+
+import type {
+  RGBA,
+} from "@figma/rest-api-spec";
+
+export interface ColorValue {
+  hex: string;
+  opacity: number;
+}
+
+/**
+ * Download Figma image and save it locally
+ * @param fileName - The filename to save as
+ * @param localPath - The local path to save to
+ * @param imageUrl - Image URL (images[nodeId])
+ * @returns A Promise that resolves to the full file path where the image was saved
+ * @throws Error if download fails
+ */
+export async function downloadFigmaImage(
+  fileName: string, 
+  localPath: string, 
+  imageUrl: string
+): Promise<string> {
+  try {
+    // Ensure local path exists
+    if (!fs.existsSync(localPath)) {
+      fs.mkdirSync(localPath, { recursive: true });
+    }
+    
+    // Build the complete file path
+    const fullPath = path.join(localPath, fileName);
+    
+    // Use axios to download the image, set responseType to stream
+    const response = await axios({
+      method: 'GET',
+      url: imageUrl,
+      responseType: 'stream',
+      timeout: 30000, // 30 seconds timeout
+    });
+    
+    // Create write stream
+    const writer = fs.createWriteStream(fullPath);
+    
+    // Pipe response stream to file stream
+    response.data.pipe(writer);
+    
+    // Return a Promise that resolves when writing is complete
+    return new Promise((resolve, reject) => {
+      writer.on('finish', () => {
+        console.log(`Image saved to: ${fullPath}`);
+        resolve(fullPath);
+      });
+      
+      writer.on('error', (err: Error) => {
+        // Delete partially downloaded file
+        fs.unlink(fullPath, () => {});
+        reject(new Error(`Failed to download image: ${err.message}`));
+      });
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Error downloading image: ${errorMessage}`);
+  }
+}
+
+/**
+ * Remove keys with empty arrays or empty objects from an object.
+ * @param input - The input object or value.
+ * @returns The processed object or the original value.
+ */
+export function removeEmptyKeys<T>(input: T): T {
+  // If not an object type or null, return directly
+  if (typeof input !== 'object' || input === null) {
+    return input;
+  }
+
+  // Handle array type
+  if (Array.isArray(input)) {
+    return input.map(item => removeEmptyKeys(item)) as T;
+  }
+
+  // Handle object type
+  const result = {} as T;
+  for (const key in input) {
+    if (Object.prototype.hasOwnProperty.call(input, key)) {
+      const value = input[key];
+      
+      // Recursively process nested objects
+      const cleanedValue = removeEmptyKeys(value);
+      
+      // Skip empty arrays and empty objects
+      if (
+        cleanedValue !== undefined && 
+        !(Array.isArray(cleanedValue) && cleanedValue.length === 0) &&
+        !(typeof cleanedValue === 'object' && 
+          cleanedValue !== null && 
+          Object.keys(cleanedValue).length === 0)
+      ) {
+        result[key] = cleanedValue;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert hex color value and opacity to rgba format
+ * @param hex - Hexadecimal color value (e.g., "#FF0000" or "#F00")
+ * @param opacity - Opacity value (0-1)
+ * @returns Color string in rgba format
+ */
+export function hexToRgba(hex: string, opacity: number = 1): string {
+  // Remove possible # prefix
+  hex = hex.replace('#', '');
+  
+  // Handle shorthand hex values (e.g., #FFF)
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+  
+  // Convert hex to RGB values
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  
+  // Ensure opacity is in the 0-1 range
+  const validOpacity = Math.min(Math.max(opacity, 0), 1);
+  
+  return `rgba(${r}, ${g}, ${b}, ${validOpacity})`;
+}
+
+/**
+ * Convert color from RGBA to { hex, opacity }
+ *
+ * @param color - The color to convert, including alpha channel
+ * @param opacity - The opacity of the color, if not included in alpha channel
+ * @returns The converted color
+ **/
+export function convertColor(color: RGBA, opacity = 1): ColorValue {
+  const r = Math.round(color.r * 255);
+  const g = Math.round(color.g * 255);
+  const b = Math.round(color.b * 255);
+
+  // Alpha channel defaults to 1. If opacity and alpha are both and < 1, their effects are multiplicative
+  const a = Math.round(opacity * color.a * 100) / 100;
+
+  const hex = "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1).toUpperCase();
+
+  return { hex, opacity: a };
+}
+
+/**
+ * Convert color from RGBA to { hex, opacity }
+ *
+ * @param color - The color to convert, including alpha channel
+ * @param opacity - The opacity of the color, if not included in alpha channel
+ * @returns The converted color
+ **/
+export function formatRGBAColor(color: RGBA, opacity = 1): string {
+  const r = Math.round(color.r * 255);
+  const g = Math.round(color.g * 255);
+  const b = Math.round(color.b * 255);
+  // Alpha channel defaults to 1. If opacity and alpha are both and < 1, their effects are multiplicative
+  const a = Math.round(opacity * color.a * 100) / 100;
+
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+/**
+ * Generate a 6-character random variable ID
+ * @param prefix - ID prefix
+ * @returns A 6-character random ID string with prefix
+ */
+export function generateVarId(prefix: string = 'var'): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  
+  for (let i = 0; i < 6; i++) {
+    const randomIndex = Math.floor(Math.random() * chars.length);
+    result += chars[randomIndex];
+  }
+  
+  return `${prefix}_${result}`;
+}
+


### PR DESCRIPTION
## changelog
1.  Extract all attribute objects to globalVars to reduce the volume of simplifiedResponse and facilitate AI to extract variables
2.  Extract vector elements that are not easy to implement in code and convert them into image nodes.
3.  Ignore all hidden nodes and empty nodes
4.  Add a new get_image tools to download the image of the vector node. You can tell AI to "download the image node to local" to trigger it.