### PR TITLE
feat: add global --json CLI flag for JSON output format

### DIFF
--- a/.changeset/tame-ideas-dream.md
+++ b/.changeset/tame-ideas-dream.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": patch
+---
+
+Add --json CLI flag and OUTPUT_FORMAT env var to support JSON output format in addition to YAML.

--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ FIGMA_NODE_ID=your_figma_node_id_here
 
 # Server configuration
 PORT=3333
+
+# Output format can either be "yaml" or "json". Is YAML by default since it's
+# smaller, but JSON is understood by most LLMs better.
+#
+# OUTPUT_FORMAT="json"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,10 @@ export async function startServer(): Promise<void> {
 
   const config = getServerConfig(isStdioMode);
 
-  const server = createServer(config.auth, { isHTTP: !isStdioMode });
+  const server = createServer(config.auth, { 
+    isHTTP: !isStdioMode, 
+    outputFormat: config.outputFormat 
+  });
 
   if (isStdioMode) {
     const transport = new StdioServerTransport();

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ interface ServerConfig {
     figmaApiKey: "cli" | "env";
     figmaOAuthToken: "cli" | "env" | "none";
     port: "cli" | "env" | "default";
-    outputFormat: "cli" | "default";
+    outputFormat: "cli" | "env" | "default";
   };
 }
 
@@ -106,6 +106,9 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
   if (argv.json) {
     config.outputFormat = "json";
     config.configSources.outputFormat = "cli";
+  } else if (process.env.OUTPUT_FORMAT) {
+    config.outputFormat = process.env.OUTPUT_FORMAT as "yaml" | "json";
+    config.configSources.outputFormat = "env";
   }
 
   // Validate configuration
@@ -131,7 +134,9 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
       console.log("- Authentication Method: Personal Access Token (X-Figma-Token)");
     }
     console.log(`- PORT: ${config.port} (source: ${config.configSources.port})`);
-    console.log(`- OUTPUT_FORMAT: ${config.outputFormat} (source: ${config.configSources.outputFormat})`);
+    console.log(
+      `- OUTPUT_FORMAT: ${config.outputFormat} (source: ${config.configSources.outputFormat})`,
+    );
     console.log(); // Empty line for better readability
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,10 +9,12 @@ config();
 interface ServerConfig {
   auth: FigmaAuthOptions;
   port: number;
+  outputFormat: "yaml" | "json";
   configSources: {
     figmaApiKey: "cli" | "env";
     figmaOAuthToken: "cli" | "env" | "none";
     port: "cli" | "env" | "default";
+    outputFormat: "cli" | "default";
   };
 }
 
@@ -25,6 +27,7 @@ interface CliArgs {
   "figma-api-key"?: string;
   "figma-oauth-token"?: string;
   port?: number;
+  json?: boolean;
 }
 
 export function getServerConfig(isStdioMode: boolean): ServerConfig {
@@ -43,6 +46,11 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
         type: "number",
         description: "Port to run the server on",
       },
+      json: {
+        type: "boolean",
+        description: "Output data from tools in JSON format instead of YAML",
+        default: false,
+      },
     })
     .help()
     .version(process.env.NPM_PACKAGE_VERSION ?? "unknown")
@@ -56,10 +64,12 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
 
   const config: Omit<ServerConfig, "auth"> = {
     port: 3333,
+    outputFormat: "yaml",
     configSources: {
       figmaApiKey: "env",
       figmaOAuthToken: "none",
       port: "default",
+      outputFormat: "default",
     },
   };
 
@@ -92,6 +102,12 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
     config.configSources.port = "env";
   }
 
