### PR TITLE
feat: Add SVG export options to control text outlining and other SVG …

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -117,8 +117,16 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
         .describe(
           "The absolute path to the directory where images are stored in the project. If the directory does not exist, it will be created. The format of this path should respect the directory format of the operating system you are running on. Don't use any special character escaping in the path name either.",
         ),
+      svgOptions: z
+        .object({
+          outlineText: z.boolean().optional().describe("Whether to outline text in SVG exports. Default is true."),
+          includeId: z.boolean().optional().describe("Whether to include IDs in SVG exports. Default is false."),
+          simplifyStroke: z.boolean().optional().describe("Whether to simplify strokes in SVG exports. Default is true."),
+        })
+        .optional()
+        .describe("Options for SVG export"),
     },
-    async ({ fileKey, nodes, localPath }) => {
+    async ({ fileKey, nodes, localPath, svgOptions }) => {
       try {
         const imageFills = nodes.filter(({ imageRef }) => !!imageRef) as {
           nodeId: string;
@@ -134,7 +142,7 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
             fileType: fileName.endsWith(".svg") ? ("svg" as const) : ("png" as const),
           }));
 
-        const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath);
+        const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath, svgOptions);
 
         const downloads = await Promise.all([fillDownloads, renderDownloads]).then(([f, r]) => [
           ...f,

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -103,6 +103,11 @@ export class FigmaService {
     fileKey: string,
     nodes: FetchImageParams[],
     localPath: string,
+    svgOptions?: {
+      outlineText?: boolean;
+      includeId?: boolean;
+      simplifyStroke?: boolean;
+    },
   ): Promise<string[]> {
     const pngIds = nodes.filter(({ fileType }) => fileType === "png").map(({ nodeId }) => nodeId);
     const pngFiles =
@@ -112,11 +117,24 @@ export class FigmaService {
           ).then(({ images = {} }) => images)
         : ({} as GetImagesResponse["images"]);
 
+    let svgParams = "&format=svg";
+    if (svgOptions) {
+      if (svgOptions.outlineText !== undefined) {
+        svgParams += `&svg_outline_text=${svgOptions.outlineText}`;
+      }
+      if (svgOptions.includeId !== undefined) {
+        svgParams += `&svg_include_id=${svgOptions.includeId}`;
+      }
+      if (svgOptions.simplifyStroke !== undefined) {
+        svgParams += `&svg_simplify_stroke=${svgOptions.simplifyStroke}`;
+      }
+    }
+
     const svgIds = nodes.filter(({ fileType }) => fileType === "svg").map(({ nodeId }) => nodeId);
     const svgFiles =
       svgIds.length > 0
         ? this.request<GetImagesResponse>(
-            `/images/${fileKey}?ids=${svgIds.join(",")}&format=svg`,
+            `/images/${fileKey}?ids=${svgIds.join(",")}${svgParams}`,
           ).then(({ images = {} }) => images)
         : ({} as GetImagesResponse["images"]);
 


### PR DESCRIPTION
This PR adds the ability to control SVG export options when downloading Figma components through the Model Context Protocol (MCP). Specifically, it allows users to control text outlining, ID inclusion, and stroke simplification in SVG exports.

### Changes
- Added a new svgOptions parameter to the download_figma_images tool
- Modified the getImages method in FigmaService to accept SVG export options
- Implemented parameter passing from MCP to Figma API
- Added support for three SVG export options:
  - `outlineText`: Controls whether text is converted to paths (svg_outline_text)
  - `includeId`: Controls whether IDs are included in SVG exports (svg_include_id)
  - `simplifyStroke`: Controls whether strokes are simplified (svg_simplify_stroke)

### Usage Example
Users can now specify SVG export options when using the `download_figma_images` tool:
```
{  
  "tool": "download_figma_images",  
  "params": {  
    "fileKey": "figmaFileKey",  
    "nodes": [  
      {  
        "nodeId": "componentNodeId",  
        "fileName": "component.svg"  
      }  
    ],  
    "localPath": "/path/to/save",  
    "svgOptions": {  
      "outlineText": false,  
      "includeId": true,  
      "simplifyStroke": false  
    }  
  }  
}
```

### Testing
- Tested with various SVG components
- Verified that text remains as text elements when outlineText: false is specified
- Confirmed that IDs are preserved when includeId: true is specified
- Validated that stroke complexity is maintained when simplifyStroke: false is specified

### Related Issues
Resolves the need to control text outlining in SVG exports from Figma components.
