### PR TITLE
fix: add --stdio option to CLI help

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,11 @@ export function getServerConfig(isStdioMode: boolean): ServerConfig {
         description: "Do not register the download_figma_images tool (skip image downloads)",
         default: false,
       },
+      stdio: {
+        type: "boolean",
+        description: "Run in stdio mode for MCP client communication (required by most MCP clients)",
+        default: false,
+      },
     })
     .help()
     .version(process.env.NPM_PACKAGE_VERSION ?? "unknown")


### PR DESCRIPTION
## Problem

The `--stdio` option was being checked in `server.ts` via `process.argv.includes('--stdio')` but wasn't defined in the yargs options in `config.ts`. This meant it didn't appear in `--help` output, confusing users who saw `--stdio` in documentation but didn't see it as an available option.

## Solution

Added the `--stdio` option to the yargs configuration so it appears in `--help` output:

```
--stdio  Run in stdio mode for MCP client communication (required by most MCP clients)
                                                      [boolean] [default: false]
```

## Testing

Verified that `npx figma-developer-mcp --help` now shows the `--stdio` option.

Fixes #274