### PR TITLE
test(transformers): add behavior-based tests for component, effects and layout transformers

### DIFF
--- a/src/tests/component.test.ts
+++ b/src/tests/component.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import * as __testedFile from "../transformers/component.js";
+
+const agNoComponentSetId = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "A simple icon button",
+    documentationLinks: [],
+    remote: false,
+  },
+};
+
+const scNoComponentSetIdResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    componentSetId: undefined,
+  },
+};
+
+const agComponent = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "A simple icon button",
+    documentationLinks: [],
+    remote: false,
+    componentSetId: "csid",
+  },
+};
+
+const scComponentSetIdResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    componentSetId: "csid",
+  },
+};
+
+const agNoDescription = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "",
+    documentationLinks: [],
+    remote: false,
+    componentSetId: "csid",
+  },
+};
+
+const scNoDescriptionResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    description: "",
+  },
+};
+
+const scDescriptionResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    description: "A simple icon button",
+  },
+};
+
+describe("src/transformers/component.ts", () => {
+  describe("simplifyComponents", () => {
+    const { simplifyComponents } = __testedFile;
+    // aggregatedComponents: Record<string, Component>
+
+    it("With set ID", () => {
+      const aggregatedComponents: Parameters<typeof simplifyComponents>[0] = agComponent;
+      const __expectedResult: ReturnType<typeof simplifyComponents> = scComponentSetIdResponse;
+      expect(simplifyComponents(aggregatedComponents)).toEqual(__expectedResult);
+    });
+
+    it("No set ID", () => {
+      const aggregatedComponents: Parameters<typeof simplifyComponents>[0] = agNoComponentSetId;
+      const __expectedResult: ReturnType<typeof simplifyComponents> = scNoComponentSetIdResponse;
+      expect(simplifyComponents(aggregatedComponents)).toEqual(__expectedResult);
+    });
+
+    it("should test simplifyComponents( mock-parameters.aggregatedComponents 3 )", () => {
+      const aggregatedComponents: Parameters<typeof simplifyComponents>[0] = {};
+      const __expectedResult: ReturnType<typeof simplifyComponents> = {};
+      expect(simplifyComponents(aggregatedComponents)).toEqual(__expectedResult);
+    });
+  });
+
+  describe("simplifyComponentSets", () => {
+    const { simplifyComponentSets } = __testedFile;
+    // aggregatedComponentSets: Record<string, ComponentSet>
+
+    it("With description", () => {
+      const aggregatedComponentSets: Parameters<typeof simplifyComponentSets>[0] = agComponent;
+      const __expectedResult: ReturnType<typeof simplifyComponentSets> = scDescriptionResponse;
+      expect(simplifyComponentSets(aggregatedComponentSets)).toEqual(__expectedResult);
+    });
+
+    it("No description", () => {
+      const aggregatedComponentSets: Parameters<typeof simplifyComponentSets>[0] = agNoDescription;
+      const __expectedResult: ReturnType<typeof simplifyComponentSets> = scNoDescriptionResponse;
+      expect(simplifyComponentSets(aggregatedComponentSets)).toEqual(__expectedResult);
+    });
+
+    it("should test simplifyComponentSets( mock-parameters.aggregatedComponentSets 3 )", () => {
+      const aggregatedComponentSets: Parameters<typeof simplifyComponentSets>[0] = {};
+      const __expectedResult: ReturnType<typeof simplifyComponentSets> = {};
+      expect(simplifyComponentSets(aggregatedComponentSets)).toEqual(__expectedResult);
+    });
+  });
+});
+
+// 3TG (https://3tg.dev) created 6 tests in 2697 ms (449.500 ms per generated test) @ 2026-04-02T06:29:41.603Z

