### PR TITLE
Add Qodo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Figma MCP Server
 
-Give [Cursor](https://cursor.sh/), [Windsurf](https://codeium.com/windsurf), [Cline](https://cline.bot/), and other AI-powered coding tools access to your Figma files with this [Model Context Protocol](https://modelcontextprotocol.io/introduction) server.
+Give [Cursor](https://cursor.sh/), [Windsurf](https://codeium.com/windsurf), [Cline](https://cline.bot/), [Qodo](https://qodo.ai/), and other AI-powered coding tools access to your Figma files with this [Model Context Protocol](https://modelcontextprotocol.io/introduction) server.
 
 When Cursor has access to Figma design data, it's **way** better at one-shotting designs accurately than alternative approaches like pasting screenshots.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Instructions on how to create a Figma API access token can be found [here](https
 
 ### JSON config for tools that use configuration files
 
-Many tools like Windsurf, Cline, and [Claude Desktop](https://claude.ai/download) use a configuration file to start the server.
+Many tools like Windsurf, Cline, Qodo, and [Claude Desktop](https://claude.ai/download) use a configuration file to start the server.
 
 The `figma-developer-mcp` server can be configured by adding the following to your configuration file:
 


### PR DESCRIPTION
At Qodo (https://qodo.ai), we recently launched support for MCPs in our agentic IDE plugins (Qodo Gen) that have over 1M downloads across VS Code and JetBrains marketplaces.

We have many Figma related use cases, and our customers started using your awesome MCP server.

We kindly request that our name be added to the list of coding agents that support this MCP server, so we edited this readme accordingly.

Thanks!
Dedy Kredo (Co-founder and CPO of Qodo)