### PR TITLE
fix: disambiguate named styles with duplicate names

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -201,9 +201,7 @@ function resolveStyleKey(
   if (!existing) return styleMatch.name;
   if (JSON.stringify(existing) === JSON.stringify(value)) return styleMatch.name;
 
-  const cleanedId = styleMatch.id.replace(/[^a-zA-Z0-9]/g, "");
-  if (!cleanedId) return styleMatch.name;
-  return `${styleMatch.name}__${cleanedId}`;
+  return `${styleMatch.name} (${styleMatch.id})`;
 }
 
 // -------------------- CONVENIENCE COMBINATIONS --------------------

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -15,7 +15,7 @@ import {
   isTextNode,
 } from "~/transformers/text.js";
 import { hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
-import { generateVarId } from "~/utils/common.js";
+import { generateVarId, isVisible } from "~/utils/common.js";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
 
 // Reverse lookup cache: serialized style value → varId.
@@ -106,7 +106,10 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
 
   // fills
   if (hasValue("fills", node) && Array.isArray(node.fills) && node.fills.length) {
-    const fills = node.fills.map((fill) => parsePaint(fill, hasChildren)).reverse();
+    const fills = node.fills
+      .filter(isVisible)
+      .map((fill) => parsePaint(fill, hasChildren))
+      .reverse();
     result.fills = registerStyle(node, context, fills, ["fill", "fills"], "fill");
   }
 

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -49,6 +49,26 @@ function findOrCreateVar(globalVars: GlobalVars, value: StyleTypes, prefix: stri
 }
 
 /**
+ * Register a style value, preferring a Figma named style when available.
+ * Falls back to an auto-generated deduplicating variable ID.
+ */
+function registerStyle(
+  node: FigmaDocumentNode,
+  context: TraversalContext,
+  value: StyleTypes,
+  styleKeys: string[],
+  prefix: string,
+): string {
+  const styleMatch = getStyleMatch(node, context, styleKeys);
+  if (styleMatch) {
+    const styleKey = resolveStyleKey(context, styleMatch, value);
+    context.globalVars.styles[styleKey] = value;
+    return styleKey;
+  }
+  return findOrCreateVar(context.globalVars, value, prefix);
+}
+
+/**
  * Extracts layout-related properties from a node.
  */
 export const layoutExtractor: ExtractorFn = (node, result, context) => {
@@ -71,15 +91,7 @@ export const textExtractor: ExtractorFn = (node, result, context) => {
   if (hasTextStyle(node)) {
     const textStyle = extractTextStyle(node);
     if (textStyle) {
-      // Prefer Figma named style when available
-      const styleMatch = getStyleMatch(node, context, ["text", "typography"]);
-      if (styleMatch) {
-        const styleKey = resolveStyleKey(context, styleMatch, textStyle);
-        context.globalVars.styles[styleKey] = textStyle;
-        result.textStyle = styleKey;
-      } else {
-        result.textStyle = findOrCreateVar(context.globalVars, textStyle, "style");
-      }
+      result.textStyle = registerStyle(node, context, textStyle, ["text", "typography"], "style");
     }
   }
 };
@@ -95,14 +107,7 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // fills
   if (hasValue("fills", node) && Array.isArray(node.fills) && node.fills.length) {
     const fills = node.fills.map((fill) => parsePaint(fill, hasChildren)).reverse();
-    const styleMatch = getStyleMatch(node, context, ["fill", "fills"]);
-    if (styleMatch) {
-      const styleKey = resolveStyleKey(context, styleMatch, fills);
-      context.globalVars.styles[styleKey] = fills;
-      result.fills = styleKey;
-    } else {
-      result.fills = findOrCreateVar(context.globalVars, fills, "fill");
-    }
+    result.fills = registerStyle(node, context, fills, ["fill", "fills"], "fill");
   }
 
   // strokes
@@ -125,15 +130,7 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // effects
   const effects = buildSimplifiedEffects(node);
   if (Object.keys(effects).length) {
-    const styleMatch = getStyleMatch(node, context, ["effect", "effects"]);
-    if (styleMatch) {
-      // Effects styles store only the effect values
-      const styleKey = resolveStyleKey(context, styleMatch, effects);
-      context.globalVars.styles[styleKey] = effects;
-      result.effects = styleKey;
-    } else {
-      result.effects = findOrCreateVar(context.globalVars, effects, "effect");
-    }
+    result.effects = registerStyle(node, context, effects, ["effect", "effects"], "effect");
   }
 
   // opacity

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -113,7 +113,7 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // strokes
   const strokes = buildSimplifiedStrokes(node, hasChildren);
   if (strokes.colors.length) {
-    result.strokes = registerStyle(node, context, strokes.colors, ["stroke", "strokes"], "stroke");
+    result.strokes = registerStyle(node, context, strokes.colors, ["stroke", "strokes"], "fill");
     if (strokes.strokeWeight) result.strokeWeight = strokes.strokeWeight;
     if (strokes.strokeDashes) result.strokeDashes = strokes.strokeDashes;
     if (strokes.strokeWeights) result.strokeWeights = strokes.strokeWeights;

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -113,18 +113,10 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // strokes
   const strokes = buildSimplifiedStrokes(node, hasChildren);
   if (strokes.colors.length) {
-    const styleMatch = getStyleMatch(node, context, ["stroke", "strokes"]);
-    if (styleMatch) {
-      // Only colors are stylable; keep other stroke props on the node
-      const styleKey = resolveStyleKey(context, styleMatch, strokes.colors);
-      context.globalVars.styles[styleKey] = strokes.colors;
-      result.strokes = styleKey;
-      if (strokes.strokeWeight) result.strokeWeight = strokes.strokeWeight;
-      if (strokes.strokeDashes) result.strokeDashes = strokes.strokeDashes;
-      if (strokes.strokeWeights) result.strokeWeights = strokes.strokeWeights;
-    } else {
-      result.strokes = findOrCreateVar(context.globalVars, strokes, "stroke");
-    }
+    result.strokes = registerStyle(node, context, strokes.colors, ["stroke", "strokes"], "stroke");
+    if (strokes.strokeWeight) result.strokeWeight = strokes.strokeWeight;
+    if (strokes.strokeDashes) result.strokeDashes = strokes.strokeDashes;
+    if (strokes.strokeWeights) result.strokeWeights = strokes.strokeWeights;
   }
 
   // effects

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -72,10 +72,11 @@ export const textExtractor: ExtractorFn = (node, result, context) => {
     const textStyle = extractTextStyle(node);
     if (textStyle) {
       // Prefer Figma named style when available
-      const styleName = getStyleName(node, context, ["text", "typography"]);
-      if (styleName) {
-        context.globalVars.styles[styleName] = textStyle;
-        result.textStyle = styleName;
+      const styleMatch = getStyleMatch(node, context, ["text", "typography"]);
+      if (styleMatch) {
+        const styleKey = resolveStyleKey(context, styleMatch, textStyle);
+        context.globalVars.styles[styleKey] = textStyle;
+        result.textStyle = styleKey;
       } else {
         result.textStyle = findOrCreateVar(context.globalVars, textStyle, "style");
       }
@@ -94,10 +95,11 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // fills
   if (hasValue("fills", node) && Array.isArray(node.fills) && node.fills.length) {
     const fills = node.fills.map((fill) => parsePaint(fill, hasChildren)).reverse();
-    const styleName = getStyleName(node, context, ["fill", "fills"]);
-    if (styleName) {
-      context.globalVars.styles[styleName] = fills;
-      result.fills = styleName;
+    const styleMatch = getStyleMatch(node, context, ["fill", "fills"]);
+    if (styleMatch) {
+      const styleKey = resolveStyleKey(context, styleMatch, fills);
+      context.globalVars.styles[styleKey] = fills;
+      result.fills = styleKey;
     } else {
       result.fills = findOrCreateVar(context.globalVars, fills, "fill");
     }
@@ -106,11 +108,12 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // strokes
   const strokes = buildSimplifiedStrokes(node, hasChildren);
   if (strokes.colors.length) {
-    const styleName = getStyleName(node, context, ["stroke", "strokes"]);
-    if (styleName) {
+    const styleMatch = getStyleMatch(node, context, ["stroke", "strokes"]);
+    if (styleMatch) {
       // Only colors are stylable; keep other stroke props on the node
-      context.globalVars.styles[styleName] = strokes.colors;
-      result.strokes = styleName;
+      const styleKey = resolveStyleKey(context, styleMatch, strokes.colors);
+      context.globalVars.styles[styleKey] = strokes.colors;
+      result.strokes = styleKey;
       if (strokes.strokeWeight) result.strokeWeight = strokes.strokeWeight;
       if (strokes.strokeDashes) result.strokeDashes = strokes.strokeDashes;
       if (strokes.strokeWeights) result.strokeWeights = strokes.strokeWeights;
@@ -122,11 +125,12 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
   // effects
   const effects = buildSimplifiedEffects(node);
   if (Object.keys(effects).length) {
-    const styleName = getStyleName(node, context, ["effect", "effects"]);
-    if (styleName) {
+    const styleMatch = getStyleMatch(node, context, ["effect", "effects"]);
+    if (styleMatch) {
       // Effects styles store only the effect values
-      context.globalVars.styles[styleName] = effects;
-      result.effects = styleName;
+      const styleKey = resolveStyleKey(context, styleMatch, effects);
+      context.globalVars.styles[styleKey] = effects;
+      result.effects = styleKey;
     } else {
       result.effects = findOrCreateVar(context.globalVars, effects, "effect");
     }
@@ -168,22 +172,38 @@ export const componentExtractor: ExtractorFn = (node, result, _context) => {
   }
 };
 
+type StyleMatch = { name: string; id: string };
+
 // Helper to fetch a Figma style name for specific style keys on a node
-function getStyleName(
+function getStyleMatch(
   node: FigmaDocumentNode,
   context: TraversalContext,
   keys: string[],
-): string | undefined {
+): StyleMatch | undefined {
   if (!hasValue("styles", node)) return undefined;
   const styleMap = node.styles as Record<string, string>;
   for (const key of keys) {
     const styleId = styleMap[key];
     if (styleId) {
       const meta = context.globalVars.extraStyles?.[styleId];
-      if (meta?.name) return meta.name;
+      if (meta?.name) return { name: meta.name, id: styleId };
     }
   }
   return undefined;
+}
+
+function resolveStyleKey(
+  context: TraversalContext,
+  styleMatch: StyleMatch,
+  value: StyleTypes,
+): string {
+  const existing = context.globalVars.styles[styleMatch.name];
+  if (!existing) return styleMatch.name;
+  if (JSON.stringify(existing) === JSON.stringify(value)) return styleMatch.name;
+
+  const cleanedId = styleMatch.id.replace(/[^a-zA-Z0-9]/g, "");
+  if (!cleanedId) return styleMatch.name;
+  return `${styleMatch.name}__${cleanedId}`;
 }
 
 // -------------------- CONVENIENCE COMBINATIONS --------------------

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -122,6 +122,35 @@ describe("extractFromDesign", () => {
     expect(fillEntries).toHaveLength(1);
   });
 
+  it("deduplicates identical colors used as both fill and stroke", async () => {
+    const sharedColor = [{ type: "SOLID", color: { r: 1, g: 0, b: 0, a: 1 }, visible: true }];
+
+    // Stroke node first — if strokes used a different prefix, the var would
+    // be named stroke_* and the fill would reuse it under the wrong prefix.
+    const strokeNode = makeNode({
+      id: "8:1",
+      name: "A",
+      type: "FRAME",
+      strokes: sharedColor,
+      strokeWeight: 1,
+    });
+    const fillNode = makeNode({ id: "8:2", name: "B", type: "FRAME", fills: sharedColor });
+
+    const { nodes, globalVars } = await extractFromDesign([strokeNode, fillNode], allExtractors);
+
+    expect(nodes[0].strokes).toBeDefined();
+    expect(nodes[1].fills).toBeDefined();
+    expect(nodes[0].strokes).toBe(nodes[1].fills);
+
+    // The shared var should use the fill prefix since stroke colors are
+    // structurally identical to fill colors in Figma (both are FILL-type styles).
+    const colorEntries = Object.entries(globalVars.styles).filter(
+      ([, value]) => JSON.stringify(value) === JSON.stringify(["#FF0000"]),
+    );
+    expect(colorEntries).toHaveLength(1);
+    expect(colorEntries[0][0]).toMatch(/^fill_/);
+  });
+
   it("disambiguates named styles when style names collide", async () => {
     const nodeA = makeNode({
       id: "7:1",

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import { extractFromDesign } from "~/extractors/node-walker.js";
 import { allExtractors, collapseSvgContainers } from "~/extractors/built-in.js";
 import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
-import type { GetFileResponse } from "@figma/rest-api-spec";
+import type { GetFileResponse, Style } from "@figma/rest-api-spec";
 import type { Node as FigmaNode } from "@figma/rest-api-spec";
+import type { GlobalVars } from "~/extractors/types.js";
 
 // Minimal Figma node factory — only the fields the walker actually reads.
 // The Figma types are deeply discriminated unions; we cast through unknown
@@ -119,6 +120,48 @@ describe("extractFromDesign", () => {
     // Only one fill entry should exist in globalVars
     const fillEntries = Object.entries(globalVars.styles).filter(([key]) => key.startsWith("fill"));
     expect(fillEntries).toHaveLength(1);
+  });
+
+  it("disambiguates named styles when style names collide", async () => {
+    const nodeA = makeNode({
+      id: "7:1",
+      name: "Text A",
+      type: "TEXT",
+      characters: "Hello",
+      style: { fontFamily: "Inter", fontWeight: 400, fontSize: 12 },
+      styles: { text: "S:1:1" },
+    });
+
+    const nodeB = makeNode({
+      id: "7:2",
+      name: "Text B",
+      type: "TEXT",
+      characters: "World",
+      style: { fontFamily: "Inter", fontWeight: 600, fontSize: 14 },
+      styles: { text: "S:2:2" },
+    });
+
+    const extraStyles: Record<string, Style> = {
+      "S:1:1": { name: "Style A" } as Style,
+      "S:2:2": { name: "Style A" } as Style,
+    };
+
+    const globalVars = { styles: {}, extraStyles } as GlobalVars;
+
+    const { nodes, globalVars: resultVars } = await extractFromDesign(
+      [nodeA, nodeB],
+      allExtractors,
+      {},
+      globalVars,
+    );
+
+    const styleKeys = Object.keys(resultVars.styles).filter((key) => key.startsWith("Style A"));
+    expect(styleKeys).toHaveLength(2);
+    expect(styleKeys).toContain("Style A");
+    const disambiguated = styleKeys.find((key) => key !== "Style A");
+    expect(disambiguated).toMatch(/^Style A__/);
+    expect(nodes[0].textStyle).toBe("Style A");
+    expect(nodes[1].textStyle).toBe(disambiguated);
   });
 });
 

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -129,7 +129,7 @@ describe("extractFromDesign", () => {
       type: "TEXT",
       characters: "Hello",
       style: { fontFamily: "Inter", fontWeight: 400, fontSize: 12 },
-      styles: { text: "S:1:1" },
+      styles: { text: "13:77" },
     });
 
     const nodeB = makeNode({
@@ -138,12 +138,12 @@ describe("extractFromDesign", () => {
       type: "TEXT",
       characters: "World",
       style: { fontFamily: "Inter", fontWeight: 600, fontSize: 14 },
-      styles: { text: "S:2:2" },
+      styles: { text: "161:300" },
     });
 
     const extraStyles: Record<string, Style> = {
-      "S:1:1": { name: "Style A" } as Style,
-      "S:2:2": { name: "Style A" } as Style,
+      "13:77": { name: "Heading / Large" } as Style,
+      "161:300": { name: "Heading / Large" } as Style,
     };
 
     const globalVars = { styles: {}, extraStyles } as GlobalVars;
@@ -155,13 +155,13 @@ describe("extractFromDesign", () => {
       globalVars,
     );
 
-    const styleKeys = Object.keys(resultVars.styles).filter((key) => key.startsWith("Style A"));
+    expect(nodes[0].textStyle).toBe("Heading / Large");
+    expect(nodes[1].textStyle).toBe("Heading / Large (161:300)");
+
+    const styleKeys = Object.keys(resultVars.styles).filter((key) =>
+      key.startsWith("Heading / Large"),
+    );
     expect(styleKeys).toHaveLength(2);
-    expect(styleKeys).toContain("Style A");
-    const disambiguated = styleKeys.find((key) => key !== "Style A");
-    expect(disambiguated).toMatch(/^Style A__/);
-    expect(nodes[0].textStyle).toBe("Style A");
-    expect(nodes[1].textStyle).toBe(disambiguated);
   });
 });
 

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -234,7 +234,11 @@ export function buildSimplifiedStrokes(
 ): SimplifiedStroke {
   let strokes: SimplifiedStroke = { colors: [] };
   if (hasValue("strokes", n) && Array.isArray(n.strokes) && n.strokes.length) {
-    strokes.colors = n.strokes.filter(isVisible).map((stroke) => parsePaint(stroke, hasChildren));
+    // Reverse to match CSS stacking order (Figma layers bottom-to-top, CSS top-to-bottom)
+    strokes.colors = n.strokes
+      .filter(isVisible)
+      .map((stroke) => parsePaint(stroke, hasChildren))
+      .reverse();
   }
 
   if (hasValue("strokeWeight", n) && typeof n.strokeWeight === "number" && n.strokeWeight > 0) {


### PR DESCRIPTION
## Summary
Fixes #265 by keeping human-readable style names while disambiguating collisions with a style-id suffix.

## Changes
- add style-name collision handling for named text/fill/stroke/effect styles
- add a regression test covering duplicate style names
