### PR TITLE
fix: path sanitization to prevent directory containment bypass

### DIFF
--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -157,7 +157,7 @@ export class FigmaService {
 
     const sanitizedPath = path.normalize(localPath).replace(/^(\.\.(\/|\\|$))+/, "");
     const resolvedPath = path.resolve(sanitizedPath);
-    if (!resolvedPath.startsWith(path.resolve(process.cwd()))) {
+    if ((resolvedPath != path.resolve(process.cwd())) && !resolvedPath.startsWith(path.resolve(process.cwd()) + path.sep)) {
       throw new Error("Invalid path specified. Directory traversal is not allowed.");
     }
 


### PR DESCRIPTION
This is a follow-up patch to https://github.com/GLips/Figma-Context-MCP/pull/206 

The previous patch did not fully prevent directory containment bypass. An attacker could still access paths like `/path/to/allowed/directory-evil` even when the allowed directory is set to `/path/to/allowed/directory`. This issue is similar to [CVE-2025-53110](https://github.com/modelcontextprotocol/servers/security/advisories/GHSA-hc55-p739-j48w) reported in another MCP server. 