### PR TITLE
fix: add --stdio option to CLI help output

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ interface CliArgs {
   host?: string;
   json?: boolean;
   "skip-image-downloads"?: boolean;
+  stdio?: boolean;
 }
 
 export function getServerConfig(isStdioMode: boolean): ServerConfig {
@@ -68,6 +69,11 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
       "skip-image-downloads": {
         type: "boolean",
         description: "Do not register the download_figma_images tool (skip image downloads)",
+        default: false,
+      },
+      stdio: {
+        type: "boolean",
+        description: "Run in stdio mode for CLI-based MCP clients (e.g., Cursor, Claude Desktop)",
         default: false,
       },
     })


### PR DESCRIPTION
## Summary

The `--stdio` flag is already supported in `server.ts` via `process.argv.includes("--stdio")`, but it was missing from the yargs option definitions in `config.ts`. This means:

- `--stdio` does not appear in `--help` output
- Users have no way to discover this option without reading source code

## Changes

- Added `stdio` boolean option to the yargs configuration in `config.ts`
- Added it to the `CliArgs` interface for type safety

## After this fix

```
$ npx figma-developer-mcp --help
Options:
  --figma-api-key         Figma API key (Personal Access Token)         [string]
  --figma-oauth-token     Figma OAuth Bearer token                      [string]
  ...
  --stdio                 Run in stdio mode for CLI-based MCP clients
                          (e.g., Cursor, Claude Desktop)  [boolean] [default: false]
  --help                  Show help                                    [boolean]
  --version               Show version number                          [boolean]
```

Fixes #274