### PR TITLE
fix: check filename extension

### DIFF
--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -25,8 +25,8 @@ const parameters = {
       fileName: z
         .string()
         .regex(
-          /^[a-zA-Z0-9_.-]+$/,
-          "File name can only contain alphanumeric characters, underscores, dots, and hyphens",
+          /^[a-zA-Z0-9_.-]+\.(png|svg)$/,
+          "File names must contain only letters, numbers, underscores, dots, or hyphens, and end with .png or .svg.",
         )
         .describe(
           "The local name for saving the fetched file, including extension. Either png or svg.",


### PR DESCRIPTION
Verify that the filename extension is `.png` or `.svg` to ensure it meets the described requirements. In current version, if the extension is missing, it may cause issues when downloading image file with option `filenameSuffix`. 

For example, call `download_figma_images` with the following arguments will save the file to `-v2.rabbit`, which is not a valid image file.
```
[
  {
    "nodeId": "2:1050",
    "fileName": "rabbit",
    "filenameSuffix": "v2"
  }
]
```

