### PR TITLE
refactor: simplify alignment conversion in layout transformer

### DIFF
--- a/src/tests/layout-alignment.test.ts
+++ b/src/tests/layout-alignment.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect } from "vitest";
+import { buildSimplifiedLayout } from "~/transformers/layout.js";
+import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
+
+function makeFrame(overrides: Record<string, unknown> = {}) {
+  return {
+    clipsContent: true,
+    layoutMode: "HORIZONTAL",
+    children: [],
+    primaryAxisAlignItems: "MIN",
+    counterAxisAlignItems: "MIN",
+    ...overrides,
+  } as unknown as FigmaDocumentNode;
+}
+
+function makeChild(overrides: Record<string, unknown> = {}) {
+  return {
+    layoutSizingHorizontal: "FIXED",
+    layoutSizingVertical: "FIXED",
+    ...overrides,
+  };
+}
+
+describe("layout alignment", () => {
+  describe("justifyContent (primary axis)", () => {
+    const cases: [string, string | undefined][] = [
+      ["MIN", undefined],
+      ["MAX", "flex-end"],
+      ["CENTER", "center"],
+      ["SPACE_BETWEEN", "space-between"],
+    ];
+
+    test.each(cases)("row: %s → %s", (figmaValue, expected) => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        primaryAxisAlignItems: figmaValue,
+      });
+      expect(buildSimplifiedLayout(node).justifyContent).toBe(expected);
+    });
+
+    test.each(cases)("column: %s → %s", (figmaValue, expected) => {
+      const node = makeFrame({
+        layoutMode: "VERTICAL",
+        primaryAxisAlignItems: figmaValue,
+      });
+      expect(buildSimplifiedLayout(node).justifyContent).toBe(expected);
+    });
+  });
+
+  describe("alignItems (counter axis)", () => {
+    const cases: [string, string | undefined][] = [
+      ["MIN", undefined],
+      ["MAX", "flex-end"],
+      ["CENTER", "center"],
+      ["BASELINE", "baseline"],
+    ];
+
+    test.each(cases)("row: %s → %s", (figmaValue, expected) => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        counterAxisAlignItems: figmaValue,
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe(expected);
+    });
+
+    test.each(cases)("column: %s → %s", (figmaValue, expected) => {
+      const node = makeFrame({
+        layoutMode: "VERTICAL",
+        counterAxisAlignItems: figmaValue,
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe(expected);
+    });
+  });
+
+  describe("alignItems stretch detection", () => {
+    test("row: all children fill cross axis → stretch", () => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        children: [
+          makeChild({ layoutSizingVertical: "FILL" }),
+          makeChild({ layoutSizingVertical: "FILL" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("stretch");
+    });
+
+    test("column: all children fill cross axis → stretch", () => {
+      const node = makeFrame({
+        layoutMode: "VERTICAL",
+        children: [
+          makeChild({ layoutSizingHorizontal: "FILL" }),
+          makeChild({ layoutSizingHorizontal: "FILL" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("stretch");
+    });
+
+    test("row: mixed children → falls back to enum value", () => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        counterAxisAlignItems: "CENTER",
+        children: [
+          makeChild({ layoutSizingVertical: "FILL" }),
+          makeChild({ layoutSizingVertical: "FIXED" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("center");
+    });
+
+    test("column: mixed children → falls back to enum value", () => {
+      const node = makeFrame({
+        layoutMode: "VERTICAL",
+        counterAxisAlignItems: "MAX",
+        children: [
+          makeChild({ layoutSizingHorizontal: "FILL" }),
+          makeChild({ layoutSizingHorizontal: "FIXED" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("flex-end");
+    });
+
+    test("absolute children are excluded from stretch check", () => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        children: [
+          makeChild({ layoutSizingVertical: "FILL" }),
+          makeChild({ layoutPositioning: "ABSOLUTE", layoutSizingVertical: "FIXED" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("stretch");
+    });
+
+    test("no children → no stretch, uses enum value", () => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        counterAxisAlignItems: "CENTER",
+        children: [],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("center");
+    });
+
+    // These two tests verify correct cross-axis detection — the bug PR #232 addressed.
+    // With the old bug, row mode checked layoutSizingHorizontal (main axis) instead of
+    // layoutSizingVertical (cross axis), so children filling main-only would false-positive.
+    test("row: children fill main axis only → no stretch", () => {
+      const node = makeFrame({
+        layoutMode: "HORIZONTAL",
+        counterAxisAlignItems: "CENTER",
+        children: [
+          makeChild({ layoutSizingHorizontal: "FILL", layoutSizingVertical: "FIXED" }),
+          makeChild({ layoutSizingHorizontal: "FILL", layoutSizingVertical: "FIXED" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("center");
+    });
+
+    test("column: children fill main axis only → no stretch", () => {
+      const node = makeFrame({
+        layoutMode: "VERTICAL",
+        counterAxisAlignItems: "CENTER",
+        children: [
+          makeChild({ layoutSizingVertical: "FILL", layoutSizingHorizontal: "FIXED" }),
+          makeChild({ layoutSizingVertical: "FILL", layoutSizingHorizontal: "FIXED" }),
+        ],
+      });
+      expect(buildSimplifiedLayout(node).alignItems).toBe("center");
+    });
+  });
+});

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -42,42 +42,9 @@ export function buildSimplifiedLayout(
   return { ...frameValues, ...layoutValues };
 }
 
-// For flex layouts, process alignment and sizing
-function convertAlign(
-  axisAlign?:
-    | HasFramePropertiesTrait["primaryAxisAlignItems"]
-    | HasFramePropertiesTrait["counterAxisAlignItems"],
-  stretch?: {
-    children: FigmaDocumentNode[];
-    axis: "primary" | "counter";
-    mode: "row" | "column" | "none";
-  },
-) {
-  if (stretch && stretch.mode !== "none") {
-    const { children, mode, axis } = stretch;
-
-    // Compute whether to check horizontally or vertically based on axis and direction
-    const direction = getDirection(axis, mode);
-
-    const shouldStretch =
-      children.length > 0 &&
-      children.reduce((shouldStretch, c) => {
-        if (!shouldStretch) return false;
-        if ("layoutPositioning" in c && c.layoutPositioning === "ABSOLUTE") return true;
-        if (direction === "horizontal") {
-          return "layoutSizingHorizontal" in c && c.layoutSizingHorizontal === "FILL";
-        } else if (direction === "vertical") {
-          return "layoutSizingVertical" in c && c.layoutSizingVertical === "FILL";
-        }
-        return false;
-      }, true);
-
-    if (shouldStretch) return "stretch";
-  }
-
-  switch (axisAlign) {
+function convertJustifyContent(align?: HasFramePropertiesTrait["primaryAxisAlignItems"]) {
+  switch (align) {
     case "MIN":
-      // MIN, AKA flex-start, is the default alignment
       return undefined;
     case "MAX":
       return "flex-end";
@@ -85,6 +52,34 @@ function convertAlign(
       return "center";
     case "SPACE_BETWEEN":
       return "space-between";
+    default:
+      return undefined;
+  }
+}
+
+function convertAlignItems(
+  align: HasFramePropertiesTrait["counterAxisAlignItems"] | undefined,
+  children: FigmaDocumentNode[],
+  mode: "row" | "column",
+) {
+  // Row cross-axis is vertical; column cross-axis is horizontal
+  const crossSizing = mode === "row" ? "layoutSizingVertical" : "layoutSizingHorizontal";
+  const allStretch =
+    children.length > 0 &&
+    children.every(
+      (c) =>
+        ("layoutPositioning" in c && c.layoutPositioning === "ABSOLUTE") ||
+        (crossSizing in c && (c as Record<string, unknown>)[crossSizing] === "FILL"),
+    );
+  if (allStretch) return "stretch";
+
+  switch (align) {
+    case "MIN":
+      return undefined;
+    case "MAX":
+      return "flex-end";
+    case "CENTER":
+      return "center";
     case "BASELINE":
       return "baseline";
     default:
@@ -118,29 +113,6 @@ function convertSizing(
   return undefined;
 }
 
-function getDirection(
-  axis: "primary" | "counter",
-  mode: "row" | "column",
-): "horizontal" | "vertical" {
-  switch (axis) {
-    case "primary":
-      switch (mode) {
-        case "row":
-          return "horizontal";
-        case "column":
-          return "vertical";
-      }
-      break;
-    case "counter":
-      switch (mode) {
-        case "row":
-          return "vertical";
-        case "column":
-          return "horizontal";
-      }
-  }
-}
-
 function buildSimplifiedFrameValues(n: FigmaDocumentNode): SimplifiedLayout | { mode: "none" } {
   if (!isFrame(n)) {
     return { mode: "none" };
@@ -164,17 +136,12 @@ function buildSimplifiedFrameValues(n: FigmaDocumentNode): SimplifiedLayout | { 
     return frameValues;
   }
 
-  // TODO: convertAlign should be two functions, one for justifyContent and one for alignItems
-  frameValues.justifyContent = convertAlign(n.primaryAxisAlignItems ?? "MIN", {
-    children: n.children,
-    axis: "primary",
-    mode: frameValues.mode,
-  });
-  frameValues.alignItems = convertAlign(n.counterAxisAlignItems ?? "MIN", {
-    children: n.children,
-    axis: "counter",
-    mode: frameValues.mode,
-  });
+  frameValues.justifyContent = convertJustifyContent(n.primaryAxisAlignItems ?? "MIN");
+  frameValues.alignItems = convertAlignItems(
+    n.counterAxisAlignItems ?? "MIN",
+    n.children,
+    frameValues.mode,
+  );
   frameValues.alignSelf = convertSelfAlign(n.layoutAlign);
 
   // Only include wrap if it's set to WRAP, since flex layouts don't default to wrapping


### PR DESCRIPTION
## Summary

- Replace `convertAlign` and `getDirection` with two focused functions: `convertJustifyContent` and `convertAlignItems`
- Cross-axis direction is now a single ternary (`mode === "row" ? "layoutSizingVertical" : "layoutSizingHorizontal"`) instead of a nested switch-in-a-switch indirection
- Each function only includes the CSS values valid for its property (`SPACE_BETWEEN` only in justify, `BASELINE` only in align)
- Add 24 tests covering all alignment enum mappings and stretch detection edge cases, including the cross-axis bug that PR #232 independently found

## Test plan

- [x] All 24 new layout alignment tests pass
- [x] TypeScript type-check passes
- [x] Pre-commit lint/format hooks pass