### PR TITLE
Experimental feature: Allow the LLM to automatically prune and read large data.

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FigmaService, type FigmaAuthOptions } from "./services/figma.js";
 import type { SimplifiedDesign } from "./services/simplify-node-response.js";
-import yaml from "js-yaml";
 import { Logger } from "./utils/logger.js";
 import { calcStringSize } from './utils/calc-string-size.js';
 
@@ -52,8 +51,7 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
     async ({ fileKey, nodeId, depth }) => {
       try {
         Logger.log(
-          `Fetching ${
-            depth ? `${depth} layers deep` : "all layers"
+          `Fetching ${depth ? `${depth} layers deep` : "all layers"
           } of ${nodeId ? `node ${nodeId} from file` : `full file`} ${fileKey}`,
         );
 
@@ -73,17 +71,11 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
           globalVars,
         };
 
-        const yamlResult = yaml.dump(result);
-        const yamlResultSize = calcStringSize(yamlResult);
-
         const jsonResult = JSON.stringify(result);
         const jsonResultSize = calcStringSize(jsonResult);
 
-        Logger.log(`Data size:
-          YAML: ${yamlResultSize} KB
-          JSON: ${jsonResultSize} KB
-        `);
-        
+        Logger.log(`Data size: ${jsonResultSize} KB `);
+
         Logger.log("Sending result to client");
         return {
           content: [{ type: "text", text: jsonResult }],

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,6 +4,7 @@ import { FigmaService, type FigmaAuthOptions } from "./services/figma.js";
 import type { SimplifiedDesign } from "./services/simplify-node-response.js";
 import yaml from "js-yaml";
 import { Logger } from "./utils/logger.js";
+import { calcStringSize } from './utils/calc-string-size.js';
 
 const serverInfo = {
   name: "Figma MCP Server",
@@ -72,12 +73,20 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
           globalVars,
         };
 
-        Logger.log("Generating YAML result from file");
         const yamlResult = yaml.dump(result);
+        const yamlResultSize = calcStringSize(yamlResult);
 
+        const jsonResult = JSON.stringify(result);
+        const jsonResultSize = calcStringSize(jsonResult);
+
+        Logger.log(`Data size:
+          YAML: ${yamlResultSize} KB
+          JSON: ${jsonResultSize} KB
+        `);
+        
         Logger.log("Sending result to client");
         return {
-          content: [{ type: "text", text: yamlResult }],
+          content: [{ type: "text", text: jsonResult }],
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -189,6 +189,7 @@ export class FigmaService {
 }
 
 function writeJSON2YamlLogs(name: string, value: any) {
+  if (process.env.NODE_ENV !== "development") return;
   const result = yaml.dump(value);
   writeLogs(name, result);
 }

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -9,6 +9,7 @@ import type {
 import { downloadFigmaImage } from "~/utils/common.js";
 import { Logger } from "~/utils/logger.js";
 import yaml from "js-yaml";
+import path from 'path';
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -165,8 +166,8 @@ export class FigmaService {
       const response = await this.request<GetFileResponse>(endpoint);
       Logger.log("Got response");
       const simplifiedResponse = parseFigmaResponse(response);
-      writeLogs("figma-raw.yml", response);
-      writeLogs("figma-simplified.yml", simplifiedResponse);
+      writeJSON2YamlLogs("figma-raw.yml", response);
+      writeJSON2YamlLogs("figma-simplified.yml", simplifiedResponse);
       return simplifiedResponse;
     } catch (e) {
       console.error("Failed to get file:", e);
@@ -178,21 +179,29 @@ export class FigmaService {
     const endpoint = `/files/${fileKey}/nodes?ids=${nodeId}${depth ? `&depth=${depth}` : ""}`;
     const response = await this.request<GetFileNodesResponse>(endpoint);
     Logger.log("Got response from getNode, now parsing.");
-    writeLogs("figma-raw.yml", response);
+    writeJSON2YamlLogs("figma-raw.yml", response);
     const simplifiedResponse = parseFigmaResponse(response);
-    writeLogs("figma-simplified.yml", simplifiedResponse);
+    writeJSON2YamlLogs("figma-simplified.yml", simplifiedResponse);
+    writeLogs("figma-raw.json", JSON.stringify(response));
+    writeLogs("figma-simplified.json", JSON.stringify(simplifiedResponse));
     return simplifiedResponse;
   }
+}
+
+function writeJSON2YamlLogs(name: string, value: any) {
+  const result = yaml.dump(value);
+  writeLogs(name, result);
 }
 
 function writeLogs(name: string, value: any) {
   try {
     if (process.env.NODE_ENV !== "development") return;
 
-    const logsDir = "logs";
+    const logsCWD = process.env.LOG_DIR || process.cwd();
+    const logsDir = path.resolve(logsCWD, "logs");
 
     try {
-      fs.accessSync(process.cwd(), fs.constants.W_OK);
+      fs.accessSync(logsCWD, fs.constants.W_OK);
     } catch (error) {
       Logger.log("Failed to write logs:", error);
       return;
@@ -201,7 +210,9 @@ function writeLogs(name: string, value: any) {
     if (!fs.existsSync(logsDir)) {
       fs.mkdirSync(logsDir);
     }
-    fs.writeFileSync(`${logsDir}/${name}`, yaml.dump(value));
+    const filePath = path.resolve(logsDir, `${name}`);
+    fs.writeFileSync(filePath, value);
+    console.log(`Wrote ${name} to ${filePath}`);
   } catch (error) {
     console.debug("Failed to write logs:", error);
   }

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -175,8 +175,8 @@ export class FigmaService {
     }
   }
 
-  async getNode(fileKey: string, nodeId: string, depth?: number | null): Promise<SimplifiedDesign> {
-    const endpoint = `/files/${fileKey}/nodes?ids=${nodeId}${depth ? `&depth=${depth}` : ""}`;
+  async getNode(fileKey: string, nodeIds: string, depth?: number | null): Promise<SimplifiedDesign> {
+    const endpoint = `/files/${fileKey}/nodes?ids=${nodeIds}${depth ? `&depth=${depth}` : ""}`;
     const response = await this.request<GetFileNodesResponse>(endpoint);
     Logger.log("Got response from getNode, now parsing.");
     writeJSON2YamlLogs("figma-raw.yml", response);

--- a/src/utils/calc-string-size.ts
+++ b/src/utils/calc-string-size.ts
@@ -1,0 +1,12 @@
+import { round } from "remeda";
+
+/**
+ * Calculate the size of a string in kilobytes
+ * @param text - The string to calculate the size of
+ * @returns The size of the string in kilobytes
+ */
+export function calcStringSize(text: string) {
+  const encoder = new TextEncoder();
+  const utf8Bytes = encoder.encode(text);
+  return round(utf8Bytes.length / 1024, 2);
+}


### PR DESCRIPTION

**Modifications:**  
1. Add a data size reading interface.  
2. Allow reading multiple nodes at once.  
3. Dynamically inject a tool prompt to guide the LLM to prune and read data when encountering sizes exceeding the specified limit.  

**Core Objective of the Prompt:**  
Guided by the "pruning" concept, the Agent decomposes data reading top-down. If a node's size exceeds the limit, it reads only level-1 data (self-properties and child node information), then applies the same rule recursively to child nodes until completion.  
![image](https://github.com/user-attachments/assets/721093b7-ccaf-4f42-b737-3077443e67f2)

**Experimental Results:**  
**Advantages:**  
- Significantly improves the experience of reading large datasets, directly avoiding exceptions caused by bulk data retrieval.  

**Disadvantages:**  
1. **Lengthy Process:** Cannot complete all tasks in one go. For example, restoring a design稿 to code in Cursor requires multiple rounds of dialogue to progress step-by-step.  
2. **Context Overflow:** After multiple dialogue rounds, data exceeds the context window, causing the LLM to forget prior information.  

**Improvement for Disadvantage 2:**  
Enable the Agent to automatically maintain a task document `record.md` to log all task-related content or to-dos. Each dialogue starts with reading `record.md`.  

**My Experimental Input in Cursor:**  
```  
@App.tsx  
Gradually restore the design to code on this page  
@figma url  

After fetching data, read, record, and update the todo list in the document, including any to-dos and task progress for the current task. Record Figma node IDs when specifying data for easy lookup @record.md  
```  

**Usage:**  
Specify the maximum data retrieval limit per request via env `GET_NODE_SIZE_LIMIT` (unit: KB):  
```json  
"Framelink Figma MCP": {  
  "command": "<command>",  
  "args": [  
    <...args>  
  ],  
  "env": {  
    "GET_NODE_SIZE_LIMIT": 150  
  }  
},  
```