### PR TITLE
Set explicit JSON body size limit for /mcp

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -43,8 +43,9 @@ export async function startServer(): Promise<void> {
 export async function startHttpServer(host: string, port: number, mcpServer: McpServer): Promise<void> {
   const app = express();
 
-  // Parse JSON requests for the Streamable HTTP endpoint only, will break SSE endpoint
-  app.use("/mcp", express.json());
+  // Parse JSON requests for the Streamable HTTP endpoint only (this will break SSE endpoints),
+  // and enforce an explicit body size limit to reduce DoS risk.
+  app.use("/mcp", express.json({ limit: "1mb" }));
 
   // Modern Streamable HTTP endpoint
   app.post("/mcp", async (req, res) => {


### PR DESCRIPTION
This sets an explicit Express JSON body size limit on the Streamable HTTP endpoint (`/mcp`).

Rationale: `express.json()` has a default limit, but making it explicit helps avoid surprises and reduces DoS risk for MCP/tool endpoints.