--- a/src/tests/effects.test.ts
+++ b/src/tests/effects.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import * as __testedFile from "../transformers/effects.js";
+
+const hiddenEffect: any = {
+  type: "DROP_SHADOW" as const,
+  visible: false,
+  color: { r: 255, g: 255, b: 255, a: 1 },
+  offset: { x: 5, y: 5 },
+  radius: 10,
+};
+
+const dropShadowEffect: any = {
+  type: "DROP_SHADOW" as const,
+  visible: true,
+  color: { r: 0, g: 0, b: 0, a: 0.5 },
+  offset: { x: 2, y: 2 },
+  radius: 4,
+  spread: 1,
+};
+
+const nodeBoxShadow: any = {
+  type: "FRAME",
+  effects: [
+    dropShadowEffect,
+    {
+      type: "INNER_SHADOW",
+      visible: true,
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      offset: { x: 0, y: 0 },
+      radius: 10,
+      spread: 0,
+    },
+  ],
+};
+
+const nodeBoxShadowExpected = {
+  boxShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5), inset 0px 0px 10px 0px rgba(255, 255, 255, 1)",
+};
+
+const nodeBlur: any = {
+  type: "RECTANGLE",
+  effects: [
+    { type: "LAYER_BLUR", visible: true, radius: 5 },
+    { type: "BACKGROUND_BLUR", visible: true, radius: 15 },
+  ],
+};
+
+const nodeMixed: any = {
+  type: "COMPONENT",
+  effects: [
+    dropShadowEffect,
+    {
+      type: "DROP_SHADOW",
+      visible: true,
+      color: { r: 0, g: 0, b: 1, a: 1 },
+      offset: { x: 2, y: 2 },
+      radius: 2,
+    },
+    { type: "LAYER_BLUR", visible: true, radius: 2 },
+    { type: "LAYER_BLUR", visible: true, radius: 4 },
+  ],
+};
+
+const nodeMixedExpected = {
+  boxShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5), 2px 2px 2px 0px rgba(0, 0, 255, 1)",
+  filter: "blur(2px) blur(4px)",
+};
+
+describe("src/transformers/effects.ts", () => {
+  describe("buildSimplifiedEffects", () => {
+    const { buildSimplifiedEffects } = __testedFile;
+    // n: FigmaDocumentNode
+
+    it("Full blur", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = nodeBlur;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = {
+        filter: "blur(5px)",
+        backdropFilter: "blur(15px)",
+      };
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+
+    it("Box shadow", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = nodeBoxShadow;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = nodeBoxShadowExpected;
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+
+    it("Mixed & Multi", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = nodeMixed;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = nodeMixedExpected;
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+
+    it("No effects", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = {
+        type: "DOCUMENT",
+        name: "Root",
+      } as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = {};
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+
+    it("Only visible effects", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = {
+        type: "RECTANGLE",
+        effects: [hiddenEffect, dropShadowEffect],
+      } as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = {
+        boxShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5)",
+      };
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+
+    it("Text shadow", () => {
+      const n: Parameters<typeof buildSimplifiedEffects>[0] = {
+        type: "TEXT",
+        effects: [dropShadowEffect],
+      } as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedEffects> = {
+        textShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5)",
+      };
+      expect(buildSimplifiedEffects(n)).toEqual(__expectedResult);
+    });
+  });
+});
+
+// 3TG (https://3tg.dev) created 6 tests in 2545 ms (424.167 ms per generated test) @ 2026-04-02T16:28:40.490Z

--- a/src/tests/layout.test.ts
+++ b/src/tests/layout.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import * as __testedFile from "../transformers/layout.js";
+
+const parentNode = {
+  type: "FRAME",
+  layoutMode: "NONE",
+  absoluteBoundingBox: { x: 0, y: 0, width: 500, height: 500 },
+};
+
+const nodeNonFrame = {
+  type: "RECTANGLE",
+  absoluteBoundingBox: { x: 100, y: 100, width: 50, height: 50 },
+  layoutSizingHorizontal: "FIXED",
+  layoutSizingVertical: "FIXED",
+};
+
+const nodeStretch = {
+  type: "FRAME",
+  layoutMode: "HORIZONTAL",
+  primaryAxisAlignItems: "CENTER",
+  children: [
+    { type: "RECTANGLE", layoutSizingHorizontal: "FILL" },
+    { type: "FRAME", layoutSizingHorizontal: "FILL" },
+    { type: "VECTOR", layoutPositioning: "ABSOLUTE" },
+  ],
+};
+
+const nodeAbsolutePositioning = {
+  type: "RECTANGLE",
+  layoutPositioning: "ABSOLUTE",
+  absoluteBoundingBox: { x: 50, y: 50, width: 100, height: 100 },
+  layoutSizingHorizontal: "FIXED",
+  layoutSizingVertical: "FIXED",
+};
+
+const nodeAbsolutePositioningResult = {
+  dimensions: {
+    height: 100,
+    width: 100,
+  },
+  mode: "none" as const,
+  sizing: {
+    horizontal: "fixed" as const,
+    vertical: "fixed" as const,
+  },
+};
+
+const nodeOverflow = {
+  type: "FRAME",
+  layoutMode: "VERTICAL",
+  overflowDirection: ["HORIZONTAL", "VERTICAL"],
+  paddingTop: 10,
+  paddingBottom: 10,
+  paddingLeft: 20,
+  paddingRight: 20,
+  itemSpacing: 8,
+};
+
+const nodeAspectRatio = {
+  type: "FRAME",
+  layoutMode: "VERTICAL",
+  layoutSizingHorizontal: "HUG",
+  layoutSizingVertical: "FILL",
+  layoutAlign: "STRETCH",
+  preserveRatio: true,
+  absoluteBoundingBox: { x: 0, y: 0, width: 200, height: 100 },
+};
+
+describe("src/transformers/layout.ts", () => {
+  describe("buildSimplifiedLayout", () => {
+    const { buildSimplifiedLayout } = __testedFile;
+    // n: FigmaDocumentNode
+    // parent: undefined | FigmaDocumentNode
+
+    it("Absolute Positioning with parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeAbsolutePositioning as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = parentNode as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> =
+        nodeAbsolutePositioningResult;
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Aspect Ratio with parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeAspectRatio as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = parentNode as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = {
+        sizing: { horizontal: "hug", vertical: "fill" },
+        mode: "none",
+      };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Non-Frame with parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeNonFrame as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = parentNode as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = {
+        mode: "none",
+        dimensions: { width: 50, height: 50 },
+        sizing: { horizontal: "fixed", vertical: "fixed" },
+      };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Overflow with parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeOverflow as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = parentNode as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = { mode: "none" };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Stretch with parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeStretch as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = parentNode as any;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = { mode: "none" };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Absolute Positioning without parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeAbsolutePositioning as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = undefined;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> =
+        nodeAbsolutePositioningResult;
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Aspect Ratio without parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeAspectRatio as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = undefined;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = {
+        sizing: { horizontal: "hug", vertical: "fill" },
+        mode: "none",
+      };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Non-Frame without parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeNonFrame as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = undefined;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = {
+        mode: "none",
+        dimensions: { width: 50, height: 50 },
+        sizing: { horizontal: "fixed", vertical: "fixed" },
+      };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Overflow without parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeOverflow as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = undefined;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = { mode: "none" };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+
+    it("Stretch without parent", () => {
+      const n: Parameters<typeof buildSimplifiedLayout>[0] = nodeStretch as any;
+      const parent: Parameters<typeof buildSimplifiedLayout>[1] = undefined;
+      const __expectedResult: ReturnType<typeof buildSimplifiedLayout> = { mode: "none" };
+      expect(buildSimplifiedLayout(n, parent)).toEqual(__expectedResult);
+    });
+  });
+});
+
+// 3TG (https://3tg.dev) created 10 tests in 2784 ms (278.400 ms per generated test) @ 2026-04-02T17:19:54.352Z

--- a/src/transformers/component.3tg.md
+++ b/src/transformers/component.3tg.md
@@ -1,0 +1,99 @@
+# Exported functions from "src/transformers/component.ts"
+
+<!--
+```json configuration
+{ "testing-framework": "vitest" }
+```
+-->
+
+## simplifyComponents(aggregatedComponents: Record<string, Component>)
+
+These are the functional requirements for function `simplifyComponents`.
+
+| test name   | aggregatedComponents | simplifyComponents         |
+| ----------- | -------------------- | -------------------------- |
+|             | {}                   | {}                         |
+| No set ID   | agNoComponentSetId   | scNoComponentSetIdResponse |
+| With set ID | agComponent          | scComponentSetIdResponse   |
+
+```typescript before
+const agNoComponentSetId = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "A simple icon button",
+    documentationLinks: [],
+    remote: false,
+  },
+};
+
+const scNoComponentSetIdResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    componentSetId: undefined,
+  },
+};
+
+const agComponent = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "A simple icon button",
+    documentationLinks: [],
+    remote: false,
+    componentSetId: "csid",
+  },
+};
+
+const scComponentSetIdResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    componentSetId: "csid",
+  },
+};
+```
+
+## simplifyComponentSets(aggregatedComponentSets: Record<string, ComponentSet>)
+
+These are the functional requirements for function `simplifyComponentSets`.
+
+| test name        | aggregatedComponentSets | simplifyComponentSets   |
+| ---------------- | ----------------------- | ----------------------- |
+|                  | {}                      | {}                      |
+| No description   | agNoDescription         | scNoDescriptionResponse |
+| With description | agComponent             | scDescriptionResponse   |
+
+```typescript before
+const agNoDescription = {
+  1: {
+    key: "abc123def456",
+    name: "IconButton",
+    description: "",
+    documentationLinks: [],
+    remote: false,
+    componentSetId: "csid",
+  },
+};
+
+const scNoDescriptionResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    description: "",
+  },
+};
+
+const scDescriptionResponse = {
+  "1": {
+    key: "abc123def456",
+    name: "IconButton",
+    id: "1",
+    description: "A simple icon button",
+  },
+};
+```

--- a/src/transformers/effects.3tg.md
+++ b/src/transformers/effects.3tg.md
@@ -1,0 +1,99 @@
+# Exported functions from "src/transformers/effects.ts"
+
+<!--
+```json configuration
+{ "testing-framework": "vitest" }
+```
+-->
+
+## buildSimplifiedEffects(n: FigmaDocumentNode)
+
+These are the functional requirements for function `buildSimplifiedEffects`.
+
+| test name            | n                                                                       | buildSimplifiedEffects                           |
+| -------------------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+| No effects           | { type: "DOCUMENT", name: "Root" } as any                               | {}                                               |
+| Only visible effects | { type: "RECTANGLE", effects: [hiddenEffect, dropShadowEffect] } as any | {boxShadow:'2px 2px 4px 1px rgba(0, 0, 0, 0.5)'} |
+
+```typescript before
+const hiddenEffect: any = {
+  type: "DROP_SHADOW" as const,
+  visible: false,
+  color: { r: 255, g: 255, b: 255, a: 1 },
+  offset: { x: 5, y: 5 },
+  radius: 10,
+};
+const dropShadowEffect: any = {
+  type: "DROP_SHADOW" as const,
+  visible: true,
+  color: { r: 0, g: 0, b: 0, a: 0.5 },
+  offset: { x: 2, y: 2 },
+  radius: 4,
+  spread: 1,
+};
+```
+
+| test name  | n             | buildSimplifiedEffects |
+| ---------- | ------------- | ---------------------- |
+| Box shadow | nodeBoxShadow | nodeBoxShadowExpected  |
+
+```typescript before
+const nodeBoxShadow: any = {
+  type: "FRAME",
+  effects: [
+    dropShadowEffect,
+    {
+      type: "INNER_SHADOW",
+      visible: true,
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      offset: { x: 0, y: 0 },
+      radius: 10,
+      spread: 0,
+    },
+  ],
+};
+const nodeBoxShadowExpected = {
+  boxShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5), inset 0px 0px 10px 0px rgba(255, 255, 255, 1)",
+};
+```
+
+| test name   | n                                                    | buildSimplifiedEffects                              |
+| ----------- | ---------------------------------------------------- | --------------------------------------------------- |
+| Text shadow | { type: "TEXT", effects: [dropShadowEffect] } as any | { textShadow:'2px 2px 4px 1px rgba(0, 0, 0, 0.5)' } |
+| Full blur   | nodeBlur                                             | { filter:'blur(5px)', backdropFilter:'blur(15px)' } |
+
+```typescript before
+const nodeBlur: any = {
+  type: "RECTANGLE",
+  effects: [
+    { type: "LAYER_BLUR", visible: true, radius: 5 },
+    { type: "BACKGROUND_BLUR", visible: true, radius: 15 },
+  ],
+};
+```
+
+| test name     | n         | buildSimplifiedEffects |
+| ------------- | --------- | ---------------------- |
+| Mixed & Multi | nodeMixed | nodeMixedExpected      |
+
+```typescript before
+const nodeMixed: any = {
+  type: "COMPONENT",
+  effects: [
+    dropShadowEffect,
+    {
+      type: "DROP_SHADOW",
+      visible: true,
+      color: { r: 0, g: 0, b: 1, a: 1 },
+      offset: { x: 2, y: 2 },
+      radius: 2,
+    },
+    { type: "LAYER_BLUR", visible: true, radius: 2 },
+    { type: "LAYER_BLUR", visible: true, radius: 4 },
+  ],
+};
+const nodeMixedExpected = {
+  boxShadow: "2px 2px 4px 1px rgba(0, 0, 0, 0.5), 2px 2px 2px 0px rgba(0, 0, 255, 1)",
+  filter: "blur(2px) blur(4px)",
+};
+```

--- a/src/transformers/layout.3tg.md
+++ b/src/transformers/layout.3tg.md
@@ -1,0 +1,112 @@
+# Exported functions from "src/transformers/layout.ts"
+
+<!--
+```json configuration
+{ "testing-framework": "vitest" }
+```
+-->
+
+## buildSimplifiedLayout(n: FigmaDocumentNode, parent?: FigmaDocumentNode)
+
+These are the functional requirements for function `buildSimplifiedLayout`.
+
+**FIXME**: we need better test values as all results are the same for and without a prent node.
+
+| test name                | n                   | parent            | buildSimplifiedLayout                                                                          |
+| ------------------------ | ------------------- | ----------------- | ---------------------------------------------------------------------------------------------- |
+| Non-Frame without parent | nodeNonFrame as any | undefined         | {mode:'none', dimensions:{width:50, height:50}, sizing:{horizontal:'fixed', vertical:'fixed'}} |
+| Non-Frame with parent    | nodeNonFrame as any | parentNode as any | {mode:'none', dimensions:{width:50, height:50}, sizing:{horizontal:'fixed', vertical:'fixed'}} |
+
+```typescript before
+const parentNode = {
+  type: "FRAME",
+  layoutMode: "NONE",
+  absoluteBoundingBox: { x: 0, y: 0, width: 500, height: 500 },
+};
+
+const nodeNonFrame = {
+  type: "RECTANGLE",
+  absoluteBoundingBox: { x: 100, y: 100, width: 50, height: 50 },
+  layoutSizingHorizontal: "FIXED",
+  layoutSizingVertical: "FIXED",
+};
+```
+
+| test name              | n                  | parent            | buildSimplifiedLayout |
+| ---------------------- | ------------------ | ----------------- | --------------------- |
+| Stretch without parent | nodeStretch as any | undefined         | {mode:'none'}         |
+| Stretch with parent    | nodeStretch as any | parentNode as any | {mode:'none'}         |
+
+```typescript before
+const nodeStretch = {
+  type: "FRAME",
+  layoutMode: "HORIZONTAL",
+  primaryAxisAlignItems: "CENTER",
+  children: [
+    { type: "RECTANGLE", layoutSizingHorizontal: "FILL" },
+    { type: "FRAME", layoutSizingHorizontal: "FILL" },
+    { type: "VECTOR", layoutPositioning: "ABSOLUTE" },
+  ],
+};
+```
+
+| test name                           | n                              | parent            | buildSimplifiedLayout         |
+| ----------------------------------- | ------------------------------ | ----------------- | ----------------------------- |
+| Absolute Positioning without parent | nodeAbsolutePositioning as any | undefined         | nodeAbsolutePositioningResult |
+| Absolute Positioning with parent    | nodeAbsolutePositioning as any | parentNode as any | nodeAbsolutePositioningResult |
+
+```typescript before
+const nodeAbsolutePositioning = {
+  type: "RECTANGLE",
+  layoutPositioning: "ABSOLUTE",
+  absoluteBoundingBox: { x: 50, y: 50, width: 100, height: 100 },
+  layoutSizingHorizontal: "FIXED",
+  layoutSizingVertical: "FIXED",
+};
+const nodeAbsolutePositioningResult = {
+  dimensions: {
+    height: 100,
+    width: 100,
+  },
+  mode: "none" as const,
+  sizing: {
+    horizontal: "fixed" as const,
+    vertical: "fixed" as const,
+  },
+};
+```
+
+| test name               | n                   | parent            | buildSimplifiedLayout |
+| ----------------------- | ------------------- | ----------------- | --------------------- |
+| Overflow without parent | nodeOverflow as any | undefined         | {mode:'none'}         |
+| Overflow with parent    | nodeOverflow as any | parentNode as any | {mode:'none'}         |
+
+```typescript before
+const nodeOverflow = {
+  type: "FRAME",
+  layoutMode: "VERTICAL",
+  overflowDirection: ["HORIZONTAL", "VERTICAL"],
+  paddingTop: 10,
+  paddingBottom: 10,
+  paddingLeft: 20,
+  paddingRight: 20,
+  itemSpacing: 8,
+};
+```
+
+| test name                   | n                      | parent            | buildSimplifiedLayout                                      |
+| --------------------------- | ---------------------- | ----------------- | ---------------------------------------------------------- |
+| Aspect Ratio without parent | nodeAspectRatio as any | undefined         | {sizing: {horizontal:'hug', vertical:'fill'}, mode:'none'} |
+| Aspect Ratio with parent    | nodeAspectRatio as any | parentNode as any | {sizing: {horizontal:'hug', vertical:'fill'}, mode:'none'} |
+
+```typescript before
+const nodeAspectRatio = {
+  type: "FRAME",
+  layoutMode: "VERTICAL",
+  layoutSizingHorizontal: "HUG",
+  layoutSizingVertical: "FILL",
+  layoutAlign: "STRETCH",
+  preserveRatio: true,
+  absoluteBoundingBox: { x: 0, y: 0, width: 200, height: 100 },
+};
+```


### PR DESCRIPTION
## Summary

Add tests for transformer functions related to components, effects, and layout.

These tests focus on verifying the transformation behavior for different node configurations and edge cases.

## Changes

* Add tests for `simplifyComponents`
* Add tests for `simplifyComponentSets`
* Add tests for `buildSimplifiedEffects`
* Add tests for `buildSimplifiedLayout`
* Cover scenarios such as:
  * Components with and without component set ID
  * Component sets with and without description
  * Visible and hidden effects
  * Drop shadows, inner shadows, text shadows
  * Blur and backdrop blur filters
  * Mixed and multiple effects
  * Layout sizing, absolute positioning, overflow, and aspect ratio

## Test Approach

Test cases are defined as behavior scenarios using Markdown tables that describe inputs and expected outputs.
Tests are generated from these scenarios to ensure consistent coverage and readable behavior definitions.

## Purpose

This contribution was made to evaluate whether this behavior-first testing approach is useful and readable for the project before expanding test coverage further.

If this approach is useful, we would be happy to show how these tests were generated and how the same workflow can be used to create additional tests.

## Attribution

Tests were generated using [3TG](https://3tg.dev), a tool that generates tests for TypeScript from behavior scenarios defined in Markdown tables.
