### PR TITLE
fix: handle drive root paths in image directory security check

### DIFF
--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -95,7 +95,9 @@ async function downloadFigmaImages(
     // LLMs frequently produce paths like "/public/images" when they mean "public/images".
     const baseDir = imageDir ?? process.cwd();
     const resolvedPath = path.resolve(path.join(baseDir, localPath));
-    if (resolvedPath !== baseDir && !resolvedPath.startsWith(baseDir + path.sep)) {
+    // Drive roots (e.g. E:\) already end with a separator — avoid doubling it
+    const baseDirPrefix = baseDir.endsWith(path.sep) ? baseDir : baseDir + path.sep;
+    if (resolvedPath !== baseDir && !resolvedPath.startsWith(baseDirPrefix)) {
       return {
         isError: true,
         content: [

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { downloadFigmaImagesTool } from "~/mcp/tools/download-figma-images-tool.js";
 import { downloadFigmaImage } from "~/utils/common.js";
 
-const stubFigmaService = {} as Parameters<typeof downloadFigmaImagesTool.handler>[1];
+const stubFigmaService = {
+  downloadImages: () => Promise.resolve([]),
+} as unknown as Parameters<typeof downloadFigmaImagesTool.handler>[1];
 
 const validParams = {
   fileKey: "abc123",
@@ -38,17 +40,13 @@ describe("download path validation", () => {
   });
 
   it("accepts valid relative path within imageDir", async () => {
-    // Will fail on the Figma API call — we only care that it doesn't
-    // return the path validation error.
     const result = await downloadFigmaImagesTool.handler(
       { ...validParams, localPath: "public/images" },
       stubFigmaService,
       imageDir,
     );
 
-    if (result.isError) {
-      expect(result.content[0].text).not.toContain("resolves outside the allowed image directory");
-    }
+    expect(result.isError).toBeUndefined();
   });
 
   it("accepts valid path when imageDir is a drive root", async () => {
@@ -62,22 +60,17 @@ describe("download path validation", () => {
       driveRoot,
     );
 
-    if (result.isError) {
-      expect(result.content[0].text).not.toContain("resolves outside the allowed image directory");
-    }
+    expect(result.isError).toBeUndefined();
   });
 
   it("accepts path with leading slash as relative", async () => {
-    // LLMs frequently produce paths like "/public/images" when they mean "public/images"
     const result = await downloadFigmaImagesTool.handler(
       { ...validParams, localPath: "/public/images" },
       stubFigmaService,
       imageDir,
     );
 
-    if (result.isError) {
-      expect(result.content[0].text).not.toContain("resolves outside the allowed image directory");
-    }
+    expect(result.isError).toBeUndefined();
   });
 });
 

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -51,6 +51,22 @@ describe("download path validation", () => {
     }
   });
 
+  it("accepts valid path when imageDir is a drive root", async () => {
+    // Windows drive roots (E:\, D:\) already end with a separator.
+    // path.resolve on posix treats this as a regular directory, which is fine
+    // — the logic under test is the prefix check, not actual Windows I/O.
+    const driveRoot = path.resolve("/");
+    const result = await downloadFigmaImagesTool.handler(
+      { ...validParams, localPath: "project/src/static/images/test" },
+      stubFigmaService,
+      driveRoot,
+    );
+
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain("resolves outside the allowed image directory");
+    }
+  });
+
   it("accepts path with leading slash as relative", async () => {
     // LLMs frequently produce paths like "/public/images" when they mean "public/images"
     const result = await downloadFigmaImagesTool.handler(


### PR DESCRIPTION
## Summary
- When `--image-dir` is a Windows drive root (e.g., `E:\`, `D:\`), the path already ends with a separator. The security check appended another `path.sep`, creating a double-separator prefix (`E:\\`) that never matched any resolved path — rejecting all valid `localPath` values.
- Fixed by checking whether `baseDir` already ends with a separator before appending one.
- Added a test case covering the drive-root scenario.

Closes #300

## Test plan
- [x] New test: `accepts valid path when imageDir is a drive root` — uses `path.resolve("/")` as the image dir and verifies the path check passes
- [x] All existing path validation tests continue to pass
- [x] Type check and lint clean