### PR TITLE
feat: add proxy support for managed networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "remeda": "^2.20.1",
+    "undici": "^8.0.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "remeda": "^2.20.1",
-    "undici": "^8.0.2",
+    "undici": "^6.24.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^2.20.1
         version: 2.20.1
       undici:
-        specifier: ^8.0.2
-        version: 8.0.2
+        specifier: ^6.24.1
+        version: 6.24.1
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1778,9 +1778,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@8.0.2:
-    resolution: {integrity: sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==}
-    engines: {node: '>=22.19.0'}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3524,7 +3524,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@8.0.2: {}
+  undici@6.24.1: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       remeda:
         specifier: ^2.20.1
         version: 2.20.1
+      undici:
+        specifier: ^8.0.2
+        version: 8.0.2
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1774,6 +1777,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@8.0.2:
+    resolution: {integrity: sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==}
+    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3516,6 +3523,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@7.18.2: {}
+
+  undici@8.0.2: {}
 
   unpipe@1.0.0: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ interface ServerConfig {
   auth: FigmaAuthOptions;
   port: number;
   host: string;
+  proxy: string | undefined;
   outputFormat: "yaml" | "json";
   skipImageDownloads: boolean;
   imageDir: string;
@@ -90,6 +91,10 @@ export function getServerConfig(): ServerConfig {
         description:
           "Base directory for image downloads. The download tool will only write files within this directory. Defaults to the current working directory.",
       },
+      proxy: {
+        type: String,
+        description: "HTTP proxy URL for corporate networks (e.g. http://proxy:8080)",
+      },
       stdio: {
         type: Boolean,
         description: "Run in stdio transport mode for MCP clients",
@@ -121,6 +126,11 @@ export function getServerConfig(): ServerConfig {
     process.cwd(),
   );
 
+  // Proxy has a 4-source fallback chain, so it doesn't fit the resolve() helper.
+  const proxyUrl =
+    argv.flags.proxy ?? envStr("FIGMA_PROXY") ?? envStr("HTTPS_PROXY") ?? envStr("HTTP_PROXY");
+  const proxySource: Source = argv.flags.proxy ? "cli" : proxyUrl ? "env" : "default";
+
   // These two don't fit the simple pattern: --json maps to a string enum,
   // and --stdio has a NODE_ENV backdoor.
   const outputFormat = resolve<"yaml" | "json">(
@@ -151,6 +161,7 @@ export function getServerConfig(): ServerConfig {
     figmaOauthToken: figmaOauthToken.source,
     port: port.source,
     host: host.source,
+    proxy: proxySource,
     outputFormat: outputFormat.source,
     skipImageDownloads: skipImageDownloads.source,
     imageDir: imageDir.source,
@@ -172,6 +183,7 @@ export function getServerConfig(): ServerConfig {
     }
     console.log(`- FRAMELINK_PORT: ${port.value} (source: ${configSources.port})`);
     console.log(`- FRAMELINK_HOST: ${host.value} (source: ${configSources.host})`);
+    console.log(`- PROXY: ${proxyUrl ?? "none"} (source: ${configSources.proxy})`);
     console.log(`- OUTPUT_FORMAT: ${outputFormat.value} (source: ${configSources.outputFormat})`);
     console.log(
       `- SKIP_IMAGE_DOWNLOADS: ${skipImageDownloads.value} (source: ${configSources.skipImageDownloads})`,
@@ -184,6 +196,7 @@ export function getServerConfig(): ServerConfig {
     auth,
     port: port.value,
     host: host.value,
+    proxy: proxyUrl,
     outputFormat: outputFormat.value,
     skipImageDownloads: skipImageDownloads.value,
     imageDir: imageDir.value,

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,7 @@ export function getServerConfig(): ServerConfig {
       },
       proxy: {
         type: String,
-        description: "HTTP proxy URL for corporate networks (e.g. http://proxy:8080)",
+        description: "HTTP proxy URL for networks that require a proxy (e.g. http://proxy:8080)",
       },
       stdio: {
         type: Boolean,

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,10 +126,10 @@ export function getServerConfig(): ServerConfig {
     process.cwd(),
   );
 
-  // Proxy has a 4-source fallback chain, so it doesn't fit the resolve() helper.
-  const proxyUrl =
-    argv.flags.proxy ?? envStr("FIGMA_PROXY") ?? envStr("HTTPS_PROXY") ?? envStr("HTTP_PROXY");
-  const proxySource: Source = argv.flags.proxy ? "cli" : proxyUrl ? "env" : "default";
+  // Only resolve explicit proxy config here. Standard env vars (HTTPS_PROXY, HTTP_PROXY,
+  // NO_PROXY) are handled by undici's EnvHttpProxyAgent at the dispatcher level, which
+  // correctly respects NO_PROXY exclusions.
+  const proxy = resolve(argv.flags.proxy, envStr("FIGMA_PROXY"), undefined);
 
   // These two don't fit the simple pattern: --json maps to a string enum,
   // and --stdio has a NODE_ENV backdoor.
@@ -161,7 +161,7 @@ export function getServerConfig(): ServerConfig {
     figmaOauthToken: figmaOauthToken.source,
     port: port.source,
     host: host.source,
-    proxy: proxySource,
+    proxy: proxy.source,
     outputFormat: outputFormat.source,
     skipImageDownloads: skipImageDownloads.source,
     imageDir: imageDir.source,
@@ -183,7 +183,7 @@ export function getServerConfig(): ServerConfig {
     }
     console.log(`- FRAMELINK_PORT: ${port.value} (source: ${configSources.port})`);
     console.log(`- FRAMELINK_HOST: ${host.value} (source: ${configSources.host})`);
-    console.log(`- PROXY: ${proxyUrl ?? "none"} (source: ${configSources.proxy})`);
+    console.log(`- PROXY: ${proxy.value ? "configured" : "none"} (source: ${configSources.proxy})`);
     console.log(`- OUTPUT_FORMAT: ${outputFormat.value} (source: ${configSources.outputFormat})`);
     console.log(
       `- SKIP_IMAGE_DOWNLOADS: ${skipImageDownloads.value} (source: ${configSources.skipImageDownloads})`,
@@ -196,7 +196,7 @@ export function getServerConfig(): ServerConfig {
     auth,
     port: port.value,
     host: host.value,
-    proxy: proxyUrl,
+    proxy: proxy.value,
     outputFormat: outputFormat.value,
     skipImageDownloads: skipImageDownloads.value,
     imageDir: imageDir.value,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { Server } from "http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ProxyAgent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { Logger } from "./utils/logger.js";
 import { createServer } from "./mcp/index.js";
 import { getServerConfig } from "./config.js";
@@ -22,6 +23,14 @@ const activeConnections = new Set<ActiveConnection>();
  */
 export async function startServer(): Promise<void> {
   const config = getServerConfig();
+
+  if (config.proxy) {
+    setGlobalDispatcher(new ProxyAgent(config.proxy));
+  } else {
+    // EnvHttpProxyAgent automatically respects HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+    // env vars when present, and falls through to direct connections when absent.
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+  }
 
   const serverOptions = {
     isHTTP: !config.isStdioMode,

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -7,7 +7,7 @@ import type {
 } from "@figma/rest-api-spec";
 import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/image-processing.js";
 import { Logger, writeLogs } from "~/utils/logger.js";
-import { fetchWithRetry } from "~/utils/fetch-with-retry.js";
+import { fetchJSON } from "~/utils/fetch-json.js";
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -61,7 +61,7 @@ export class FigmaService {
       Logger.log(`Calling ${this.baseUrl}${endpoint}`);
       const headers = this.getAuthHeaders();
 
-      return await fetchWithRetry<T & { status?: number }>(`${this.baseUrl}${endpoint}`, {
+      return await fetchJSON<T & { status?: number }>(`${this.baseUrl}${endpoint}`, {
         headers,
       });
     } catch (error) {

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -30,7 +30,7 @@ export async function fetchJSON<T extends { status?: number }>(
     if (isConnectionError(error)) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
-        `${message}\n\nCould not connect to the Figma API. If you are behind a corporate proxy, ` +
+        `${message}\n\nCould not connect to the Figma API. If your network requires a proxy, ` +
           `set the --proxy flag in your MCP server config or the FIGMA_PROXY environment variable ` +
           `to your proxy URL (e.g. http://proxy:8080).`,
       );

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -15,7 +15,7 @@ const CONNECTION_ERROR_CODES = new Set([
   "UND_ERR_CONNECT_TIMEOUT",
 ]);
 
-export async function fetchWithRetry<T extends { status?: number }>(
+export async function fetchJSON<T extends { status?: number }>(
   url: string,
   options: RequestOptions = {},
 ): Promise<T> {

--- a/src/utils/fetch-with-retry.ts
+++ b/src/utils/fetch-with-retry.ts
@@ -1,9 +1,3 @@
-import { execFile } from "child_process";
-import { promisify } from "util";
-import { Logger } from "./logger.js";
-
-const execFileAsync = promisify(execFile);
-
 type RequestOptions = RequestInit & {
   /**
    * Force format of headers to be a record of strings, e.g. { "Authorization": "Bearer 123" }
@@ -12,6 +6,14 @@ type RequestOptions = RequestInit & {
    */
   headers?: Record<string, string>;
 };
+
+const CONNECTION_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 
 export async function fetchWithRetry<T extends { status?: number }>(
   url: string,
@@ -24,77 +26,21 @@ export async function fetchWithRetry<T extends { status?: number }>(
       throw new Error(`Fetch failed with status ${response.status}: ${response.statusText}`);
     }
     return (await response.json()) as T;
-  } catch (fetchError: unknown) {
-    const fetchMessage = fetchError instanceof Error ? fetchError.message : String(fetchError);
-    Logger.log(
-      `[fetchWithRetry] Initial fetch failed for ${url}: ${fetchMessage}. Likely a corporate proxy or SSL issue. Attempting curl fallback.`,
-    );
-
-    const curlHeaders = formatHeadersForCurl(options.headers);
-    // Most options here are to ensure stderr only contains errors, so we can use it to confidently check if an error occurred.
-    // -s: Silent mode—no progress bar in stderr
-    // -S: Show errors in stderr
-    // --fail-with-body: curl errors with code 22, and outputs body of failed request, e.g. "Fetch failed with status 404"
-    // -L: Follow redirects
-    const curlArgs = ["-s", "-S", "--fail-with-body", "-L", ...curlHeaders, url];
-
-    try {
-      // Fallback to curl for  corporate networks that have proxies that sometimes block fetch
-      Logger.log(`[fetchWithRetry] Executing curl with args: ${JSON.stringify(curlArgs)}`);
-      const { stdout, stderr } = await execFileAsync("curl", curlArgs);
-
-      if (stderr) {
-        // curl often outputs progress to stderr, so only treat as error if stdout is empty
-        // or if stderr contains typical error keywords.
-        if (
-          !stdout ||
-          stderr.toLowerCase().includes("error") ||
-          stderr.toLowerCase().includes("fail")
-        ) {
-          throw new Error(`Curl command failed with stderr: ${stderr}`);
-        }
-        Logger.log(
-          `[fetchWithRetry] Curl command for ${url} produced stderr (but might be informational): ${stderr}`,
-        );
-      }
-
-      if (!stdout) {
-        throw new Error("Curl command returned empty stdout.");
-      }
-
-      const result = JSON.parse(stdout) as T;
-
-      // Successful Figma requests don't have a status property, and some endpoints return 200 with an
-      // error status in the body, e.g. https://www.figma.com/developers/api#get-images-endpoint
-      if (result.status && result.status !== 200) {
-        throw new Error(`Curl command failed: ${result}`);
-      }
-
-      return result;
-    } catch (curlError: unknown) {
-      const curlMessage = curlError instanceof Error ? curlError.message : String(curlError);
-      Logger.error(`[fetchWithRetry] Curl fallback also failed for ${url}: ${curlMessage}`);
-      // Re-throw the original fetch error to give context about the initial failure
-      // or throw a new error that wraps both, depending on desired error reporting.
-      // For now, re-throwing the original as per the user example's spirit.
-      throw fetchError;
+  } catch (error: unknown) {
+    if (isConnectionError(error)) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${message}\n\nCould not connect to the Figma API. If you are behind a corporate proxy, ` +
+          `set the --proxy flag in your MCP server config or the FIGMA_PROXY environment variable ` +
+          `to your proxy URL (e.g. http://proxy:8080).`,
+      );
     }
+    throw error;
   }
 }
 
-/**
- * Converts HeadersInit to an array of curl header arguments for execFile.
- * @param headers Headers to convert.
- * @returns Array of strings for curl arguments: ["-H", "key: value", "-H", "key2: value2"]
- */
-function formatHeadersForCurl(headers: Record<string, string> | undefined): string[] {
-  if (!headers) {
-    return [];
-  }
-
-  const headerArgs: string[] = [];
-  for (const [key, value] of Object.entries(headers)) {
-    headerArgs.push("-H", `${key}: ${value}`);
-  }
-  return headerArgs;
+function isConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const cause = (error as { cause?: { code?: string } }).cause;
+  return cause?.code !== undefined && CONNECTION_ERROR_CODES.has(cause.code);
 }


### PR DESCRIPTION
## Summary

Closes #267

Adds proper HTTP proxy support so users behind network proxies can reach the Figma API.

- **`--proxy` flag / `FIGMA_PROXY` env var** — explicit proxy configuration for MCP client configs, where shell env vars often don't propagate to child processes
- **Automatic `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` support** — via undici's `EnvHttpProxyAgent` as the default global dispatcher, respecting standard proxy env vars when they're present (no-op when absent)
- **Proxy-aware error messaging** — connection-level failures (`ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`) now include actionable guidance pointing users toward `--proxy` configuration
- **Removes the `curl` subprocess fallback** — which was the previous proxy workaround but introduced a command execution surface and only covered API calls (not image downloads)

All outbound `fetch()` calls (both API and image downloads) are now routed through the proxy via `setGlobalDispatcher`, requiring zero changes to individual call sites.

Uses `undici@6.x` (not 8.x) to maintain Node 18+ compatibility.

Documentation PR: FramelinkAI/web#2

## Test plan

- [ ] Start server with `--proxy http://localhost:9999` — requests should fail trying to reach the fake proxy (not `api.figma.com` directly), confirming `ProxyAgent` is active
- [ ] Start server with `HTTPS_PROXY=http://localhost:9999` — same behavior, confirming `EnvHttpProxyAgent` picks up the env var
- [ ] Connection failures should show the new error message with `--proxy` guidance
- [ ] Start server normally (no proxy config) — confirm everything works as before