### PR TITLE
F/optimize margin

### DIFF
--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -13,10 +13,6 @@ export interface SimplifiedLayout {
   alignSelf?: "flex-start" | "flex-end" | "center" | "stretch";
   wrap?: boolean;
   gap?: string;
-  locationRelativeToParent?: {
-    x: number;
-    y: number;
-  };
   dimensions?: {
     width?: number;
     height?: number;

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -23,6 +23,7 @@ export interface SimplifiedLayout {
     aspectRatio?: number;
   };
   padding?: string;
+  margin?: string;
   sizing?: {
     horizontal?: "fixed" | "fill" | "hug";
     vertical?: "fixed" | "fill" | "hug";
@@ -209,17 +210,18 @@ function buildSimplifiedLayoutValues(
   // Only include positioning-related properties if parent layout isn't flex or if the node is absolute
   if (
     isFrame(parent) &&
-    // If parent is a frame but not an AutoLayout, or if the node is absolute, include positioning-related properties
-    (!parent.layoutMode || parent.layoutMode === "NONE" || n.layoutPositioning === "ABSOLUTE")
+    (!parent?.layoutMode || parent?.layoutMode === "NONE" || n.layoutPositioning === "ABSOLUTE")
   ) {
-    if (n.layoutPositioning === "ABSOLUTE") {
-      layoutValues.position = "absolute";
-    }
     if (n.absoluteBoundingBox && parent.absoluteBoundingBox) {
-      layoutValues.locationRelativeToParent = {
-        x: n.absoluteBoundingBox.x - parent.absoluteBoundingBox.x,
-        y: n.absoluteBoundingBox.y - parent.absoluteBoundingBox.y,
-      };
+      let marginLeft =
+        n.absoluteBoundingBox.x - (parent?.absoluteBoundingBox?.x ?? n.absoluteBoundingBox.x);
+      let marginTop =
+        n.absoluteBoundingBox.y - (parent?.absoluteBoundingBox?.y ?? n.absoluteBoundingBox.y);
+      marginLeft = marginLeft - (parent?.paddingLeft ?? 0);
+      marginTop = marginTop - (parent?.paddingTop ?? 0);
+      if (marginLeft !== 0 || marginTop !== 0) {
+        layoutValues.margin = `${marginTop} 0 0 ${marginLeft}`;
+      }
     }
   }
 


### PR DESCRIPTION
**Pull Request Description**

This PR introduces the following changes to improve the layout handling in the project:

1. **Added `margin` field to the layout configuration**: A new `margin` field has been added to guide the LLM in setting appropriate spacing for elements. This addition aims to provide clearer instructions for consistent and precise layout rendering.

2. **Removed `locationRelativeToParent` field**: I’ve removed the `locationRelativeToParent` field as I believe it’s less critical for achieving accurate positioning. My reasoning is that by properly handling all layout attributes in the MCP, we can reliably set element positions and sizes without relying on this field. Additionally, using `locationRelativeToParent` might introduce risks of "AI hallucinations," leading to less precise layouts. That said, this is just a suggestion, and I’m open to feedback if the team feels this field should be retained or if there are use cases I might have overlooked.

Looking forward to your thoughts and suggestions!