### PR TITLE
docs: add env setting guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,8 @@ CursorがFigmaデザインデータにアクセスできる場合、スクリー
 }
 ```
 
+または `env` フィールドに `FIGMA_API_KEY` と `PORT` を設定することもできます。
+
 Framelink Figma MCPサーバーの設定方法の詳細については、[Framelinkドキュメント](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)を参照してください。
 
 ## スター履歴

--- a/README.ko.md
+++ b/README.ko.md
@@ -88,6 +88,8 @@ Cursor가 Figma 디자인 데이터에 접근할 수 있을 때, 스크린샷을
 }
 ```
 
+또는 `env` 필드에 `FIGMA_API_KEY`와 `PORT`를 넣을 수 있습니다.
+
 Framelink Figma MCP 서버를 구성하는 방법에 대한 자세한 정보가 필요하면 [Framelink 문서](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)를 참조하세요.
 
 ## 스타 히스토리

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The `figma-developer-mcp` server can be configured by adding the following to yo
 }
 ```
 
+Or you can set `FIGMA_API_KEY` and `PORT` in the `env` field.
+
 If you need more information on how to configure the Framelink Figma MCP server, see the [Framelink docs](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## Star History

--- a/README.zh.md
+++ b/README.zh.md
@@ -88,6 +88,8 @@
 }
 ```
 
+或者您可以在 `env` 字段中设置 `FIGMA_API_KEY` 和 `PORT`。
+
 有关如何配置 Framelink Figma MCP 服务器的更多信息，请参阅 [Framelink 文档](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=readme&utm_campaign=readme)。
 
 ## 星标历史


### PR DESCRIPTION
#96 

This pull request updates the documentation in multiple languages to include an alternative method for configuring the Framelink Figma MCP server by setting `FIGMA_API_KEY` and `PORT` in the `env` field.

Documentation updates by language:

* **Japanese (`README.ja.md`)**: Added instructions for setting `FIGMA_API_KEY` and `PORT` in the `env` field.
* **Korean (`README.ko.md`)**: Added instructions for setting `FIGMA_API_KEY` and `PORT` in the `env` field.
* **English (`README.md`)**: Added instructions for setting `FIGMA_API_KEY` and `PORT` in the `env` field.
* **Chinese (`README.zh.md`)**: Added instructions for setting `FIGMA_API_KEY` and `PORT` in the `env` field.