+  // Handle JSON output format
+  if (argv.json) {
+    config.outputFormat = "json";
+    config.configSources.outputFormat = "cli";
+  }
+
   // Validate configuration
   if (!auth.figmaApiKey && !auth.figmaOAuthToken) {
     console.error(
@@ -115,6 +131,7 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
       console.log("- Authentication Method: Personal Access Token (X-Figma-Token)");
     }
     console.log(`- PORT: ${config.port} (source: ${config.configSources.port})`);
+    console.log(`- OUTPUT_FORMAT: ${config.outputFormat} (source: ${config.configSources.outputFormat})`);
     console.log(); // Empty line for better readability
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,9 +10,14 @@ const serverInfo = {
   version: process.env.NPM_PACKAGE_VERSION ?? "unknown",
 };
 
+type CreateServerOptions = {
+  isHTTP?: boolean;
+  outputFormat?: "yaml" | "json";
+};
+
 function createServer(
   authOptions: FigmaAuthOptions,
-  { isHTTP = false, outputFormat = "yaml" }: { isHTTP?: boolean; outputFormat?: "yaml" | "json" } = {},
+  { isHTTP = false, outputFormat = "yaml" }: CreateServerOptions = {},
 ) {
   const server = new McpServer(serverInfo);
   // const figmaService = new FigmaService(figmaApiKey);
@@ -24,7 +29,11 @@ function createServer(
   return server;
 }
 
-function registerTools(server: McpServer, figmaService: FigmaService, outputFormat: "yaml" | "json"): void {
+function registerTools(
+  server: McpServer,
+  figmaService: FigmaService,
+  outputFormat: "yaml" | "json",
+): void {
   // Tool to get file information
   server.tool(
     "get_figma_data",
@@ -73,9 +82,8 @@ function registerTools(server: McpServer, figmaService: FigmaService, outputForm
         };
 
         Logger.log(`Generating ${outputFormat.toUpperCase()} result from file`);
-        const formattedResult = outputFormat === "json" 
-          ? JSON.stringify(result, null, 2)
-          : yaml.dump(result);
+        const formattedResult =
+          outputFormat === "json" ? JSON.stringify(result, null, 2) : yaml.dump(result);
 
         Logger.log("Sending result to client");
         return {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -47,8 +47,15 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
         .describe(
           "OPTIONAL. Do NOT use unless explicitly requested by the user. Controls how many levels deep to traverse the node tree,",
         ),
+      outputFormat: z
+        .enum(["yaml", "json"])
+        .optional()
+        .default("yaml")
+        .describe(
+          "Output format for the returned data. Can be 'yaml' dump (using `js-yaml`) or stringified 'json' (using `JSON.stringify`). Defaults to 'yaml'.",
+        ),
     },
-    async ({ fileKey, nodeId, depth }) => {
+    async ({ fileKey, nodeId, depth, outputFormat = "yaml" }) => {
       try {
         Logger.log(
           `Fetching ${
@@ -72,12 +79,13 @@ function registerTools(server: McpServer, figmaService: FigmaService): void {
           globalVars,
         };
 
-        Logger.log("Generating YAML result from file");
-        const yamlResult = yaml.dump(result);
+        Logger.log(`Generating ${outputFormat.toUpperCase()} result from file`);
+        const formattedResult =
+          outputFormat === "json" ? JSON.stringify(result, null, 2) : yaml.dump(result);
 
         Logger.log("Sending result to client");
         return {
-          content: [{ type: "text", text: yamlResult }],
+          content: [{ type: "text", text: formattedResult }],
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);


### PR DESCRIPTION
# Add global `--json` CLI flag for JSON output format

Currently, the MCP server exclusively returns Figma data serialized as YAML strings using `js-yaml`. While YAML is suitable for many use cases, some downstream consumers or LLM agents might prefer or require data in JSON format.

This change introduces a global CLI flag `--json` that allows users to specify their desired output format for all tools that return structured data. This enhancement aims to reduce the need for client-side YAML-to-JSON conversion if JSON is the preferred format (as in general LLMs work better with JSON).

## The actual changes:

1. **New `--json` CLI Flag:**
   * A global `--json` boolean flag has been added to the CLI interface.
   * This flag affects all tools that output structured data across the entire MCP server.
   * It defaults to `false` (YAML output) to ensure backward compatibility with existing integrations.
   * Follows the same pattern as other global flags like `--stdio`.

2. **Global Output Format Configuration:**
   * The `--json` flag sets a global `outputFormat` configuration that gets passed through the server initialization.
   * All tools that output structured data now respect this global setting.
   * Configuration source tracking has been added for debugging and transparency.

3. **Conditional Output Serialization:**
   * When `--json` flag is used, structured data is serialized using `JSON.stringify(result, null, 2)` (providing pretty-printed JSON).
   * When the flag is omitted, data is serialized using `yaml.dump(result)`, maintaining the original behavior.
   * Currently affects the `get_figma_data` tool, with easy extensibility to other tools that return structured data.

## Usage Examples:
```bash
# Default YAML output (backward compatible)
npx figma-developer-mcp --figma-api-key=YOUR-KEY --stdio

# New JSON output
npx figma-developer-mcp --figma-api-key=YOUR-KEY --json --stdio
```

---
*Note: An earlier implementation used a tool-specific `outputFormat` parameter within `get_figma_data`, but was changed to this global CLI flag approach for better consistency and maintainability.*