### PR TITLE
Add scale support for download_figma_images tool

### DIFF
--- a/.changeset/lovely-socks-grab.md
+++ b/.changeset/lovely-socks-grab.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": patch
+---
+
+Add scale support for PNG images pulled via download_figma_images tool.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -112,13 +112,14 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
         })
         .array()
         .describe("The nodes to fetch as images"),
+        scale: z.number().positive().optional().describe("Export scale, no use for SVG"),
       localPath: z
         .string()
         .describe(
           "The absolute path to the directory where images are stored in the project. If the directory does not exist, it will be created. The format of this path should respect the directory format of the operating system you are running on. Don't use any special character escaping in the path name either.",
         ),
     },
-    async ({ fileKey, nodes, localPath }) => {
+    async ({ fileKey, nodes, scale, localPath }) => {
       try {
         const imageFills = nodes.filter(({ imageRef }) => !!imageRef) as {
           nodeId: string;
@@ -134,7 +135,7 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
             fileType: fileName.endsWith(".svg") ? ("svg" as const) : ("png" as const),
           }));
 
-        const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath);
+        const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath, scale);
 
         const downloads = await Promise.all([fillDownloads, renderDownloads]).then(([f, r]) => [
           ...f,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -112,7 +112,13 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
         })
         .array()
         .describe("The nodes to fetch as images"),
-        scale: z.number().positive().optional().describe("Export scale, no use for SVG"),
+      scale: z
+        .number()
+        .positive()
+        .optional()
+        .describe(
+          "Export scale for PNG images. Optional, generally 2 is best, though users may specify a different scale.",
+        ),
       localPath: z
         .string()
         .describe(

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -103,12 +103,13 @@ export class FigmaService {
     fileKey: string,
     nodes: FetchImageParams[],
     localPath: string,
+    scale: number = 2,
   ): Promise<string[]> {
     const pngIds = nodes.filter(({ fileType }) => fileType === "png").map(({ nodeId }) => nodeId);
     const pngFiles =
       pngIds.length > 0
         ? this.request<GetImagesResponse>(
-            `/images/${fileKey}?ids=${pngIds.join(",")}&scale=2&format=png`,
+            `/images/${fileKey}?ids=${pngIds.join(",")}&scale=${scale}&format=png`,
           ).then(({ images = {} }) => images)
         : ({} as GetImagesResponse["images"]);
 


### PR DESCRIPTION
This pull request adds support for the scale parameter in the download_figma_images tool.
With this update, users can now specify the export scale when downloading images from Figma, allowing for more flexible and high-resolution asset exports.

The implementation ensures backward compatibility and does not affect SVG exports.

### Key Changes

- Added an optional scale parameter to the download_figma_images tool.
- Updated the image download logic to handle the scale value for supported image types.
- Improved documentation and type definitions for the tool parameters.

### Motivation
This enhancement enables users to export images at different resolutions directly from the tool, improving workflow efficiency for design and development teams.