### PR TITLE
Add multilingual support for documentation (ko/ja/zh)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,99 @@
+<a href="https://www.framelink.ai/?utm_source=github&utm_medium=readme&utm_campaign=readme" target="_blank" rel="noopener">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.framelink.ai/github/HeaderDark.png" />
+    <img alt="Framelink" src="https://www.framelink.ai/github/HeaderLight.png" />
+  </picture>
+</a>
+
+<div align="center">
+  <h1>Framelink Figma MCP サーバー</h1>
+  <p>
+    🌐 利用可能な言語:
+    <a href="README.md">English</a> |
+    <a href="README.ko.md">한국어 (Korean)</a> |
+    <a href="README.zh.md">中文 (Chinese)</a>
+  </p>
+  <h3>コーディングエージェントにFigmaデータへのアクセスを提供。<br/>ワンショットで任意のフレームワークにデザインを実装。</h3>
+  <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">
+    <img alt="週間ダウンロード" src="https://img.shields.io/npm/dm/figma-developer-mcp.svg">
+  </a>
+  <a href="https://github.com/GLips/Figma-Context-MCP/blob/main/LICENSE">
+    <img alt="MITライセンス" src="https://img.shields.io/github/license/GLips/Figma-Context-MCP" />
+  </a>
+  <a href="https://framelink.ai/discord">
+    <img alt="Discord" src="https://img.shields.io/discord/1352337336913887343?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <br />
+  <a href="https://twitter.com/glipsman">
+    <img alt="Twitter" src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fglipsman&label=%40glipsman" />
+  </a>
+</div>
+
+<br/>
+
+[Cursor](https://cursor.sh/)、[Windsurf](https://codeium.com/windsurf)、[Cline](https://cline.bot/)などのAI搭載コーディングツールに、この[Model Context Protocol](https://modelcontextprotocol.io/introduction)サーバーを通じてFigmaファイルへのアクセスを提供します。
+
+CursorがFigmaデザインデータにアクセスできる場合、スクリーンショットを貼り付けるなどの代替アプローチよりも**はるかに**正確にワンショットでデザインを実装できます。
+
+<h3><a href="https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme">クイックスタートガイドを見る →</a></h3>
+
+## デモ
+
+[FigmaデザインデータでCursorでUIを構築するデモを見る](https://youtu.be/6G9yb-LrEqg)
+
+[![ビデオを見る](https://img.youtube.com/vi/6G9yb-LrEqg/maxresdefault.jpg)](https://youtu.be/6G9yb-LrEqg)
+
+## 仕組み
+
+1. IDEのチャットを開きます（例：Cursorのエージェントモード）。
+2. Figmaファイル、フレーム、またはグループへのリンクを貼り付けます。
+3. CursorにFigmaファイルで何かをするように依頼します（例：デザインの実装）。
+4. CursorはFigmaから関連するメタデータを取得し、コードを書くために使用します。
+
+このMCPサーバーは、Cursorで使用するために特別に設計されています。[Figma API](https://www.figma.com/developers/api)からコンテキストを応答する前に、応答を簡素化して翻訳し、モデルに最も関連性の高いレイアウトとスタイリング情報のみを提供します。
+
+モデルに提供されるコンテキストの量を減らすことで、AIの精度を高め、応答をより関連性のあるものにするのに役立ちます。
+
+## はじめに
+
+多くのコードエディタやその他のAIクライアントは、MCPサーバーを管理するために設定ファイルを使用します。
+
+`figma-developer-mcp`サーバーは、以下を設定ファイルに追加することで設定できます。
+
+> 注：このサーバーを使用するには、Figmaアクセストークンを作成する必要があります。Figma APIアクセストークンの作成方法については[こちら](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)をご覧ください。
+
+### MacOS / Linux
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+Framelink Figma MCPサーバーの設定方法の詳細については、[Framelinkドキュメント](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)を参照してください。
+
+## スター履歴
+
+<a href="https://star-history.com/#GLips/Figma-Context-MCP"><img src="https://api.star-history.com/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="スター履歴チャート" width="600" /></a>
+
+## 詳細情報
+
+Framelink Figma MCPサーバーはシンプルですが強力です。[Framelink](https://framelink.ai?utm_source=github&utm_medium=readme&utm_campaign=readme)サイトで詳細情報をご覧ください。 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,99 @@
+<a href="https://www.framelink.ai/?utm_source=github&utm_medium=readme&utm_campaign=readme" target="_blank" rel="noopener">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.framelink.ai/github/HeaderDark.png" />
+    <img alt="Framelink" src="https://www.framelink.ai/github/HeaderLight.png" />
+  </picture>
+</a>
+
+<div align="center">
+  <h1>Framelink Figma MCP 서버</h1>
+  <p>
+    🌐 다른 언어:
+    <a href="README.md">English</a> |
+    <a href="README.ja.md">日本語 (Japanese)</a> |
+    <a href="README.zh.md">中文 (Chinese)</a>
+  </p>
+  <h3>코딩 에이전트에게 Figma 데이터에 대한 접근 권한을 부여하세요.<br/>한 번에 모든 프레임워크에서 디자인을 구현하세요.</h3>
+  <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">
+    <img alt="주간 다운로드" src="https://img.shields.io/npm/dm/figma-developer-mcp.svg">
+  </a>
+  <a href="https://github.com/GLips/Figma-Context-MCP/blob/main/LICENSE">
+    <img alt="MIT 라이선스" src="https://img.shields.io/github/license/GLips/Figma-Context-MCP" />
+  </a>
+  <a href="https://framelink.ai/discord">
+    <img alt="Discord" src="https://img.shields.io/discord/1352337336913887343?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <br />
+  <a href="https://twitter.com/glipsman">
+    <img alt="Twitter" src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fglipsman&label=%40glipsman" />
+  </a>
+</div>
+
+<br/>
+
+[Cursor](https://cursor.sh/), [Windsurf](https://codeium.com/windsurf), [Cline](https://cline.bot/) 및 기타 AI 기반 코딩 도구에 [Model Context Protocol](https://modelcontextprotocol.io/introduction) 서버를 통해 Figma 파일에 대한 접근 권한을 부여하세요.
+
+Cursor가 Figma 디자인 데이터에 접근할 수 있을 때, 스크린샷을 붙여넣는 것과 같은 대안적인 접근 방식보다 **훨씬** 더 정확하게 디자인을 한 번에 구현할 수 있습니다.
+
+<h3><a href="https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme">빠른 시작 가이드 보기 →</a></h3>
+
+## 데모
+
+[Figma 디자인 데이터로 Cursor에서 UI를 구축하는 데모 시청](https://youtu.be/6G9yb-LrEqg)
+
+[![비디오 시청](https://img.youtube.com/vi/6G9yb-LrEqg/maxresdefault.jpg)](https://youtu.be/6G9yb-LrEqg)
+
+## 작동 방식
+
+1. IDE의 채팅을 엽니다 (예: Cursor의 에이전트 모드).
+2. Figma 파일, 프레임 또는 그룹에 대한 링크를 붙여넣습니다.
+3. Cursor에게 Figma 파일로 무언가를 하도록 요청합니다 (예: 디자인 구현).
+4. Cursor는 Figma에서 관련 메타데이터를 가져와 코드를 작성하는 데 사용합니다.
+
+이 MCP 서버는 Cursor와 함께 사용하도록 특별히 설계되었습니다. [Figma API](https://www.figma.com/developers/api)에서 컨텍스트를 응답하기 전에, 응답을 단순화하고 번역하여 모델에 가장 관련성이 높은 레이아웃 및 스타일링 정보만 제공합니다.
+
+모델에 제공되는 컨텍스트의 양을 줄이면 AI의 정확도를 높이고 응답을 더 관련성 있게 만드는 데 도움이 됩니다.
+
+## 시작하기
+
+많은 코드 편집기와 기타 AI 클라이언트는 MCP 서버를 관리하기 위해 구성 파일을 사용합니다.
+
+`figma-developer-mcp` 서버는 다음을 구성 파일에 추가하여 설정할 수 있습니다.
+
+> 참고: 이 서버를 사용하려면 Figma 액세스 토큰을 생성해야 합니다. Figma API 액세스 토큰을 생성하는 방법에 대한 지침은 [여기](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)에서 찾을 수 있습니다.
+
+### MacOS / Linux
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+Framelink Figma MCP 서버를 구성하는 방법에 대한 자세한 정보가 필요하면 [Framelink 문서](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)를 참조하세요.
+
+## 스타 히스토리
+
+<a href="https://star-history.com/#GLips/Figma-Context-MCP"><img src="https://api.star-history.com/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="스타 히스토리 차트" width="600" /></a>
+
+## 더 알아보기
+
+Framelink Figma MCP 서버는 단순하지만 강력합니다. [Framelink](https://framelink.ai?utm_source=github&utm_medium=readme&utm_campaign=readme) 사이트에서 더 많은 정보를 얻으세요. 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 <div align="center">
   <h1>Framelink Figma MCP Server</h1>
+  <p>
+    🌐 Available in:
+    <a href="README.ko.md">한국어 (Korean)</a> |
+    <a href="README.ja.md">日本語 (Japanese)</a> |
+    <a href="README.zh.md">中文 (Chinese)</a>
+  </p>
   <h3>Give your coding agent access to your Figma data.<br/>Implement designs in any framework in one-shot.</h3>
   <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">
     <img alt="weekly downloads" src="https://img.shields.io/npm/dm/figma-developer-mcp.svg">

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,99 @@
+<a href="https://www.framelink.ai/?utm_source=github&utm_medium=readme&utm_campaign=readme" target="_blank" rel="noopener">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.framelink.ai/github/HeaderDark.png" />
+    <img alt="Framelink" src="https://www.framelink.ai/github/HeaderLight.png" />
+  </picture>
+</a>
+
+<div align="center">
+  <h1>Framelink Figma MCP 服务器</h1>
+  <p>
+    🌐 可用语言:
+    <a href="README.md">English</a> |
+    <a href="README.ko.md">한국어 (Korean)</a> |
+    <a href="README.ja.md">日本語 (Japanese)</a>
+  </p>
+  <h3>为您的编码代理提供 Figma 数据访问权限。<br/>一次性在任何框架中实现设计。</h3>
+  <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">
+    <img alt="每周下载" src="https://img.shields.io/npm/dm/figma-developer-mcp.svg">
+  </a>
+  <a href="https://github.com/GLips/Figma-Context-MCP/blob/main/LICENSE">
+    <img alt="MIT 许可证" src="https://img.shields.io/github/license/GLips/Figma-Context-MCP" />
+  </a>
+  <a href="https://framelink.ai/discord">
+    <img alt="Discord" src="https://img.shields.io/discord/1352337336913887343?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <br />
+  <a href="https://twitter.com/glipsman">
+    <img alt="Twitter" src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fglipsman&label=%40glipsman" />
+  </a>
+</div>
+
+<br/>
+
+通过此 [Model Context Protocol](https://modelcontextprotocol.io/introduction) 服务器，为 [Cursor](https://cursor.sh/)、[Windsurf](https://codeium.com/windsurf)、[Cline](https://cline.bot/) 和其他 AI 驱动的编码工具提供 Figma 文件访问权限。
+
+当 Cursor 可以访问 Figma 设计数据时，它比粘贴截图等替代方法**更**能一次性准确实现设计。
+
+<h3><a href="https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme">查看快速入门指南 →</a></h3>
+
+## 演示
+
+[观看使用 Figma 设计数据在 Cursor 中构建 UI 的演示](https://youtu.be/6G9yb-LrEqg)
+
+[![观看视频](https://img.youtube.com/vi/6G9yb-LrEqg/maxresdefault.jpg)](https://youtu.be/6G9yb-LrEqg)
+
+## 工作原理
+
+1. 打开 IDE 的聊天（例如：Cursor 的代理模式）。
+2. 粘贴 Figma 文件、框架或组的链接。
+3. 要求 Cursor 对 Figma 文件执行某些操作（例如：实现设计）。
+4. Cursor 将从 Figma 获取相关元数据并使用它来编写代码。
+
+此 MCP 服务器专为与 Cursor 一起使用而设计。在从 [Figma API](https://www.figma.com/developers/api) 响应上下文之前，它会简化和翻译响应，以便只向模型提供最相关的布局和样式信息。
+
+减少提供给模型的上下文数量有助于提高 AI 的准确性并使响应更具相关性。
+
+## 开始使用
+
+许多代码编辑器和其他 AI 客户端使用配置文件来管理 MCP 服务器。
+
+可以通过将以下内容添加到配置文件中来设置 `figma-developer-mcp` 服务器。
+
+> 注意：您需要创建 Figma 访问令牌才能使用此服务器。有关如何创建 Figma API 访问令牌的说明，请参见[此处](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)。
+
+### MacOS / Linux
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+有关如何配置 Framelink Figma MCP 服务器的更多信息，请参阅 [Framelink 文档](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)。
+
+## 星标历史
+
+<a href="https://star-history.com/#GLips/Figma-Context-MCP"><img src="https://api.star-history.com/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="星标历史图表" width="600" /></a>
+
+## 了解更多
+
+Framelink Figma MCP 服务器简单但功能强大。在 [Framelink](https://framelink.ai?utm_source=github&utm_medium=readme&utm_campaign=readme) 网站上了解更多信息。 


### PR DESCRIPTION
Dear [Graham Lipsman](https://github.com/GLips),

I am a Korean engineer working in Japan, and I wanted to express my sincere gratitude for your Figma MCP. Your project has been receiving tremendous love and appreciation across Asia, and it has been an invaluable tool in my daily work.

Given the growing popularity of Framelink Figma MCP in Asian markets, I would like to contribute by adding multilingual README translations (Korean, Japanese, and Chinese) to make it more accessible to developers in these regions.

Changes made:
- Added Korean translation (README.ko.md)
- Added Japanese translation (README.ja.md)
- Added Chinese translation (README.zh.md)

All translations maintain the original structure while ensuring cultural and linguistic accuracy. I hope this contribution helps expand the reach of your excellent project across Asian developer communities.

Thank you for considering this pull request.