### PR TITLE
feat(icon.ts simplify-node-response.ts): optimize icon handling with direct MCP response integration

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -16,7 +16,7 @@ function createServer(
 ) {
   const server = new McpServer(serverInfo);
   // const figmaService = new FigmaService(figmaApiKey);
-  const figmaService = new FigmaService(authOptions);
+  const figmaService = FigmaService.getInstance(authOptions);
   registerTools(server, figmaService);
 
   Logger.isHTTP = isHTTP;
@@ -92,83 +92,76 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
 
   // TODO: Clean up all image download related code, particularly getImages in Figma service
   // Tool to download images
-  server.tool(
-    "download_figma_images",
-    "Download SVG and PNG images used in a Figma file based on the IDs of image or icon nodes",
-    {
-      fileKey: z.string().describe("The key of the Figma file containing the node"),
-      nodes: z
-        .object({
-          nodeId: z
-            .string()
-            .describe("The ID of the Figma image node to fetch, formatted as 1234:5678"),
-          imageRef: z
-            .string()
-            .optional()
-            .describe(
-              "If a node has an imageRef fill, you must include this variable. Leave blank when downloading Vector SVG images.",
-            ),
-          fileName: z.string().describe("The local name for saving the fetched file"),
-        })
-        .array()
-        .describe("The nodes to fetch as images"),
-      scale: z
-        .number()
-        .positive()
-        .optional()
-        .describe(
-          "Export scale for PNG images. Optional, generally 2 is best, though users may specify a different scale.",
-        ),
-      localPath: z
-        .string()
-        .describe(
-          "The absolute path to the directory where images are stored in the project. If the directory does not exist, it will be created. The format of this path should respect the directory format of the operating system you are running on. Don't use any special character escaping in the path name either.",
-        ),
-    },
-    async ({ fileKey, nodes, scale, localPath }) => {
-      try {
-        const imageFills = nodes.filter(({ imageRef }) => !!imageRef) as {
-          nodeId: string;
-          imageRef: string;
-          fileName: string;
-        }[];
-        const fillDownloads = figmaService.getImageFills(fileKey, imageFills, localPath);
-        const renderRequests = nodes
-          .filter(({ imageRef }) => !imageRef)
-          .map(({ nodeId, fileName }) => ({
-            nodeId,
-            fileName,
-            fileType: fileName.endsWith(".svg") ? ("svg" as const) : ("png" as const),
-          }));
-
-        const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath, scale);
-
-        const downloads = await Promise.all([fillDownloads, renderDownloads]).then(([f, r]) => [
-          ...f,
-          ...r,
-        ]);
-
-        // If any download fails, return false
-        const saveSuccess = !downloads.find((success) => !success);
-        return {
-          content: [
-            {
-              type: "text",
-              text: saveSuccess
-                ? `Success, ${downloads.length} images downloaded: ${downloads.join(", ")}`
-                : "Failed",
-            },
-          ],
-        };
-      } catch (error) {
-        Logger.error(`Error downloading images from file ${fileKey}:`, error);
-        return {
-          isError: true,
-          content: [{ type: "text", text: `Error downloading images: ${error}` }],
-        };
-      }
-    },
-  );
+  // server.tool(
+  //   "download_figma_images",
+  //   "Download SVG and PNG images used in a Figma file based on the IDs of image or icon nodes",
+  //   {
+  //     fileKey: z.string().describe("The key of the Figma file containing the node"),
+  //     nodes: z
+  //       .object({
+  //         nodeId: z
+  //           .string()
+  //           .describe("The ID of the Figma image node to fetch, formatted as 1234:5678"),
+  //         imageRef: z
+  //           .string()
+  //           .optional()
+  //           .describe(
+  //             "If a node has an imageRef fill, you must include this variable. Leave blank when downloading Vector SVG images.",
+  //           ),
+  //         fileName: z.string().describe("The local name for saving the fetched file"),
+  //       })
+  //       .array()
+  //       .describe("The nodes to fetch as images"),
+  //     localPath: z
+  //       .string()
+  //       .describe(
+  //         "The absolute path to the directory where images are stored in the project. If the directory does not exist, it will be created. The format of this path should respect the directory format of the operating system you are running on. Don't use any special character escaping in the path name either.",
+  //       ),
+  //   },
+  //   async ({ fileKey, nodes, localPath }) => {
+  //     try {
+  //       const imageFills = nodes.filter(({ imageRef }) => !!imageRef) as {
+  //         nodeId: string;
+  //         imageRef: string;
+  //         fileName: string;
+  //       }[];
+  //       const fillDownloads = figmaService.getImageFills(fileKey, imageFills, localPath);
+  //       const renderRequests = nodes
+  //         .filter(({ imageRef }) => !imageRef)
+  //         .map(({ nodeId, fileName }) => ({
+  //           nodeId,
+  //           fileName,
+  //           fileType: fileName.endsWith(".svg") ? ("svg" as const) : ("png" as const),
+  //         }));
+  //
+  //       const renderDownloads = figmaService.getImages(fileKey, renderRequests, localPath);
+  //
+  //       const downloads = await Promise.all([fillDownloads, renderDownloads]).then(([f, r]) => [
+  //         ...f,
+  //         ...r,
+  //       ]);
+  //
+  //       // If any download fails, return false
+  //       const saveSuccess = !downloads.find((success) => !success);
+  //       return {
+  //         content: [
+  //           {
+  //             type: "text",
+  //             text: saveSuccess
+  //               ? `Success, ${downloads.length} images downloaded: ${downloads.join(", ")}`
+  //               : "Failed",
+  //           },
+  //         ],
+  //       };
+  //     } catch (error) {
+  //       Logger.error(`Error downloading images from file ${fileKey}:`, error);
+  //       return {
+  //         isError: true,
+  //         content: [{ type: "text", text: `Error downloading images: ${error}` }],
+  //       };
+  //     }
+  //   },
+  // );
 }
 
 export { createServer };

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -10,6 +10,7 @@ import { downloadFigmaImage } from "~/utils/common.js";
 import { Logger } from "~/utils/logger.js";
 import { fetchWithRetry } from "~/utils/fetch-with-retry.js";
 import yaml from "js-yaml";
