### PR TITLE
feat(layout.js): Handle size calculations for non-AutoLayout elements and absolutely positioned elements.

### DIFF
--- a/.changeset/social-days-pick.md
+++ b/.changeset/social-days-pick.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": minor
+---
+
+Handle size calculations for non-AutoLayout elements and absolutely positioned elements.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -45,7 +45,7 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
         .number()
         .optional()
         .describe(
-          "How many levels deep to traverse the node tree, only use if explicitly requested by the user",
+          "OPTIONAL. Do NOT use unless explicitly requested by the user. Controls how many levels deep to traverse the node tree,",
         ),
     },
     async ({ fileKey, nodeId, depth }) => {

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -207,17 +207,20 @@ function buildSimplifiedLayoutValues(
   };
 
   // Only include positioning-related properties if parent layout isn't flex or if the node is absolute
-  if (isFrame(parent) && (parent?.layoutMode === "NONE" || n.layoutPositioning === "ABSOLUTE")) {
+  if (
+    isFrame(parent) &&
+    // If parent is a frame but not an AutoLayout, or if the node is absolute, include positioning-related properties
+    (!parent.layoutMode || parent.layoutMode === "NONE" || n.layoutPositioning === "ABSOLUTE")
+  ) {
     if (n.layoutPositioning === "ABSOLUTE") {
       layoutValues.position = "absolute";
     }
     if (n.absoluteBoundingBox && parent.absoluteBoundingBox) {
       layoutValues.locationRelativeToParent = {
-        x: n.absoluteBoundingBox.x - (parent?.absoluteBoundingBox?.x ?? n.absoluteBoundingBox.x),
-        y: n.absoluteBoundingBox.y - (parent?.absoluteBoundingBox?.y ?? n.absoluteBoundingBox.y),
+        x: n.absoluteBoundingBox.x - parent.absoluteBoundingBox.x,
+        y: n.absoluteBoundingBox.y - parent.absoluteBoundingBox.y,
       };
     }
-    return layoutValues;
   }
 
   // Handle dimensions based on layout growth and alignment
@@ -226,12 +229,13 @@ function buildSimplifiedLayoutValues(
 
     // Only include dimensions that aren't meant to stretch
     if (mode === "row") {
+      // AutoLayout row, only include dimensions if the node is not growing
       if (!n.layoutGrow && n.layoutSizingHorizontal == "FIXED")
         dimensions.width = n.absoluteBoundingBox.width;
       if (n.layoutAlign !== "STRETCH" && n.layoutSizingVertical == "FIXED")
         dimensions.height = n.absoluteBoundingBox.height;
     } else if (mode === "column") {
-      // column
+      // AutoLayout column, only include dimensions if the node is not growing
       if (n.layoutAlign !== "STRETCH" && n.layoutSizingHorizontal == "FIXED")
         dimensions.width = n.absoluteBoundingBox.width;
       if (!n.layoutGrow && n.layoutSizingVertical == "FIXED")
@@ -241,7 +245,7 @@ function buildSimplifiedLayoutValues(
         dimensions.aspectRatio = n.absoluteBoundingBox?.width / n.absoluteBoundingBox?.height;
       }
     } else {
-      // The size of the layout processed without AutoLayout.
+      // Node is not an AutoLayout. Include dimensions if the node is not growing (which it should never be)
       if (!n.layoutSizingHorizontal || n.layoutSizingHorizontal === "FIXED") {
         dimensions.width = n.absoluteBoundingBox.width;
       }

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -221,7 +221,7 @@ function buildSimplifiedLayoutValues(
   }
 
   // Handle dimensions based on layout growth and alignment
-  if (isRectangle("absoluteBoundingBox", n) && isRectangle("absoluteBoundingBox", parent)) {
+  if (isRectangle("absoluteBoundingBox", n)) {
     const dimensions: { width?: number; height?: number; aspectRatio?: number } = {};
 
     // Only include dimensions that aren't meant to stretch
@@ -239,6 +239,14 @@ function buildSimplifiedLayoutValues(
 
       if (n.preserveRatio) {
         dimensions.aspectRatio = n.absoluteBoundingBox?.width / n.absoluteBoundingBox?.height;
+      }
+    } else {
+      // The size of the layout processed without AutoLayout.
+      if (!n.layoutSizingHorizontal || n.layoutSizingHorizontal === "FIXED") {
+        dimensions.width = n.absoluteBoundingBox.width;
+      }
+      if (!n.layoutSizingVertical || n.layoutSizingVertical === "FIXED") {
+        dimensions.height = n.absoluteBoundingBox.height;
       }
     }
 


### PR DESCRIPTION
PR Description: Improved Size Handling for Non-AutoLayout Elements

**Overview**
This PR addresses an issue where the size data for child elements in non-AutoLayout layouts was not being propagated correctly, causing the LLM to generate incorrect style attributes. Additionally, a condition restricting size calculations to specific parent elements was removed to ensure proper sizing for top-level Frame elements.

**Changes Made**
Improved Size Propagation: Updated the code to properly pass down size data for child elements in non-AutoLayout layouts, ensuring the LLM can generate accurate style attributes.

Removed Condition: Eliminated the isRectangle("absoluteBoundingBox", parent) condition, as it was preventing the top-level Frame elements from receiving correct size calculations.