### PR TITLE
fix: disambiguate duplicate style names

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -16,12 +16,14 @@ import {
 } from "~/transformers/text.js";
 import { hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { generateVarId } from "~/utils/common.js";
-import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
+import type { Node as FigmaDocumentNode, Style } from "@figma/rest-api-spec";
 
 // Reverse lookup cache: serialized style value → varId.
 // Keyed on the GlobalVars instance so it's automatically scoped to each
 // extraction run and garbage-collected when the run's context is released.
 const styleCaches = new WeakMap<GlobalVars, Map<string, string>>();
+const styleNameCounts = new WeakMap<Record<string, Style>, Map<string, number>>();
+const styleKeyCache = new WeakMap<Record<string, Style>, Map<string, string>>();
 
 function getStyleCache(globalVars: GlobalVars): Map<string, string> {
   let cache = styleCaches.get(globalVars);
@@ -30,6 +32,40 @@ function getStyleCache(globalVars: GlobalVars): Map<string, string> {
     styleCaches.set(globalVars, cache);
   }
   return cache;
+}
+
+function getStyleNameCounts(extraStyles: Record<string, Style>): Map<string, number> {
+  let counts = styleNameCounts.get(extraStyles);
+  if (!counts) {
+    counts = new Map();
+    for (const style of Object.values(extraStyles)) {
+      if (!style.name) continue;
+      counts.set(style.name, (counts.get(style.name) ?? 0) + 1);
+    }
+    styleNameCounts.set(extraStyles, counts);
+  }
+  return counts;
+}
+
+function getShortStyleId(styleId: string): string {
+  const base = styleId.split(":").pop() ?? styleId;
+  return base.length > 6 ? base.slice(-6) : base;
+}
+
+function getStyleKey(extraStyles: Record<string, Style>, styleId: string, name: string): string {
+  let cache = styleKeyCache.get(extraStyles);
+  if (!cache) {
+    cache = new Map();
+    styleKeyCache.set(extraStyles, cache);
+  }
+
+  const existing = cache.get(styleId);
+  if (existing) return existing;
+
+  const counts = getStyleNameCounts(extraStyles);
+  const key = counts.get(name) && counts.get(name)! > 1 ? `${name} (${getShortStyleId(styleId)})` : name;
+  cache.set(styleId, key);
+  return key;
 }
 
 /**
@@ -180,7 +216,10 @@ function getStyleName(
     const styleId = styleMap[key];
     if (styleId) {
       const meta = context.globalVars.extraStyles?.[styleId];
-      if (meta?.name) return meta.name;
+      if (meta?.name) {
+        const extraStyles = context.globalVars.extraStyles;
+        return extraStyles ? getStyleKey(extraStyles, styleId, meta.name) : meta.name;
+      }
     }
   }
   return undefined;

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { extractFromDesign } from "~/extractors/node-walker.js";
 import { allExtractors, collapseSvgContainers } from "~/extractors/built-in.js";
 import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
+import type { GlobalVars } from "~/extractors/types.js";
 import type { GetFileResponse } from "@figma/rest-api-spec";
 import type { Node as FigmaNode } from "@figma/rest-api-spec";
 
@@ -119,6 +120,55 @@ describe("extractFromDesign", () => {
     // Only one fill entry should exist in globalVars
     const fillEntries = Object.entries(globalVars.styles).filter(([key]) => key.startsWith("fill"));
     expect(fillEntries).toHaveLength(1);
+  });
+
+  it("disambiguates named styles that share the same name", async () => {
+    const styleName = "Heading / Large";
+    const styleIdA = "S:1234567890";
+    const styleIdB = "S:abcdef1234";
+
+    const extraStyles = {
+      [styleIdA]: { name: styleName },
+      [styleIdB]: { name: styleName },
+    };
+
+    const baseStyle = {
+      fontFamily: "Inter",
+      fontWeight: 400,
+      fontSize: 14,
+      lineHeightPx: 20,
+      textAlignHorizontal: "LEFT",
+      textAlignVertical: "TOP",
+    };
+
+    const nodeA = makeNode({
+      id: "6:1",
+      name: "Title A",
+      type: "TEXT",
+      characters: "Hello",
+      style: baseStyle,
+      styles: { text: styleIdA },
+    });
+
+    const nodeB = makeNode({
+      id: "6:2",
+      name: "Title B",
+      type: "TEXT",
+      characters: "World",
+      style: baseStyle,
+      styles: { text: styleIdB },
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([nodeA, nodeB], allExtractors, {}, {
+      styles: {},
+      extraStyles,
+    } as GlobalVars & { extraStyles: typeof extraStyles });
+
+    const styleKeys = Object.keys(globalVars.styles).filter((key) => key.startsWith(styleName));
+    expect(styleKeys).toHaveLength(2);
+    expect(nodes[0].textStyle).not.toBe(nodes[1].textStyle);
+    expect(nodes[0].textStyle).toBe(`${styleName} (567890)`);
+    expect(nodes[1].textStyle).toBe(`${styleName} (ef1234)`);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #265 by disambiguating named styles that share a name.

## Changes
- append a short style-id suffix when multiple styles share the same name
- add a regression test for duplicate style names

## Testing
- not run (not requested)