### PR TITLE
Make shadows on text nodes apply text-shadow rather than box-shadow

### DIFF
--- a/.changeset/two-moments-lead.md
+++ b/.changeset/two-moments-lead.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": patch
+---
+
+Make shadows on text nodes apply text-shadow rather than box-shadow

--- a/src/transformers/effects.ts
+++ b/src/transformers/effects.ts
@@ -11,6 +11,7 @@ export type SimplifiedEffects = {
   boxShadow?: string;
   filter?: string;
   backdropFilter?: string;
+  textShadow?: string;
 };
 
 export function buildSimplifiedEffects(n: FigmaDocumentNode): SimplifiedEffects {
@@ -42,7 +43,14 @@ export function buildSimplifiedEffects(n: FigmaDocumentNode): SimplifiedEffects 
     .join(" ");
 
   const result: SimplifiedEffects = {};
-  if (boxShadow) result.boxShadow = boxShadow;
+
+  if (boxShadow) {
+    if (n.type === "TEXT") {
+      result.textShadow = boxShadow;
+    } else {
+      result.boxShadow = boxShadow;
+    }
+  }
   if (filterBlurValues) result.filter = filterBlurValues;
   if (backdropFilterValues) result.backdropFilter = backdropFilterValues;
 


### PR DESCRIPTION
On figma show
<img width="779" alt="image" src="https://github.com/user-attachments/assets/2aa6de4a-cf47-49c3-8d40-52a726ca2f70" />

Get from mcp
![image](https://github.com/user-attachments/assets/19d74f04-87d2-4f93-b89e-51911483f07a)

Causes shadows to be correct
<img width="164" alt="image" src="https://github.com/user-attachments/assets/7ad11a9e-a05c-414a-bdf4-224ec2217f3b" />
