### PR TITLE
docs: localize documentation for Traditional Chinese readers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,9 +9,10 @@
   <h1>Framelink Figma MCP サーバー</h1>
   <p>
     🌐 利用可能な言語:
-    <a href="README.md">English</a> |
-    <a href="README.ko.md">한국어 (Korean)</a> |
-    <a href="README.zh.md">中文 (Chinese)</a>
+    <a href="README.md">English (英語)</a> |
+    <a href="README.ko.md">한국어 (韓国語)</a> |
+    <a href="README.zh-cn.md">简体中文 (簡体字中国語)</a> |
+    <a href="README.zh-tw.md">繁體中文 (繁体字中国語)</a>
   </p>
   <h3>コーディングエージェントにFigmaデータへのアクセスを提供。<br/>ワンショットで任意のフレームワークにデザインを実装。</h3>
   <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,9 +9,10 @@
   <h1>Framelink Figma MCP 서버</h1>
   <p>
     🌐 다른 언어:
-    <a href="README.md">English</a> |
-    <a href="README.ja.md">日本語 (Japanese)</a> |
-    <a href="README.zh.md">中文 (Chinese)</a>
+    <a href="README.md">English (영어)</a> |
+    <a href="README.ja.md">日本語 (일본어)</a> |
+    <a href="README.zh-cn.md">简体中文 (중국어 간체)</a> |
+    <a href="README.zh-tw.md">繁體中文 (중국어 번체)</a>
   </p>
   <h3>코딩 에이전트에게 Figma 데이터에 대한 접근 권한을 부여하세요.<br/>한 번에 모든 프레임워크에서 디자인을 구현하세요.</h3>
   <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
     🌐 Available in:
     <a href="README.ko.md">한국어 (Korean)</a> |
     <a href="README.ja.md">日本語 (Japanese)</a> |
-    <a href="README.zh.md">中文 (Chinese)</a>
+    <a href="README.zh-cn.md">简体中文 (Simplified Chinese)</a> |
+    <a href="README.zh-tw.md">繁體中文 (Traditional Chinese)</a>
   </p>
   <h3>Give your coding agent access to your Figma data.<br/>Implement designs in any framework in one-shot.</h3>
   <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -9,9 +9,10 @@
   <h1>Framelink Figma MCP 服务器</h1>
   <p>
     🌐 可用语言:
-    <a href="README.md">English</a> |
-    <a href="README.ko.md">한국어 (Korean)</a> |
-    <a href="README.ja.md">日本語 (Japanese)</a>
+    <a href="README.md">English (英语)</a> |
+    <a href="README.ko.md">한국어 (韩语)</a> |
+    <a href="README.ja.md">日本語 (日语)</a> |
+    <a href="README.zh-tw.md">繁體中文 (繁体中文)</a>
   </p>
   <h3>为您的编码代理提供 Figma 数据访问权限。<br/>一次性在任何框架中实现设计。</h3>
   <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -1,0 +1,148 @@
