### PR TITLE
Add CLI usage

### DIFF
--- a/.changeset/major-shoes-carry.md
+++ b/.changeset/major-shoes-carry.md
@@ -1,0 +1,5 @@
+---
+"figma-developer-mcp": minor
+---
+
+Introduce CLI option for downloading and persisting Figma data

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,7 @@ export default [
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
+      "no-undef": "off",
     },
   },
   {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,14 +1,27 @@
 #!/usr/bin/env node
 
-import { config } from "dotenv";
-import { resolve } from "path";
-import { startServer } from "./server.js";
+import { startServerConfigurable } from "./server.js";
+import { executeOnce } from "./exec-mode.js";
+import { getParsedArgs, getServerConfig } from "./config.js";
 
-// Load .env from the current working directory
-config({ path: resolve(process.cwd(), ".env") });
+const argv = getParsedArgs();
 
-// Start the server immediately - this file is only for execution
-startServer().catch((error) => {
-  console.error("Failed to start server:", error);
-  process.exit(1);
-});
+// Route to exec mode or server mode
+const execUrl = argv.exec || argv.e;
+
+if (execUrl) {
+  // Exec mode: one-off data fetch, then exit
+  const config = getServerConfig(argv, false, true);
+  executeOnce(execUrl, config.auth, config.outputFormat).catch((error) => {
+    console.error("Failed to execute:", error);
+    process.exit(1);
+  });
+} else {
+  // Server mode (stdio or HTTP)
+  const isStdioMode = process.env.NODE_ENV === "cli" || argv.stdio === true;
+
+  startServerConfigurable(argv, isStdioMode).catch((error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });
+}

--- a/src/exec-mode.ts
+++ b/src/exec-mode.ts
@@ -1,0 +1,40 @@
+import { FigmaService } from "./services/figma.js";
+import { simplifyRawFigmaObject, allExtractors } from "./extractors/index.js";
+import { parseFigmaUrl } from "./utils/url-parser.js";
+import type { FigmaAuthOptions } from "./services/figma.js";
+import yaml from "js-yaml";
+
+/**
+ * Execute a single Figma data fetch and output to stdout, then exit.
+ * This is a non-server mode for one-off data retrieval.
+ */
+export async function executeOnce(
+  figmaUrl: string,
+  authOptions: FigmaAuthOptions,
+  outputFormat: "yaml" | "json",
+): Promise<void> {
+  const { fileKey, nodeId: rawNodeId } = parseFigmaUrl(figmaUrl);
+
+  // Replace - with : in nodeId for API query Figma API expects
+  const nodeId = rawNodeId?.replace(/-/g, ":");
+
+  const figmaService = new FigmaService(authOptions);
+
+  const rawApiResponse = nodeId
+    ? await figmaService.getRawNode(fileKey, nodeId, null)
+    : await figmaService.getRawFile(fileKey, null);
+
+  const simplifiedDesign = simplifyRawFigmaObject(rawApiResponse, allExtractors);
+
+  const { nodes, globalVars, ...metadata } = simplifiedDesign;
+  const result = {
+    metadata,
+    nodes,
+    globalVars,
+  };
+
+  const formattedResult =
+    outputFormat === "json" ? JSON.stringify(result, null, 2) : yaml.dump(result);
+
+  console.log(formattedResult);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { Server } from "http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Logger } from "./utils/logger.js";
 import { createServer } from "./mcp/index.js";
-import { getServerConfig } from "./config.js";
+import { getParsedArgs, getServerConfig, type CliArgs } from "./config.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 let httpServer: Server | null = null;
@@ -20,10 +20,15 @@ const transports = {
  * Start the MCP server in either stdio or HTTP mode.
  */
 export async function startServer(): Promise<void> {
-  // Check if we're running in stdio mode (e.g., via CLI)
-  const isStdioMode = process.env.NODE_ENV === "cli" || process.argv.includes("--stdio");
+  const argv = getParsedArgs();
 
-  const config = getServerConfig(isStdioMode);
+  // Server mode (stdio or HTTP)
+  const isStdioMode = process.env.NODE_ENV === "cli" || argv.stdio === true;
+  await startServerConfigurable(argv, isStdioMode);
+}
+
+export async function startServerConfigurable(argv: CliArgs, isStdioMode: boolean): Promise<void> {
+  const config = getServerConfig(argv, isStdioMode, false);
 
   const server = createServer(config.auth, {
     isHTTP: !isStdioMode,


### PR DESCRIPTION
Hey! :slightly_smiling_face: 
Not even a month has passed. :grin: 

I'm not super happy about `exec` polluting `config.ts` to skip `console.log`'s, but I'm not sure whether it is a good idea to overhaul more for such simple addition. :thinking: 

Also not super happy about having to have a compatibility adapter for `startServer`, but I've ran out of ideas for now, maybe tomorrow I'll have better ones. :grin: 
Just wanted to avoid using `process.argv` directly and rely on yargs entirely. :thinking: 

Let me know if it makes sense to add example of using `-e` to `README.md`, or in `--help` for users that are not aware of output piping like `figma-server-mcp -e "figma-link" > figma-node.yaml`.
I tried to avoid adding more arguments like `--output`. :slightly_smiling_face: 

Also figma links could contain `&` which would run whatever after `&` as a "command", so suggesting quoting figma link probably makes sense as well. :thinking: 

Also out of scope, but I checked out if there's some solution to the `process.argv` with type inference and it appears there is one. :thinking: 
https://bloomberg.github.io/stricli/docs/getting-started/alternatives

Feel free to do anything with the PR.
Let me know your thoughts :slightly_smiling_face: 
Thanks.