### PR TITLE
fix(common.ts): fix bug by resolving promise only after file write co…

### DIFF
--- a/.changeset/spicy-phones-pay.md
+++ b/.changeset/spicy-phones-pay.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": patch
+---
+
+Resolve promise in image downloading function only after file is finished writing.

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -67,13 +67,17 @@ export async function downloadFigmaImage(
             }
             writer.write(value);
           }
-          resolve(fullPath);
         } catch (err) {
           writer.end();
           fs.unlink(fullPath, () => {});
           reject(err);
         }
       };
+
+      // Resolve only when the stream is fully written
+      writer.on('finish', () => {
+        resolve(fullPath);
+      });
 
       writer.on("error", (err) => {
         reader.cancel();


### PR DESCRIPTION
This PR fixes a bug where the promise was resolved before the file write operation completed. 
The change ensures the promise resolves only after the writer stream emits the 'finish' event, confirming the file is fully written to disk. This prevents premature callbacks and ensures data integrity.