+<a href="https://www.framelink.ai/?utm_source=github&utm_medium=referral&utm_campaign=readme" target="_blank" rel="noopener">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.framelink.ai/github/HeaderDark.png" />
+    <img alt="Framelink" src="https://www.framelink.ai/github/HeaderLight.png" />
+  </picture>
+</a>
+
+<div align="center">
+  <h1>Framelink Figma MCP 伺服器</h1>
+  <p>
+    🌐 可用語言:
+    <a href="README.md">English (英文)</a> |
+    <a href="README.ko.md">한국어 (韓文)</a> |
+    <a href="README.ja.md">日本語 (日文)</a> |
+    <a href="README.zh-cn.md">简体中文 (簡體中文)</a>
+  </p>
+  <h3>讓您的程式碼代理存取您的 Figma 資料。<br/>在任何框架中一次性完成設計。</h3>
+  <a href="https://npmcharts.com/compare/figma-developer-mcp?interval=30">
+    <img alt="每週下載次數" src="https://img.shields.io/npm/dm/figma-developer-mcp.svg">
+  </a>
+  <a href="https://github.com/GLips/Figma-Context-MCP/blob/main/LICENSE">
+    <img alt="MIT 授權條款" src="https://img.shields.io/github/license/GLips/Figma-Context-MCP" />
+  </a>
+  <a href="https://framelink.ai/discord">
+    <img alt="Discord" src="https://img.shields.io/discord/1352337336913887343?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <br />
+  <a href="https://twitter.com/glipsman">
+    <img alt="Twitter" src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fglipsman&label=%40glipsman" />
+  </a>
+</div>
+
+<br/>
+
+使用此 [Model Context Protocol](https://modelcontextprotocol.io/introduction) 伺服器，讓 [Cursor](https://cursor.sh/) 和其他由 AI 驅動的程式碼工具存取您的 Figma 檔案。
+
+當 Cursor 可以存取 Figma 設計資料時，它在一次性精準實現設計方面，比貼上螢幕截圖等替代方案**好得多**。
+
+<h3><a href="https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=referral&utm_campaign=readme">查看快速入門指南 →</a></h3>
+
+## 示範
+
+[觀看在 Cursor 中使用 Figma 設計資料建構 UI 的示範](https://youtu.be/6G9yb-LrEqg)
+
+[ ![觀看影片](https://img.youtube.com/vi/6G9yb-LrEqg/maxresdefault.jpg) ](https://youtu.be/6G9yb-LrEqg)
+
+## 運作方式
+
+1. 開啟您 IDE 的聊天功能（例如 Cursor 中的代理模式）。
+2. 貼上 Figma 檔案、框架或群組的連結。
+3. 要求 Cursor 對 Figma 檔案執行操作 — 例如，實現設計。
+4. Cursor 將從 Figma 取得相關元數據，並用它來編寫您的程式碼。
+
+此 MCP 伺服器專為與 Cursor 搭配使用而設計。在從 [Figma API](https://www.figma.com/developers/api) 回應內容之前，它會簡化和轉譯回應，以便只向模型提供最相關的版面配置和樣式資訊。
+
+減少提供給模型的內容有助於提高 AI 的準確性並使回應更具關聯性。
+
+## 入門指南
+
+許多程式碼編輯器和其他 AI 客戶端都使用設定檔來管理 MCP 伺服器。
+
+可以透過將以下內容新增至您的設定檔來設定 `figma-developer-mcp` 伺र्वर。
+
+> 注意：您需要建立一個 Figma 存取權杖才能使用此伺服器。有關如何建立 Figma API 存取權杖的說明，請參閱[此處](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)。
+
+### MacOS / Linux
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "mcpServers": {
+    "Framelink Figma MCP": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"]
+    }
+  }
+}
+```
+
+或者您可以在 `env` 欄位中設定 `FIGMA_API_KEY` 和 `PORT`。
+
+如果您需要有關如何設定 Framelink Figma MCP 伺服器的更多資訊，請參閱 [Framelink 文件](https://www.framelink.ai/docs/quickstart?utm_source=github&utm_medium=referral&utm_campaign=readme)。
+
+## Star 歷史
+
+<a href="https://star-history.com/#GLips/Figma-Context-MCP"><img src="https://api.star-history.com/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="Star History Chart" width="600" /></a>
+
+## 了解更多
+
+Framelink Figma MCP 伺服器既簡單又強大。請前往 [Framelink](https://framelink.ai?utm_source=github&utm_medium=referral&utm_campaign=readme) 網站了解更多資訊，以充分利用它。
+
+<!-- SPONSORS:LIST:START -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+## 贊助商
+
+### 🥇 黃金贊助商
+
+<table>
+  <tr>
+   <td align="center"><a href="https://framelink.ai/?ref=framelink-mcp&utm_source=github&utm_medium=referral&utm_campaign=framelink-mcp"><img src="https://avatars.githubusercontent.com/u/204619719" width="180" alt="Framelink"/><br />Framelink</a></td>
+  </tr>
+</table>
+
+### 🥈 白銀贊助商
+
+<table>
+  <tr>
+   <!-- <td align="center"><a href=""><img src="" width="150" alt="tbd"/><br />Title</a></td> -->
+  </tr>
+</table>
+
+### 🥉 青銅贊助商
+
+<table>
+  <tr>
+   <!-- <td align="center"><a href=""><img src="" width="120" alt="tbd"/><br />tbd</a></td>-->
+  </tr>
+</table>
+
+### 😻 小額贊助者
+
+<table>
+  <tr>
+   <!-- <td align="center"><a href=""><img src="" width="100" alt="tbd"/><br />tbd</a></td>-->
+  </tr>
+  <tr>
+   <!-- <td align="center"><a href=""><img src="" width="100" alt="tbd"/><br />tbd</a></td>-->
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- SPONSORS:LIST:END -->


### PR DESCRIPTION
- Split the Chinese README into Simplified (zh-cn) and Traditional (zh-tw) versions, with a new README.zh-tw.md file added.
- Update all language selection menus in the readmes to reference the correct language variants and include native language names.
- Improve clarity in language labels throughout the documentation.
- README.zh.md renamed to README.zh-cn.md to explicitly indicate Simplified Chinese.
- README.zh-tw.md provides full Traditional Chinese documentation and localized instructions, increasing accessibility for Traditional Chinese readers.