### PR TITLE
feat: replace yargs with cleye for CLI flag parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,14 +52,13 @@
   "dependencies": {
     "@figma/rest-api-spec": "^0.33.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@types/yargs": "^17.0.33",
+    "cleye": "^2.2.1",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "js-yaml": "^4.1.1",
     "remeda": "^2.20.1",
     "sharp": "^0.34.3",
-    "yargs": "^17.7.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
-      '@types/yargs':
-        specifier: ^17.0.33
-        version: 17.0.33
+      cleye:
+        specifier: ^2.2.1
+        version: 2.2.1
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -35,9 +35,6 @@ importers:
       sharp:
         specifier: ^0.34.3
         version: 0.34.3
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -660,12 +657,6 @@ packages:
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.33':
-    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
-
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -878,9 +869,8 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+  cleye@2.2.1:
+    resolution: {integrity: sha512-eZzJGlG3N6+IsKV+297HIRS2fyRsLMOrx62hGUmmcyOtP/I+L7JVeSKZH49WZUdVB8NoaZOUvq01363I/PHJiA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1034,10 +1024,6 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1201,10 +1187,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
@@ -1682,10 +1664,6 @@ packages:
   remeda@2.20.1:
     resolution: {integrity: sha512-gsEsSmjE0CHkNp6xEsWsU/6JVNWq7rqw+ZfzNMbVV4YFIPtTj/i0FfxurTRI6Z9sAnQufU9de2Cb3xHsUTFTMA==}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1838,6 +1816,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  terminal-columns@2.0.0:
+    resolution: {integrity: sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1914,6 +1895,9 @@ packages:
   type-fest@4.34.1:
     resolution: {integrity: sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==}
     engines: {node: '>=16'}
+
+  type-flag@4.0.3:
+    resolution: {integrity: sha512-YA09cL07U7hSV+/doSfKl+RkIZ2olCnevZsVgAuyBUG3h2ROf9Oh2vmbq5Rf26aA9/qu9RtStuc7ap5PC6k/vw==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -2050,18 +2034,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2506,12 +2478,6 @@ snapshots:
       '@types/node': 20.17.0
       '@types/send': 0.17.4
 
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.33':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.7.3))(eslint@9.39.3)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2774,11 +2740,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  cliui@8.0.1:
+  cleye@2.2.1:
     dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
+      terminal-columns: 2.0.0
+      type-flag: 4.0.3
 
   color-convert@2.0.1:
     dependencies:
@@ -2913,8 +2878,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
-
-  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -3152,8 +3115,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.2.7:
     dependencies:
@@ -3559,8 +3520,6 @@ snapshots:
     dependencies:
       type-fest: 4.34.1
 
-  require-directory@2.1.1: {}
-
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -3808,6 +3767,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  terminal-columns@2.0.0: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -3882,6 +3843,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.34.1: {}
+
+  type-flag@4.0.3: {}
 
   type-is@1.6.18:
     dependencies:
@@ -3986,20 +3949,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  y18n@5.0.8: {}
-
-  yargs-parser@21.1.1: {}
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 
-import { config } from "dotenv";
-import { resolve } from "path";
 import { startServer } from "./server.js";
 
-// Load .env from the current working directory
-config({ path: resolve(process.cwd(), ".env") });
-
-// Start the server immediately - this file is only for execution
 startServer().catch((error) => {
   console.error("Failed to start server:", error);
   process.exit(1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,24 +1,49 @@
 import { config as loadEnv } from "dotenv";
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import { resolve } from "path";
+import { cli } from "cleye";
+import { resolve as resolvePath } from "path";
 import type { FigmaAuthOptions } from "./services/figma.js";
+
+type Source = "cli" | "env" | "default";
+
+interface Resolved<T> {
+  value: T;
+  source: Source;
+}
 
 interface ServerConfig {
   auth: FigmaAuthOptions;
   port: number;
   host: string;
   outputFormat: "yaml" | "json";
-  skipImageDownloads?: boolean;
-  configSources: {
-    figmaApiKey: "cli" | "env";
-    figmaOAuthToken: "cli" | "env" | "none";
-    port: "cli" | "env" | "default";
-    host: "cli" | "env" | "default";
-    outputFormat: "cli" | "env" | "default";
-    envFile: "cli" | "default";
-    skipImageDownloads?: "cli" | "env" | "default";
-  };
+  skipImageDownloads: boolean;
+  isStdioMode: boolean;
+  configSources: Record<string, Source>;
+}
+
+/** Resolve a config value through the priority chain: CLI flag → env var → default. */
+function resolve<T>(flag: T | undefined, env: T | undefined, fallback: T): Resolved<T> {
+  if (flag !== undefined) return { value: flag, source: "cli" };
+  if (env !== undefined) return { value: env, source: "env" };
+  return { value: fallback, source: "default" };
+}
+
+function envStr(name: string): string | undefined {
+  return process.env[name] || undefined;
+}
+
+function envInt(...names: string[]): number | undefined {
+  for (const name of names) {
+    const val = process.env[name];
+    if (val) return parseInt(val, 10);
+  }
+  return undefined;
+}
+
+function envBool(name: string): boolean | undefined {
+  const val = process.env[name];
+  if (val === "true") return true;
+  if (val === "false") return false;
+  return undefined;
 }
 
 function maskApiKey(key: string): string {
@@ -26,152 +51,81 @@ function maskApiKey(key: string): string {
   return `****${key.slice(-4)}`;
 }
 
-interface CliArgs {
-  "figma-api-key"?: string;
-  "figma-oauth-token"?: string;
-  env?: string;
-  port?: number;
-  host?: string;
-  json?: boolean;
-  "skip-image-downloads"?: boolean;
-}
-
-export function getServerConfig(isStdioMode: boolean): ServerConfig {
-  // Parse command line arguments
-  const argv = yargs(hideBin(process.argv))
-    .options({
-      "figma-api-key": {
-        type: "string",
+export function getServerConfig(): ServerConfig {
+  const argv = cli({
+    name: "figma-developer-mcp",
+    version: process.env.NPM_PACKAGE_VERSION ?? "unknown",
+    flags: {
+      figmaApiKey: {
+        type: String,
         description: "Figma API key (Personal Access Token)",
       },
-      "figma-oauth-token": {
-        type: "string",
+      figmaOauthToken: {
+        type: String,
         description: "Figma OAuth Bearer token",
       },
       env: {
-        type: "string",
+        type: String,
         description: "Path to custom .env file to load environment variables from",
       },
       port: {
-        type: "number",
+        type: Number,
         description: "Port to run the server on",
       },
       host: {
-        type: "string",
+        type: String,
         description: "Host to run the server on",
       },
       json: {
-        type: "boolean",
+        type: Boolean,
         description: "Output data from tools in JSON format instead of YAML",
-        default: false,
       },
-      "skip-image-downloads": {
-        type: "boolean",
+      skipImageDownloads: {
+        type: Boolean,
         description: "Do not register the download_figma_images tool (skip image downloads)",
-        default: false,
       },
-    })
-    .help()
-    .version(process.env.NPM_PACKAGE_VERSION ?? "unknown")
-    .parseSync() as CliArgs;
+      stdio: {
+        type: Boolean,
+        description: "Run in stdio transport mode for MCP clients",
+      },
+    },
+  });
 
-  // Load environment variables ASAP from custom path or default
-  let envFilePath: string;
-  let envFileSource: "cli" | "default";
-
-  if (argv["env"]) {
-    envFilePath = resolve(argv["env"]);
-    envFileSource = "cli";
-  } else {
-    envFilePath = resolve(process.cwd(), ".env");
-    envFileSource = "default";
-  }
-
-  // Override anything auto-loaded from .env if a custom file is provided.
+  // Load .env before resolving env-backed values
+  const envFilePath = argv.flags.env
+    ? resolvePath(argv.flags.env)
+    : resolvePath(process.cwd(), ".env");
+  const envFileSource: Source = argv.flags.env ? "cli" : "default";
   loadEnv({ path: envFilePath, override: true });
 
+  // Resolve config values: CLI flag → env var → default
+  const figmaApiKey = resolve(argv.flags.figmaApiKey, envStr("FIGMA_API_KEY"), "");
+  const figmaOauthToken = resolve(argv.flags.figmaOauthToken, envStr("FIGMA_OAUTH_TOKEN"), "");
+  const port = resolve(argv.flags.port, envInt("FRAMELINK_PORT", "PORT"), 3333);
+  const host = resolve(argv.flags.host, envStr("FRAMELINK_HOST"), "127.0.0.1");
+  const skipImageDownloads = resolve(
+    argv.flags.skipImageDownloads,
+    envBool("SKIP_IMAGE_DOWNLOADS"),
+    false,
+  );
+
+  // These two don't fit the simple pattern: --json maps to a string enum,
+  // and --stdio has a NODE_ENV backdoor.
+  const outputFormat = resolve<"yaml" | "json">(
+    argv.flags.json ? "json" : undefined,
+    envStr("OUTPUT_FORMAT") as "yaml" | "json" | undefined,
+    "yaml",
+  );
+  const isStdioMode = argv.flags.stdio === true || process.env.NODE_ENV === "cli";
+
+  // Auth
+  const useOAuth = Boolean(figmaOauthToken.value);
   const auth: FigmaAuthOptions = {
-    figmaApiKey: "",
-    figmaOAuthToken: "",
-    useOAuth: false,
+    figmaApiKey: figmaApiKey.value,
+    figmaOAuthToken: figmaOauthToken.value,
+    useOAuth,
   };
 
-  const config: Omit<ServerConfig, "auth"> = {
-    port: 3333,
-    host: "127.0.0.1",
-    outputFormat: "yaml",
-    skipImageDownloads: false,
-    configSources: {
-      figmaApiKey: "env",
-      figmaOAuthToken: "none",
-      port: "default",
-      host: "default",
-      outputFormat: "default",
-      envFile: envFileSource,
-      skipImageDownloads: "default",
-    },
-  };
-
-  // Handle FIGMA_API_KEY
-  if (argv["figma-api-key"]) {
-    auth.figmaApiKey = argv["figma-api-key"];
-    config.configSources.figmaApiKey = "cli";
-  } else if (process.env.FIGMA_API_KEY) {
-    auth.figmaApiKey = process.env.FIGMA_API_KEY;
-    config.configSources.figmaApiKey = "env";
-  }
-
-  // Handle FIGMA_OAUTH_TOKEN
-  if (argv["figma-oauth-token"]) {
-    auth.figmaOAuthToken = argv["figma-oauth-token"];
-    config.configSources.figmaOAuthToken = "cli";
-    auth.useOAuth = true;
-  } else if (process.env.FIGMA_OAUTH_TOKEN) {
-    auth.figmaOAuthToken = process.env.FIGMA_OAUTH_TOKEN;
-    config.configSources.figmaOAuthToken = "env";
-    auth.useOAuth = true;
-  }
-
-  // Handle PORT (FRAMELINK_PORT takes precedence, PORT is fallback for backwards compatibility)
-  if (argv.port) {
-    config.port = argv.port;
-    config.configSources.port = "cli";
-  } else if (process.env.FRAMELINK_PORT) {
-    config.port = parseInt(process.env.FRAMELINK_PORT, 10);
-    config.configSources.port = "env";
-  } else if (process.env.PORT) {
-    config.port = parseInt(process.env.PORT, 10);
-    config.configSources.port = "env";
-  }
-
-  // Handle HOST
-  if (argv.host) {
-    config.host = argv.host;
-    config.configSources.host = "cli";
-  } else if (process.env.FRAMELINK_HOST) {
-    config.host = process.env.FRAMELINK_HOST;
-    config.configSources.host = "env";
-  }
-
-  // Handle JSON output format
-  if (argv.json) {
-    config.outputFormat = "json";
-    config.configSources.outputFormat = "cli";
-  } else if (process.env.OUTPUT_FORMAT) {
-    config.outputFormat = process.env.OUTPUT_FORMAT as "yaml" | "json";
-    config.configSources.outputFormat = "env";
-  }
-
-  // Handle skipImageDownloads
-  if (argv["skip-image-downloads"]) {
-    config.skipImageDownloads = true;
-    config.configSources.skipImageDownloads = "cli";
-  } else if (process.env.SKIP_IMAGE_DOWNLOADS === "true") {
-    config.skipImageDownloads = true;
-    config.configSources.skipImageDownloads = "env";
-  }
-
-  // Validate configuration
   if (!auth.figmaApiKey && !auth.figmaOAuthToken) {
     console.error(
       "Either FIGMA_API_KEY or FIGMA_OAUTH_TOKEN is required (via CLI argument or .env file)",
@@ -179,34 +133,46 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
     process.exit(1);
   }
 
-  // Log configuration sources
+  const configSources: Record<string, Source> = {
+    envFile: envFileSource,
+    figmaApiKey: figmaApiKey.source,
+    figmaOauthToken: figmaOauthToken.source,
+    port: port.source,
+    host: host.source,
+    outputFormat: outputFormat.source,
+    skipImageDownloads: skipImageDownloads.source,
+  };
+
   if (!isStdioMode) {
     console.log("\nConfiguration:");
-    console.log(`- ENV_FILE: ${envFilePath} (source: ${config.configSources.envFile})`);
-    if (auth.useOAuth) {
+    console.log(`- ENV_FILE: ${envFilePath} (source: ${configSources.envFile})`);
+    if (useOAuth) {
       console.log(
-        `- FIGMA_OAUTH_TOKEN: ${maskApiKey(auth.figmaOAuthToken)} (source: ${config.configSources.figmaOAuthToken})`,
+        `- FIGMA_OAUTH_TOKEN: ${maskApiKey(auth.figmaOAuthToken)} (source: ${configSources.figmaOauthToken})`,
       );
       console.log("- Authentication Method: OAuth Bearer Token");
     } else {
       console.log(
-        `- FIGMA_API_KEY: ${maskApiKey(auth.figmaApiKey)} (source: ${config.configSources.figmaApiKey})`,
+        `- FIGMA_API_KEY: ${maskApiKey(auth.figmaApiKey)} (source: ${configSources.figmaApiKey})`,
       );
       console.log("- Authentication Method: Personal Access Token (X-Figma-Token)");
     }
-    console.log(`- FRAMELINK_PORT: ${config.port} (source: ${config.configSources.port})`);
-    console.log(`- FRAMELINK_HOST: ${config.host} (source: ${config.configSources.host})`);
+    console.log(`- FRAMELINK_PORT: ${port.value} (source: ${configSources.port})`);
+    console.log(`- FRAMELINK_HOST: ${host.value} (source: ${configSources.host})`);
+    console.log(`- OUTPUT_FORMAT: ${outputFormat.value} (source: ${configSources.outputFormat})`);
     console.log(
-      `- OUTPUT_FORMAT: ${config.outputFormat} (source: ${config.configSources.outputFormat})`,
+      `- SKIP_IMAGE_DOWNLOADS: ${skipImageDownloads.value} (source: ${configSources.skipImageDownloads})`,
     );
-    console.log(
-      `- SKIP_IMAGE_DOWNLOADS: ${config.skipImageDownloads} (source: ${config.configSources.skipImageDownloads})`,
-    );
-    console.log(); // Empty line for better readability
+    console.log();
   }
 
   return {
-    ...config,
     auth,
+    port: port.value,
+    host: host.value,
+    outputFormat: outputFormat.value,
+    skipImageDownloads: skipImageDownloads.value,
+    isStdioMode,
+    configSources,
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,18 +20,15 @@ const transports = {
  * Start the MCP server in either stdio or HTTP mode.
  */
 export async function startServer(): Promise<void> {
-  // Check if we're running in stdio mode (e.g., via CLI)
-  const isStdioMode = process.env.NODE_ENV === "cli" || process.argv.includes("--stdio");
-
-  const config = getServerConfig(isStdioMode);
+  const config = getServerConfig();
 
   const server = createServer(config.auth, {
-    isHTTP: !isStdioMode,
+    isHTTP: !config.isStdioMode,
     outputFormat: config.outputFormat,
     skipImageDownloads: config.skipImageDownloads,
   });
 
-  if (isStdioMode) {
+  if (config.isStdioMode) {
     const transport = new StdioServerTransport();
     await server.connect(transport);
   } else {


### PR DESCRIPTION
## Summary

- Replace yargs with [cleye](https://github.com/privatenumber/cleye), a lightweight TypeScript-first CLI parser with auto-generated `--help` and strong type inference
- Add `--stdio` as a proper CLI flag (previously detected via raw `process.argv.includes()`, invisible in `--help`)
- Internalize stdio mode detection in `getServerConfig()` — callers no longer need to detect it externally
- Add `resolve()` helper to collapse repetitive CLI > env > default if/else chains into one-liners
- Remove duplicate `.env` loading from `bin.ts`
- Remove `CliArgs` interface (cleye infers types from flag definitions)
- Remove `yargs` and `@types/yargs` dependencies

### Before
```
$ node dist/bin.js --help
# --stdio not listed, incomplete help output
```

### After
```
$ node dist/bin.js --help
figma-developer-mcp v0.6.5

Usage:
  figma-developer-mcp [flags...]

Flags:
      --env <string>                      Path to custom .env file to load environment variables from
      --figma-api-key <string>            Figma API key (Personal Access Token)
      --figma-oauth-token <string>        Figma OAuth Bearer token
  -h, --help                              Show help
      --host <string>                     Host to run the server on
      --json                              Output data from tools in JSON format instead of YAML
      --port <number>                     Port to run the server on
      --skip-image-downloads              Do not register the download_figma_images tool (skip image downloads)
      --stdio                             Run in stdio transport mode for MCP clients
      --version                           Show version
```

### Breaking change

`getServerConfig()` no longer takes an `isStdioMode` parameter. It detects stdio mode internally and returns it as `ServerConfig.isStdioMode`. This affects external consumers importing `getServerConfig` from the package.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 11 tests pass
- [x] `pnpm build && node dist/bin.js --help` — all flags including `--stdio` appear
- [x] `pnpm build && node dist/bin.js --version` — version displays correctly
- [x] Verify stdio mode: `echo '{}' | node dist/bin.js --stdio --figma-api-key=test-key`
- [ ] Verify HTTP mode: `node dist/bin.js --figma-api-key=test-key --port 4000`