+import path from "path";
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -17,7 +18,7 @@ export type FigmaAuthOptions = {
   useOAuth: boolean;
 };
 
-type FetchImageParams = {
+export type FetchImageParams = {
   /**
    * The Node in Figma that will either be rendered or have its background image downloaded
    */
@@ -40,15 +41,27 @@ type FetchImageFillParams = Omit<FetchImageParams, "fileType"> & {
 };
 
 export class FigmaService {
+// Static property to store the singleton instance
+  private static instance: FigmaService | null = null;
+
   private readonly apiKey: string;
   private readonly oauthToken: string;
   private readonly useOAuth: boolean;
   private readonly baseUrl = "https://api.figma.com/v1";
 
-  constructor({ figmaApiKey, figmaOAuthToken, useOAuth }: FigmaAuthOptions) {
+  private constructor({ figmaApiKey, figmaOAuthToken, useOAuth }: FigmaAuthOptions) {
     this.apiKey = figmaApiKey || "";
     this.oauthToken = figmaOAuthToken || "";
     this.useOAuth = !!useOAuth && !!this.oauthToken;
+  }
+
+// Static method to retrieve the singleton instance
+  public static getInstance(options?: FigmaAuthOptions): FigmaService {
+    if (!FigmaService.instance && options) {
+      const {figmaApiKey, figmaOAuthToken, useOAuth} = options
+      FigmaService.instance = new FigmaService({ figmaApiKey, figmaOAuthToken, useOAuth });
+    }
+    return <FigmaService>FigmaService.instance;
   }
 
   private async request<T>(endpoint: string): Promise<T> {
@@ -128,6 +141,17 @@ export class FigmaService {
       .map(({ nodeId, fileName }) => {
         const imageUrl = files[nodeId];
         if (imageUrl) {
+          // Build the complete file path
+          const fullPath = path.join(localPath, fileName);
+
+          if (!fs.existsSync(localPath)) {
+            fs.mkdirSync(localPath, { recursive: true });
+          }
+
+          if (fs.existsSync(fullPath)) {
+            fs.unlinkSync(fullPath)
+          }
+
           return downloadFigmaImage(fileName, localPath, imageUrl);
         }
         return false;
@@ -143,7 +167,7 @@ export class FigmaService {
       Logger.log(`Retrieving Figma file: ${fileKey} (depth: ${depth ?? "default"})`);
       const response = await this.request<GetFileResponse>(endpoint);
       Logger.log("Got response");
-      const simplifiedResponse = parseFigmaResponse(response);
+      const simplifiedResponse = await parseFigmaResponse(fileKey, response);
       writeLogs("figma-raw.yml", response);
       writeLogs("figma-simplified.yml", simplifiedResponse);
       return simplifiedResponse;
@@ -158,7 +182,7 @@ export class FigmaService {
     const response = await this.request<GetFileNodesResponse>(endpoint);
     Logger.log("Got response from getNode, now parsing.");
     writeLogs("figma-raw.yml", response);
-    const simplifiedResponse = parseFigmaResponse(response);
+    const simplifiedResponse = await parseFigmaResponse(fileKey, response);
     writeLogs("figma-simplified.yml", simplifiedResponse);
     return simplifiedResponse;
   }

--- a/src/services/simplify-node-response.ts
+++ b/src/services/simplify-node-response.ts
@@ -13,7 +13,7 @@ import type {
   SimplifiedComponentSetDefinition,
 } from "~/utils/sanitization.js";
 import { sanitizeComponents, sanitizeComponentSets } from "~/utils/sanitization.js";
-import { hasValue, isRectangleCornerRadii, isTruthy } from "~/utils/identity.js";
+import { getNodeCategory, hasValue, isRectangleCornerRadii, isTruthy } from "~/utils/identity.js";
 import {
   removeEmptyKeys,
   generateVarId,
@@ -23,6 +23,8 @@ import {
 } from "~/utils/common.js";
 import { buildSimplifiedStrokes, type SimplifiedStroke } from "~/transformers/style.js";
 import { buildSimplifiedEffects, type SimplifiedEffects } from "~/transformers/effects.js";
+import { buildSimplifiedIcon, type SimpledIcon } from "~/transformers/icon.js";
+
 /**
  * TODO ITEMS
  *
@@ -60,7 +62,9 @@ type StyleTypes =
   | string;
 type GlobalVars = {
   styles: Record<StyleId, StyleTypes>;
+  icons: Record<string, SimpledIcon>;
 };
+
 export interface SimplifiedDesign {
   name: string;
   lastModified: string;
@@ -93,6 +97,7 @@ export interface SimplifiedNode {
   // for rect-specific strokes, etc.
   componentId?: string;
   componentProperties?: Record<string, any>;
+  icon?: string;
   // children
   children?: SimplifiedNode[];
 }
@@ -129,7 +134,10 @@ export interface ColorValue {
 }
 
 // ---------------------- PARSING ----------------------
-export function parseFigmaResponse(data: GetFileResponse | GetFileNodesResponse): SimplifiedDesign {
+export async function parseFigmaResponse(
+  fileKey: string,
+  data: GetFileResponse | GetFileNodesResponse,
+): Promise<SimplifiedDesign> {
   const aggregatedComponents: Record<string, Component> = {};
   const aggregatedComponentSets: Record<string, ComponentSet> = {};
   let nodesToParse: Array<FigmaDocumentNode>;
@@ -158,14 +166,18 @@ export function parseFigmaResponse(data: GetFileResponse | GetFileNodesResponse)
 
   const { name, lastModified, thumbnailUrl } = data;
 
-  let globalVars: GlobalVars = {
+  const globalVars: GlobalVars = {
     styles: {},
+    icons: {},
   };
 
-  const simplifiedNodes: SimplifiedNode[] = nodesToParse
-    .filter(isVisible)
-    .map((n) => parseNode(globalVars, n))
-    .filter((child) => child !== null && child !== undefined);
+  const visibleNodes = nodesToParse.filter(isVisible);
+  let simplifiedNodes = [];
+  for (const n of visibleNodes) {
+    const parsedNode = await parseNode(fileKey, globalVars, n);
+    simplifiedNodes.push(parsedNode);
+  }
+  simplifiedNodes = simplifiedNodes.filter((child) => child !== null && child !== undefined);
 
   const simplifiedDesign: SimplifiedDesign = {
     name,
@@ -179,24 +191,6 @@ export function parseFigmaResponse(data: GetFileResponse | GetFileNodesResponse)
 
   return removeEmptyKeys(simplifiedDesign);
 }
-
-// Helper function to find node by ID
-const findNodeById = (id: string, nodes: SimplifiedNode[]): SimplifiedNode | undefined => {
-  for (const node of nodes) {
-    if (node?.id === id) {
-      return node;
-    }
-
-    if (node?.children && node.children.length > 0) {
-      const foundInChildren = findNodeById(id, node.children);
-      if (foundInChildren) {
-        return foundInChildren;
-      }
-    }
-  }
-
-  return undefined;
-};
 
 /**
  * Find or create global variables
@@ -222,11 +216,29 @@ function findOrCreateVar(globalVars: GlobalVars, value: any, prefix: string): St
   return varId;
 }
 
-function parseNode(
+/**
+ * Find or create a global variable for an icon
+ *
+ * @param icon - Icon object containing fileName and other properties
+ * @param globalVars - Global variables object to store icons
+ * @returns The fileName of the icon
+ */
+function findOrCreateVarForIcons(icon: SimpledIcon, globalVars: GlobalVars): string {
+  const { fileName } = icon;
+  globalVars.icons = globalVars.icons ?? {};
+  const isExist = Object.keys(globalVars.icons).findIndex((key) => key === icon.fileName) !== -1;
+  if (!isExist) {
+    globalVars.icons[fileName] = icon;
+  }
+  return fileName;
+}
+
+async function parseNode(
+  fileKey: string,
   globalVars: GlobalVars,
   n: FigmaDocumentNode,
   parent?: FigmaDocumentNode,
-): SimplifiedNode | null {
+): Promise<SimplifiedNode | null> {
   const { id, name, type } = n;
 
   const simplified: SimplifiedNode = {
@@ -235,12 +247,21 @@ function parseNode(
     type,
   };
 
-  if (type === "INSTANCE") {
-    if (hasValue("componentId", n)) {
-      simplified.componentId = n.componentId;
+  // Determine the category of the node
+  const category = getNodeCategory(n);
+  if (category === "component") {
+    if (type === "INSTANCE") {
+      if (hasValue("componentId", n)) {
+        simplified.componentId = n.componentId;
+      }
+      if (hasValue("componentProperties", n)) {
+        simplified.componentProperties = n.componentProperties;
+      }
     }
-    if (hasValue("componentProperties", n)) {
-      simplified.componentProperties = n.componentProperties;
+  } else if (category === "icon") {
+    const icon = await buildSimplifiedIcon(fileKey, n);
+    if (icon) {
+      simplified.icon = findOrCreateVarForIcons(icon, globalVars);
     }
   }
 
@@ -309,20 +330,37 @@ function parseNode(
   }
 
   // Recursively process child nodes
-  if (hasValue("children", n) && Array.isArray(n.children) && n.children.length > 0) {
-    const children = n.children
-      .filter(isVisible)
-      .map((child) => parseNode(globalVars, child, n))
-      .filter((child) => child !== null && child !== undefined);
-    if (children.length) {
-      simplified.children = children;
+  if (hasValue("children", n) && shouldTraverseChildren(n, simplified)) {
+    const visibleNodes = n.children.filter(isVisible);
+    let simplifiedNodes = [];
+    for (const visibleNode of visibleNodes) {
+      const parsedNode = await parseNode(fileKey, globalVars, visibleNode, n);
+      simplifiedNodes.push(parsedNode);
+    }
+    simplifiedNodes = simplifiedNodes.filter((child) => child !== null && child !== undefined);
+
+    if (simplifiedNodes.length) {
+      simplified.children = simplifiedNodes;
     }
   }
 
-  // Convert VECTOR to IMAGE
-  if (type === "VECTOR") {
-    simplified.type = "IMAGE-SVG";
-  }
-
   return simplified;
+}
+
+/**
+ * Determines whether to traverse the children of a Figma node
+ *
+ * @param n - The Figma node to evaluate
+ * @param simplifiedParent - The simplified parent node containing metadata like icon classification
+ * @returns True if the node's children should be traversed, false otherwise
+ */
+function shouldTraverseChildren(n: FigmaDocumentNode, simplifiedParent: SimplifiedNode): boolean {
+  // If a node has a determined classification (e.g., icon or component), its type alone
+  // provides enough information to generate code, and traversing children is unnecessary.
+  return (
+    hasValue("children", n) &&
+    Array.isArray(n.children) &&
+    n.children.length > 0 &&
+    !simplifiedParent.icon
+  );
 }

--- a/src/transformers/icon.ts
+++ b/src/transformers/icon.ts
@@ -1,0 +1,133 @@
+import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
+import { type FetchImageParams, FigmaService } from "~/services/figma.js";
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import fs from "fs";
+import path from "path";
+import * as os from "node:os";
+
+/**
+ * Represents a simplified icon object with type, filename, and content.
+ */
+export type SimpledIcon = {
+  type: "svg" | "png";
+  fileName: string;
+  content: string;
+};
+
+/**
+ * Builds a simplified icon object from a Figma document node.
+ * Generates an SVG icon if all children of the node are of type VECTOR.
+ * Removes componentId for INSTANCE nodes, fetches the image, and constructs the icon object.
+ * Uses MD5 file naming to generate unique file names based on file content, ensuring frontend projects
+ * avoid redundant imports of the same image by reusing identical assets.
+ *
+ * @param fileKey - The key identifying the Figma file
+ * @param n - The Figma document node to process
+ * @returns A Promise resolving to a SimpledIcon object if successful, or null if the node is invalid or processing fails
+ */
+export async function buildSimplifiedIcon(
+  fileKey: string,
+  n: FigmaDocumentNode,
+): Promise<SimpledIcon | null> {
+  if ("children" in n) {
+    const isAllVectorChildren = n.children.every((child) => child.type === "VECTOR");
+    if (isAllVectorChildren) {
+      const figmaService = FigmaService.getInstance();
+      const params: FetchImageParams[] = [
+        {
+          nodeId: n.id,
+          fileName: generateRandomName("svg"),
+          fileType: "svg",
+        },
+      ];
+      const tempDir = getImageTempDirPath("svg");
+      const urls = await figmaService.getImages(fileKey, params, tempDir, 1);
+      const url = urls[0];
+      if (url) {
+        // Generate an MD5-based file name using the file content and node name to ensure uniqueness
+        const md5Name = generateFileMd5Name("svg", url, n.name);
+        const result: SimpledIcon = {
+          type: "svg",
+          fileName: md5Name,
+          content: fs.readFileSync(url, "utf8"),
+        };
+        fs.unlinkSync(url);
+        return result;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Retrieves the temporary directory path for images.
+ * Returns the appropriate temporary directory path based on the environment and file type.
+ *
+ * @param fileType - The image file type, either "svg" or "png".
+ * @returns The full path to the temporary image directory.
+ */
+function getImageTempDirPath(fileType: "svg" | "png"): string {
+  const baseDir = os.tmpdir();
+  const result = path.join(baseDir, "figma-mcp", "tmp", fileType === "svg" ? "svg" : "png");
+  if (process.env.NODE_ENV === "development") {
+    console.log(`Base temporary directory: ${result}`);
+  }
+  return result;
+}
+
+/**
+ * Generates a random filename with the specified file type extension.
+ *
+ * @param fileType - The file type for the extension, either "svg" or "png".
+ * @param length - The length of the random filename (excluding extension), defaults to 8.
+ * @returns A random filename with the specified file type extension.
+ */
+function generateRandomName(fileType: "svg" | "png", length: number = 8): string {
+  const characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    const randomIndex = Math.floor(Math.random() * characters.length);
+    result += characters[randomIndex];
+  }
+  return `${result}.${fileType}`;
+}
+
+/**
+ * Sanitizes a filename by replacing non-alphanumeric characters with underscores.
+ *
+ * @param str - The string to sanitize.
+ * @returns The sanitized filename string.
+ */
+function sanitizeFilename(str: string): string {
+  return str.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+/**
+ * Generates a filename with an MD5 hash based on the file type, content, and input string.
+ * Constructs a filename by extracting the last segment of the input string, sanitizing it,
+ * and appending a 6-character MD5 hash of the file content.
+ *
+ * @param fileType - The file type for the extension, either "svg" or "png".
+ * @param fileUrl - The path to the file to read for MD5 hashing.
+ * @param inputString - The input string to derive the base filename from.
+ * @returns The generated filename in the format `<baseName>_<md5Hash>.<fileType>`.
+ */
+function generateFileMd5Name(
+  fileType: "svg" | "png",
+  fileUrl: string,
+  inputString: string,
+): string {
+  const parts = inputString.toLowerCase().split(/[/_]/);
+  let baseName = parts[parts.length - 1];
+
+  baseName = baseName || "file";
+
+  baseName = sanitizeFilename(baseName);
+
+  const fileContent = readFileSync(fileUrl);
+  const md5Hash = createHash("md5").update(fileContent).digest("hex").slice(-6);
+
+  return `${baseName}_${md5Hash}.${fileType}`;
+}

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -3,6 +3,7 @@ import type {
   HasLayoutTrait,
   StrokeWeights,
   HasFramePropertiesTrait,
+  Node as FigmaDocumentNode,
 } from "@figma/rest-api-spec";
 import { isTruthy } from "remeda";
 import type { CSSHexColor, CSSRGBAColor } from "~/services/simplify-node-response.js";
@@ -78,4 +79,25 @@ export function isRectangleCornerRadii(val: unknown): val is number[] {
 
 export function isCSSColorValue(val: unknown): val is CSSRGBAColor | CSSHexColor {
   return typeof val === "string" && (val.startsWith("#") || val.startsWith("rgba"));
+}
+
+/**
+ * Determines the category of a Figma node
+ *
+ * @param n - The Figma node to evaluate
+ * @returns The category ("component" or "icon") or null if no category applies
+ */
+export function getNodeCategory(n: FigmaDocumentNode): "component" | "icon" | null {
+  if (hasValue("children", n)) {
+    // If all children are vectors, categorize as an icon
+    const isAllVectorChildren = n.children.every((child) => child.type === "VECTOR");
+    if (isAllVectorChildren) {
+      return "icon";
+    }
+  }
+
+  if (n.type === "INSTANCE") {
+    return "component";
+  }
+  return null;
 }


### PR DESCRIPTION
# Overview
This pull request optimizes the icon handling process in the frontend project by transitioning from LLM-based icon recognition and individual downloads to directly utilizing the Figma MCP server response. During local development, an LLM prompt manages icon file checks, creation, and correct referencing. I suggest adding prompt documentation and Figma icon naming guidelines in the README to ensure the Figma MCP server operates as expected.

# Changes Made
- Icon Handling Update:
  - Icons are now sourced directly from the icons resource in the Figma MCP response, eliminating LLM-based recognition and manual downloads.
  - During development, the LLM prompt identifies icons, checks if they exist in the src/assets/icons directory, creates new files using the icon field value if absent, and ensures correct referencing of the icons resource. Existing files are reused to avoid duplication.
  - Icon filenames are generated with an MD5 hash based on file content, ensuring unique filenames and preventing duplicate writes in the frontend project.
  - This change focuses exclusively on icons, with no component-related modifications.
  
# Prompt
These were the reference prompts I used while working on this PR:
Constraints:
- If an element returned from the Figma MCP data contains an icon field, it indicates that the element is an icon and must use the corresponding resource from the icons assets.
- Before using the icons resource, check if the corresponding file exists in the src/assets/icons directory of the project root.
  - If it does not exist, create a new file in that directory named after the value of the icon field, and write the resource content from Figma into that file.
  - If it already exists, reuse the existing file without recreating it.
- The component name used for the import should remove the suffix after the last underscore (_) in the filename.
For example, if the icon field is arrow_right_aba990.svg, the usage should be:
```javascript
import ArrowRight from "./assets/arrow_right_aba990.svg?react";
<ArrowRight />
```
![image](https://github.com/user-attachments/assets/2772b3c9-48c4-4b77-89b5-d56efc1c5118)
![image](https://github.com/user-attachments/assets/810d2713-0000-425e-8d92-e145a38cf246)
![image](https://github.com/user-attachments/assets/e1a1b5df-b4af-46e2-bd59-253f69d1aef4)
![image](https://github.com/user-attachments/assets/2b45af41-c427-4ebc-be38-90737ab1f2b4)


# Documentation Update Suggestion:
Suggested adding a section in the README with LLM prompt guidelines and Figma icon naming recommendations to guide users interacting with the Figma MCP server during local development, ensuring the server operates as expected and standardizing icon naming.

# README Update (Suggested)
To ensure users can effectively interact with the Figma MCP server, I suggest adding the following guidelines to the Readme files.

**Suggested Prompt**:
1. If a Figma node in the MCP response contains an icon field, it indicates the element is an icon, and the corresponding icons resource from the response must be used.
2. Before using the icons resource, check if a file named after the icon field value (e.g., arrow_right_aba990.svg) exists in the src/assets/icons directory of the project root.
  - If the file does not exist, create a new file in src/assets/icons using the icon field value as the filename and write the corresponding icons resource content from the Figma MCP response into it.
  - If the file exists, reuse it without modification to avoid duplication.
3. Based on your project's specific method for using SVG files, define how the icon should be imported and utilized (e.g., as a React component, or other approach).

**Suggested Figma Guidelines**
1. Icon names should consist of ASCII characters only. Avoid using non-ASCII characters or symbols to ensure compatibility with file systems and development environments.

This is a bold change, but local testing shows promising results, and I’d greatly appreciate feedback from the maintainers to ensure it aligns with the project’s goals. 😊
