### PR TITLE
fix: handle null values in Figma prototype file responses

### DIFF
--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -70,12 +70,17 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
     nodesToParse = nodeResponses.map((n) => n?.document).filter((doc) => doc && isVisible(doc));
   } else {
     // GetFileResponse
-    Object.assign(aggregatedComponents, data.components);
-    Object.assign(aggregatedComponentSets, data.componentSets);
+    if (data.components) {
+      Object.assign(aggregatedComponents, data.components);
+    }
+    if (data.componentSets) {
+      Object.assign(aggregatedComponentSets, data.componentSets);
+    }
     if (data.styles) {
       extraStyles = data.styles;
     }
-    nodesToParse = data.document.children.filter(isVisible);
+    // Handle null document or children in prototype file responses
+    nodesToParse = data.document?.children?.filter(isVisible) ?? [];
   }
 
   const { name } = data;

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -55,6 +55,8 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
     // GetFileNodesResponse
     const nodeResponses = Object.values(data.nodes);
     nodeResponses.forEach((nodeResponse) => {
+      // Skip null responses (can occur for prototype files or inaccessible branches)
+      if (!nodeResponse) return;
       if (nodeResponse.components) {
         Object.assign(aggregatedComponents, nodeResponse.components);
       }
@@ -65,7 +67,7 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
         Object.assign(extraStyles, nodeResponse.styles);
       }
     });
-    nodesToParse = nodeResponses.map((n) => n.document).filter(isVisible);
+    nodesToParse = nodeResponses.map((n) => n?.document).filter((doc) => doc && isVisible(doc));
   } else {
     // GetFileResponse
     Object.assign(aggregatedComponents, data.components);


### PR DESCRIPTION
## Problem

When accessing Figma prototype files (URLs with /proto/ format), the MCP server crashes with:


cannot read properties of null (reading 'components')


This occurs because:
1. The Figma API returns 
null
 for node responses when accessing prototype files or inaccessible branches
2. The 
parseAPIResponse()
 function in 
design-extractor.ts
 does not handle null values before accessing properties
3. Both 
GetFileNodesResponse
 and 
GetFileResponse
 paths lack null-safety checks

Fixes #201

## Root Cause

In 
src/extractors/design-extractor.ts
:

- Line 58: 
nodeResponse.components
 accessed without checking if 
nodeResponse
 is null
- Line 68: 
n.document
 accessed without optional chaining
- Line 74-75: 
data.components
 and 
data.componentSets
 accessed without null checks
- Line 80: 
data.document.children
 accessed without optional chaining

## Changes

Added comprehensive null-safety checks:

1. **Skip null nodeResponses** (line 58): Added early return if 
nodeResponse
 is null
2. **Optional chaining for document access** (line 70): Changed to 
n?.document
 with proper filter
3. **Null checks for components/componentSets** (lines 74-79): Added 
if
 guards before Object.assign
4. **Safe document children access** (line 82): Changed to 
data.document?.children?.filter()
 with nullish coalescing to empty array

## Verification

- ✅ 
pnpm type-check
: No TypeScript errors
- ✅ 
pnpm test
: All 11 tests pass (1 skipped)
- ✅ 
git diff --check
: No whitespace issues
- ✅ Changes limited to 1 file: 
src/extractors/design-extractor.ts
 (+11/-4 lines)

## Risk/Edge Cases

- **Prototype files**: Now handled gracefully by skipping null responses
- **Inaccessible branches**: Same fix applies - null responses are filtered out
- **Regular design files**: No behavioral change - existing functionality preserved
- **Empty responses**: Returns empty 
nodesToParse
 array instead of crashing

## Issue Link

Closes #201