### PR TITLE
Use compressed JSON data responses again to improve transmission efficiency.

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FigmaService, type FigmaAuthOptions } from "./services/figma.js";
 import type { SimplifiedDesign } from "./services/simplify-node-response.js";
-import yaml from "js-yaml";
 import { Logger } from "./utils/logger.js";
 import { calcStringSize } from './utils/calc-string-size.js';
 
@@ -52,8 +51,7 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
     async ({ fileKey, nodeId, depth }) => {
       try {
         Logger.log(
-          `Fetching ${
-            depth ? `${depth} layers deep` : "all layers"
+          `Fetching ${depth ? `${depth} layers deep` : "all layers"
           } of ${nodeId ? `node ${nodeId} from file` : `full file`} ${fileKey}`,
         );
 
@@ -73,17 +71,11 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
           globalVars,
         };
 
-        const yamlResult = yaml.dump(result);
-        const yamlResultSize = calcStringSize(yamlResult);
-
         const jsonResult = JSON.stringify(result);
         const jsonResultSize = calcStringSize(jsonResult);
 
-        Logger.log(`Data size:
-          YAML: ${yamlResultSize} KB
-          JSON: ${jsonResultSize} KB
-        `);
-        
+        Logger.log(`Data size: ${jsonResultSize} KB `);
+
         Logger.log("Sending result to client");
         return {
           content: [{ type: "text", text: jsonResult }],

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,6 +4,7 @@ import { FigmaService, type FigmaAuthOptions } from "./services/figma.js";
 import type { SimplifiedDesign } from "./services/simplify-node-response.js";
 import yaml from "js-yaml";
 import { Logger } from "./utils/logger.js";
+import { calcStringSize } from './utils/calc-string-size.js';
 
 const serverInfo = {
   name: "Figma MCP Server",
@@ -72,12 +73,20 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
           globalVars,
         };
 
-        Logger.log("Generating YAML result from file");
         const yamlResult = yaml.dump(result);
+        const yamlResultSize = calcStringSize(yamlResult);
 
+        const jsonResult = JSON.stringify(result);
+        const jsonResultSize = calcStringSize(jsonResult);
+
+        Logger.log(`Data size:
+          YAML: ${yamlResultSize} KB
+          JSON: ${jsonResultSize} KB
+        `);
+        
         Logger.log("Sending result to client");
         return {
-          content: [{ type: "text", text: yamlResult }],
+          content: [{ type: "text", text: jsonResult }],
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -189,6 +189,7 @@ export class FigmaService {
 }
 
 function writeJSON2YamlLogs(name: string, value: any) {
+  if (process.env.NODE_ENV !== "development") return;
   const result = yaml.dump(value);
   writeLogs(name, result);
 }

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -9,6 +9,7 @@ import type {
 import { downloadFigmaImage } from "~/utils/common.js";
 import { Logger } from "~/utils/logger.js";
 import yaml from "js-yaml";
+import path from 'path';
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -165,8 +166,8 @@ export class FigmaService {
       const response = await this.request<GetFileResponse>(endpoint);
       Logger.log("Got response");
       const simplifiedResponse = parseFigmaResponse(response);
-      writeLogs("figma-raw.yml", response);
-      writeLogs("figma-simplified.yml", simplifiedResponse);
+      writeJSON2YamlLogs("figma-raw.yml", response);
+      writeJSON2YamlLogs("figma-simplified.yml", simplifiedResponse);
       return simplifiedResponse;
     } catch (e) {
       console.error("Failed to get file:", e);
@@ -178,21 +179,29 @@ export class FigmaService {
     const endpoint = `/files/${fileKey}/nodes?ids=${nodeId}${depth ? `&depth=${depth}` : ""}`;
     const response = await this.request<GetFileNodesResponse>(endpoint);
     Logger.log("Got response from getNode, now parsing.");
-    writeLogs("figma-raw.yml", response);
+    writeJSON2YamlLogs("figma-raw.yml", response);
     const simplifiedResponse = parseFigmaResponse(response);
-    writeLogs("figma-simplified.yml", simplifiedResponse);
+    writeJSON2YamlLogs("figma-simplified.yml", simplifiedResponse);
+    writeLogs("figma-raw.json", JSON.stringify(response));
+    writeLogs("figma-simplified.json", JSON.stringify(simplifiedResponse));
     return simplifiedResponse;
   }
+}
+
+function writeJSON2YamlLogs(name: string, value: any) {
+  const result = yaml.dump(value);
+  writeLogs(name, result);
 }
 
 function writeLogs(name: string, value: any) {
   try {
     if (process.env.NODE_ENV !== "development") return;
 
-    const logsDir = "logs";
+    const logsCWD = process.env.LOG_DIR || process.cwd();
+    const logsDir = path.resolve(logsCWD, "logs");
 
     try {
-      fs.accessSync(process.cwd(), fs.constants.W_OK);
+      fs.accessSync(logsCWD, fs.constants.W_OK);
     } catch (error) {
       Logger.log("Failed to write logs:", error);
       return;
@@ -201,7 +210,9 @@ function writeLogs(name: string, value: any) {
     if (!fs.existsSync(logsDir)) {
       fs.mkdirSync(logsDir);
     }
-    fs.writeFileSync(`${logsDir}/${name}`, yaml.dump(value));
+    const filePath = path.resolve(logsDir, `${name}`);
+    fs.writeFileSync(filePath, value);
+    console.log(`Wrote ${name} to ${filePath}`);
   } catch (error) {
     console.debug("Failed to write logs:", error);
   }

--- a/src/utils/calc-string-size.ts
+++ b/src/utils/calc-string-size.ts
@@ -1,0 +1,12 @@
+import { round } from "remeda";
+
+/**
+ * Calculate the size of a string in kilobytes
+ * @param text - The string to calculate the size of
+ * @returns The size of the string in kilobytes
+ */
+export function calcStringSize(text: string) {
+  const encoder = new TextEncoder();
+  const utf8Bytes = encoder.encode(text);
+  return round(utf8Bytes.length / 1024, 2);
+}


### PR DESCRIPTION
I see https://github.com/GLips/Figma-Context-MCP/pull/40

I found that the reason why the JSON-formatted data was relatively large before was due to the addition of formatting during the response. `JSON.stringify(value, null, 2)`
In my local tests, compressed JSON data is superior to YAML. This is because YAML requires additional indentation to represent hierarchies, especially when the child nodes have a deep hierarchy, and its efficiency is not good.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/d7e90bce-0a7a-42f8-8305-740bd8049eea" />
<img width="466" alt="image" src="https://github.com/user-attachments/assets/47f26daa-870a-445d-b7f0-9dc7906fac0d" />

can test on this branch.
https://github.com/fightZy/Figma-Context-MCP/tree/8489791
