### PR TITLE
feat: add component property support (BOOLEAN & TEXT)

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -14,7 +14,11 @@ import {
   hasTextStyle,
   isTextNode,
 } from "~/transformers/text.js";
-import { simplifyComponentProperties } from "~/transformers/component.js";
+import {
+  simplifyComponentProperties,
+  simplifyPropertyDefinitions,
+  simplifyPropertyReferences,
+} from "~/transformers/component.js";
 import { hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { generateVarId, isVisible } from "~/utils/common.js";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
@@ -144,18 +148,55 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
 };
 
 /**
- * Extracts component-related properties from INSTANCE nodes.
+ * Extracts component-related properties from nodes.
+ * Handles three cases: INSTANCE property values, property references on any node,
+ * and property definitions on COMPONENT/COMPONENT_SET nodes.
  */
-export const componentExtractor: ExtractorFn = (node, result, _context) => {
+export const componentExtractor: ExtractorFn = (node, result, context) => {
+  // Instance nodes: componentId + simplified componentProperties
   if (node.type === "INSTANCE") {
     if (hasValue("componentId", node)) {
       result.componentId = node.componentId;
     }
-
     if (hasValue("componentProperties", node)) {
       result.componentProperties = simplifyComponentProperties(
         node.componentProperties as Record<string, { type: string; value: boolean | string }>,
       );
+    }
+  }
+
+  // Any node with property references: annotate with simplified refs
+  if (
+    "componentPropertyReferences" in node &&
+    node.componentPropertyReferences &&
+    typeof node.componentPropertyReferences === "object"
+  ) {
+    const refs = simplifyPropertyReferences(
+      node.componentPropertyReferences as Record<string, string>,
+    );
+    if (Object.keys(refs).length > 0) {
+      result.componentPropertyReferences = refs;
+    }
+  }
+
+  // Component/ComponentSet definitions: collect property definitions
+  if (
+    (node.type === "COMPONENT" || node.type === "COMPONENT_SET") &&
+    "componentPropertyDefinitions" in node &&
+    node.componentPropertyDefinitions &&
+    typeof node.componentPropertyDefinitions === "object"
+  ) {
+    const defs = simplifyPropertyDefinitions(
+      node.componentPropertyDefinitions as Record<
+        string,
+        { type: string; defaultValue: boolean | string }
+      >,
+    );
+    if (Object.keys(defs).length > 0) {
+      if (!context.globalVars.componentPropertyDefinitions) {
+        context.globalVars.componentPropertyDefinitions = {};
+      }
+      context.globalVars.componentPropertyDefinitions[node.id] = defs;
     }
   }
 };

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -159,9 +159,12 @@ export const componentExtractor: ExtractorFn = (node, result, context) => {
       result.componentId = node.componentId;
     }
     if (hasValue("componentProperties", node)) {
-      result.componentProperties = simplifyComponentProperties(
+      const props = simplifyComponentProperties(
         node.componentProperties as Record<string, { type: string; value: boolean | string }>,
       );
+      if (Object.keys(props).length > 0) {
+        result.componentProperties = props;
+      }
     }
   }
 

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -214,7 +214,7 @@ function getStyleMatch(
   for (const key of keys) {
     const styleId = styleMap[key];
     if (styleId) {
-      const meta = context.globalVars.extraStyles?.[styleId];
+      const meta = context.extraStyles?.[styleId];
       if (meta?.name) return { name: meta.name, id: styleId };
     }
   }

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -14,6 +14,7 @@ import {
   hasTextStyle,
   isTextNode,
 } from "~/transformers/text.js";
+import { simplifyComponentProperties } from "~/transformers/component.js";
 import { hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { generateVarId, isVisible } from "~/utils/common.js";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
@@ -151,14 +152,9 @@ export const componentExtractor: ExtractorFn = (node, result, _context) => {
       result.componentId = node.componentId;
     }
 
-    // Add specific properties for instances of components
     if (hasValue("componentProperties", node)) {
-      result.componentProperties = Object.entries(node.componentProperties ?? {}).map(
-        ([name, { value, type }]) => ({
-          name,
-          value: value.toString(),
-          type,
-        }),
+      result.componentProperties = simplifyComponentProperties(
+        node.componentProperties as Record<string, { type: string; value: boolean | string }>,
       );
     }
   }

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -196,10 +196,7 @@ export const componentExtractor: ExtractorFn = (node, result, context) => {
       >,
     );
     if (Object.keys(defs).length > 0) {
-      if (!context.globalVars.componentPropertyDefinitions) {
-        context.globalVars.componentPropertyDefinitions = {};
-      }
-      context.globalVars.componentPropertyDefinitions[node.id] = defs;
+      context.traversalState.componentPropertyDefinitions[node.id] = defs;
     }
   }
 };

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -7,7 +7,7 @@ import type {
   Style,
 } from "@figma/rest-api-spec";
 import { simplifyComponents, simplifyComponentSets } from "~/transformers/component.js";
-import type { ExtractorFn, TraversalOptions, SimplifiedDesign, TraversalContext } from "./types.js";
+import type { ExtractorFn, TraversalOptions, SimplifiedDesign } from "./types.js";
 import { extractFromDesign } from "./node-walker.js";
 
 /**
@@ -23,12 +23,11 @@ export async function simplifyRawFigmaObject(
     parseAPIResponse(apiResponse);
 
   // Process nodes using the flexible extractor system
-  const globalVars: TraversalContext["globalVars"] = { styles: {}, extraStyles };
   const {
     nodes: extractedNodes,
     globalVars: finalGlobalVars,
     traversalState,
-  } = await extractFromDesign(rawNodes, nodeExtractors, options, globalVars);
+  } = await extractFromDesign(rawNodes, nodeExtractors, options, { styles: {} }, extraStyles);
 
   return {
     ...metadata,

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -24,21 +24,19 @@ export async function simplifyRawFigmaObject(
 
   // Process nodes using the flexible extractor system
   const globalVars: TraversalContext["globalVars"] = { styles: {}, extraStyles };
-  const { nodes: extractedNodes, globalVars: finalGlobalVars } = await extractFromDesign(
-    rawNodes,
-    nodeExtractors,
-    options,
-    globalVars,
-  );
+  const {
+    nodes: extractedNodes,
+    globalVars: finalGlobalVars,
+    traversalState,
+  } = await extractFromDesign(rawNodes, nodeExtractors, options, globalVars);
 
-  // Pass property definitions collected during traversal to component metadata
   return {
     ...metadata,
     nodes: extractedNodes,
-    components: simplifyComponents(components, finalGlobalVars.componentPropertyDefinitions),
+    components: simplifyComponents(components, traversalState.componentPropertyDefinitions),
     componentSets: simplifyComponentSets(
       componentSets,
-      finalGlobalVars.componentPropertyDefinitions,
+      traversalState.componentPropertyDefinitions,
     ),
     globalVars: { styles: finalGlobalVars.styles },
   };

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -7,7 +7,6 @@ import type {
   Style,
 } from "@figma/rest-api-spec";
 import { simplifyComponents, simplifyComponentSets } from "~/transformers/component.js";
-import { isVisible } from "~/utils/common.js";
 import type { ExtractorFn, TraversalOptions, SimplifiedDesign, TraversalContext } from "./types.js";
 import { extractFromDesign } from "./node-walker.js";
 
@@ -32,12 +31,15 @@ export async function simplifyRawFigmaObject(
     globalVars,
   );
 
-  // Return complete design
+  // Pass property definitions collected during traversal to component metadata
   return {
     ...metadata,
     nodes: extractedNodes,
-    components: simplifyComponents(components),
-    componentSets: simplifyComponentSets(componentSets),
+    components: simplifyComponents(components, finalGlobalVars.componentPropertyDefinitions),
+    componentSets: simplifyComponentSets(
+      componentSets,
+      finalGlobalVars.componentPropertyDefinitions,
+    ),
     globalVars: { styles: finalGlobalVars.styles },
   };
 }
@@ -65,7 +67,7 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
         Object.assign(extraStyles, nodeResponse.styles);
       }
     });
-    nodesToParse = nodeResponses.map((n) => n.document).filter(isVisible);
+    nodesToParse = nodeResponses.map((n) => n.document);
   } else {
     // GetFileResponse
     Object.assign(aggregatedComponents, data.components);
@@ -73,7 +75,7 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
     if (data.styles) {
       extraStyles = data.styles;
     }
-    nodesToParse = data.document.children.filter(isVisible);
+    nodesToParse = data.document.children;
   }
 
   const { name } = data;

--- a/src/extractors/index.ts
+++ b/src/extractors/index.ts
@@ -4,6 +4,7 @@ export type {
   SimplifiedNode,
   TraversalContext,
   TraversalOptions,
+  TraversalState,
   GlobalVars,
   StyleTypes,
 } from "./types.js";

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -51,7 +51,7 @@ export async function extractFromDesign(
 
   const processedNodes: SimplifiedNode[] = [];
   for (const node of nodes) {
-    if (!shouldProcessNode(node, options)) continue;
+    if (!shouldProcessNode(node, context, options)) continue;
     const result = await processNodeWithExtractors(node, extractors, context, options);
     if (result !== null) processedNodes.push(result);
   }
@@ -71,7 +71,7 @@ async function processNodeWithExtractors(
   context: TraversalContext,
   options: TraversalOptions,
 ): Promise<SimplifiedNode | null> {
-  if (!shouldProcessNode(node, options)) {
+  if (!shouldProcessNode(node, context, options)) {
     return null;
   }
 
@@ -84,6 +84,11 @@ async function processNodeWithExtractors(
     type: node.type === "VECTOR" ? "IMAGE-SVG" : node.type,
   };
 
+  // Mark rescued hidden nodes so the AI knows the default rendered state
+  if (!isVisible(node)) {
+    result.visible = false;
+  }
+
   // Apply all extractors to this node in a single pass
   for (const extractor of extractors) {
     extractor(node, result, context);
@@ -95,13 +100,20 @@ async function processNodeWithExtractors(
       ...context,
       currentDepth: context.currentDepth + 1,
       parent: node,
+      // COMPONENT nodes define properties; INSTANCE nodes resolve them
+      insideComponentDefinition:
+        node.type === "COMPONENT" || node.type === "COMPONENT_SET"
+          ? true
+          : node.type === "INSTANCE"
+            ? false
+            : context.insideComponentDefinition,
     };
 
     // Use the same pattern as the existing parseNode function
     if (hasValue("children", node) && node.children.length > 0) {
       const children: SimplifiedNode[] = [];
       for (const child of node.children) {
-        if (!shouldProcessNode(child, options)) continue;
+        if (!shouldProcessNode(child, childContext, options)) continue;
         const processed = await processNodeWithExtractors(child, extractors, childContext, options);
         if (processed !== null) children.push(processed);
       }
@@ -125,13 +137,23 @@ async function processNodeWithExtractors(
 /**
  * Determine if a node should be processed based on filters.
  */
-function shouldProcessNode(node: FigmaDocumentNode, options: TraversalOptions): boolean {
-  // Skip invisible nodes
+function shouldProcessNode(
+  node: FigmaDocumentNode,
+  context: TraversalContext | undefined,
+  options: TraversalOptions,
+): boolean {
   if (!isVisible(node)) {
-    return false;
+    // Rescue hidden nodes controlled by a boolean property inside component definitions
+    const hasVisibleRef =
+      "componentPropertyReferences" in node &&
+      node.componentPropertyReferences &&
+      typeof node.componentPropertyReferences === "object" &&
+      "visible" in node.componentPropertyReferences;
+    if (!(hasVisibleRef && context?.insideComponentDefinition)) {
+      return false;
+    }
   }
 
-  // Apply custom node filter if provided
   if (options.nodeFilter && !options.nodeFilter(node)) {
     return false;
   }

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -1,6 +1,7 @@
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
 import { isVisible } from "~/utils/common.js";
 import { hasValue } from "~/utils/identity.js";
+import type { Style } from "@figma/rest-api-spec";
 import type {
   ExtractorFn,
   TraversalContext,
@@ -42,6 +43,7 @@ export async function extractFromDesign(
   extractors: ExtractorFn[],
   options: TraversalOptions = {},
   globalVars: GlobalVars = { styles: {} },
+  extraStyles?: Record<string, Style>,
 ): Promise<{
   nodes: SimplifiedNode[];
   globalVars: GlobalVars;
@@ -49,6 +51,7 @@ export async function extractFromDesign(
 }> {
   const context: TraversalContext = {
     globalVars,
+    extraStyles,
     currentDepth: 0,
     traversalState: { componentPropertyDefinitions: {} },
   };

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -5,6 +5,7 @@ import type {
   ExtractorFn,
   TraversalContext,
   TraversalOptions,
+  TraversalState,
   GlobalVars,
   SimplifiedNode,
 } from "./types.js";
@@ -41,10 +42,15 @@ export async function extractFromDesign(
   extractors: ExtractorFn[],
   options: TraversalOptions = {},
   globalVars: GlobalVars = { styles: {} },
-): Promise<{ nodes: SimplifiedNode[]; globalVars: GlobalVars }> {
+): Promise<{
+  nodes: SimplifiedNode[];
+  globalVars: GlobalVars;
+  traversalState: TraversalState;
+}> {
   const context: TraversalContext = {
     globalVars,
     currentDepth: 0,
+    traversalState: { componentPropertyDefinitions: {} },
   };
 
   nodesProcessed = 0;
@@ -59,6 +65,7 @@ export async function extractFromDesign(
   return {
     nodes: processedNodes,
     globalVars: context.globalVars,
+    traversalState: context.traversalState,
   };
 }
 

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -94,11 +94,6 @@ async function processNodeWithExtractors(
     type: node.type === "VECTOR" ? "IMAGE-SVG" : node.type,
   };
 
-  // Mark rescued hidden nodes so the AI knows the default rendered state
-  if (!isVisible(node)) {
-    result.visible = false;
-  }
-
   // Apply all extractors to this node in a single pass
   for (const extractor of extractors) {
     extractor(node, result, context);

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -139,7 +139,7 @@ async function processNodeWithExtractors(
  */
 function shouldProcessNode(
   node: FigmaDocumentNode,
-  context: TraversalContext | undefined,
+  context: TraversalContext,
   options: TraversalOptions,
 ): boolean {
   if (!isVisible(node)) {
@@ -149,7 +149,7 @@ function shouldProcessNode(
       node.componentPropertyReferences &&
       typeof node.componentPropertyReferences === "object" &&
       "visible" in node.componentPropertyReferences;
-    if (!(hasVisibleRef && context?.insideComponentDefinition)) {
+    if (!(hasVisibleRef && context.insideComponentDefinition)) {
       return false;
     }
   }

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -4,7 +4,6 @@ import type { SimplifiedLayout } from "~/transformers/layout.js";
 import type { SimplifiedFill, SimplifiedStroke } from "~/transformers/style.js";
 import type { SimplifiedEffects } from "~/transformers/effects.js";
 import type {
-  ComponentProperties,
   SimplifiedComponentDefinition,
   SimplifiedComponentSetDefinition,
 } from "~/transformers/component.js";
@@ -19,12 +18,14 @@ export type StyleTypes =
 
 export type GlobalVars = {
   styles: Record<string, StyleTypes>;
+  componentPropertyDefinitions?: Record<string, Record<string, boolean | string>>;
 };
 
 export interface TraversalContext {
   globalVars: GlobalVars & { extraStyles?: Record<string, Style> };
   currentDepth: number;
   parent?: FigmaDocumentNode;
+  insideComponentDefinition?: boolean;
 }
 
 export interface TraversalOptions {
@@ -88,8 +89,10 @@ export interface SimplifiedNode {
   // layout & alignment
   layout?: string;
   // for rect-specific strokes, etc.
+  visible?: false;
   componentId?: string;
-  componentProperties?: ComponentProperties[];
+  componentProperties?: Record<string, boolean | string>;
+  componentPropertyReferences?: Record<string, string>;
   // children
   children?: SimplifiedNode[];
 }

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -21,7 +21,8 @@ export type GlobalVars = {
 };
 
 export interface TraversalContext {
-  globalVars: GlobalVars & { extraStyles?: Record<string, Style> };
+  globalVars: GlobalVars;
+  extraStyles?: Record<string, Style>;
   currentDepth: number;
   parent?: FigmaDocumentNode;
   insideComponentDefinition?: boolean;

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -6,6 +6,7 @@ import type { SimplifiedEffects } from "~/transformers/effects.js";
 import type {
   SimplifiedComponentDefinition,
   SimplifiedComponentSetDefinition,
+  SimplifiedPropertyDefinition,
 } from "~/transformers/component.js";
 
 export type StyleTypes =
@@ -30,7 +31,7 @@ export interface TraversalContext {
 }
 
 export interface TraversalState {
-  componentPropertyDefinitions: Record<string, Record<string, boolean | string>>;
+  componentPropertyDefinitions: Record<string, Record<string, SimplifiedPropertyDefinition>>;
 }
 
 export interface TraversalOptions {
@@ -93,8 +94,6 @@ export interface SimplifiedNode {
   borderRadius?: string;
   // layout & alignment
   layout?: string;
-  // for rect-specific strokes, etc.
-  visible?: false;
   componentId?: string;
   componentProperties?: Record<string, boolean | string>;
   componentPropertyReferences?: Record<string, string>;

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -18,7 +18,6 @@ export type StyleTypes =
 
 export type GlobalVars = {
   styles: Record<string, StyleTypes>;
-  componentPropertyDefinitions?: Record<string, Record<string, boolean | string>>;
 };
 
 export interface TraversalContext {
@@ -26,6 +25,11 @@ export interface TraversalContext {
   currentDepth: number;
   parent?: FigmaDocumentNode;
   insideComponentDefinition?: boolean;
+  traversalState: TraversalState;
+}
+
+export interface TraversalState {
+  componentPropertyDefinitions: Record<string, Record<string, boolean | string>>;
 }
 
 export interface TraversalOptions {

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -299,7 +299,7 @@ describe("component property support", () => {
     expect(instance.children![0].name).toBe("Title");
   });
 
-  it("collects componentPropertyDefinitions into globalVars", async () => {
+  it("collects componentPropertyDefinitions during traversal", async () => {
     const componentNode = makeNode({
       id: "12:1",
       name: "Product Card",
@@ -312,15 +312,13 @@ describe("component property support", () => {
       children: [makeNode({ id: "12:2", name: "Title", type: "TEXT", characters: "Product Name" })],
     });
 
-    const { globalVars } = await extractFromDesign([componentNode], allExtractors);
+    const { traversalState } = await extractFromDesign([componentNode], allExtractors);
 
-    expect(globalVars.componentPropertyDefinitions).toBeDefined();
-    expect(globalVars.componentPropertyDefinitions!["12:1"]).toBeDefined();
-    expect(globalVars.componentPropertyDefinitions!["12:1"]).toEqual({
+    expect(traversalState.componentPropertyDefinitions["12:1"]).toEqual({
       "On Sale": true,
       Title: "Product Name",
     });
-    expect(globalVars.componentPropertyDefinitions!["12:1"]).not.toHaveProperty("Icon");
+    expect(traversalState.componentPropertyDefinitions["12:1"]).not.toHaveProperty("Icon");
   });
 
   it("annotates componentPropertyReferences with characters→text rename", async () => {
@@ -429,5 +427,47 @@ describe("simplifyRawFigmaObject", () => {
     const label = result.nodes[1].children![0].children![0];
     expect(label.name).toBe("Label");
     expect(label.text).toBe("World");
+  });
+
+  it("flows property definitions from tree traversal into component metadata", async () => {
+    const componentNode = makeNode({
+      id: "20:1",
+      name: "Product Card",
+      type: "COMPONENT",
+      componentPropertyDefinitions: {
+        "On Sale#341:0": { type: "BOOLEAN", defaultValue: true },
+        "Title#341:1": { type: "TEXT", defaultValue: "Product Name" },
+      },
+      children: [makeNode({ id: "20:2", name: "Content", type: "FRAME" })],
+    });
+
+    const mockResponse = {
+      name: "Test File",
+      document: {
+        id: "0:0",
+        name: "Document",
+        type: "DOCUMENT",
+        children: [componentNode],
+        visible: true,
+      },
+      components: {
+        "20:1": { key: "abc123", name: "Product Card", componentSetId: undefined },
+      },
+      componentSets: {},
+      styles: {},
+      schemaVersion: 0,
+      version: "1",
+      role: "owner",
+      lastModified: "2024-01-01",
+      thumbnailUrl: "",
+      editorType: "figma",
+    } as unknown as GetFileResponse;
+
+    const result = await simplifyRawFigmaObject(mockResponse, allExtractors);
+
+    expect(result.components["20:1"].propertyDefinitions).toEqual({
+      "On Sale": true,
+      Title: "Product Name",
+    });
   });
 });

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -271,7 +271,6 @@ describe("component property support", () => {
 
     const badge = card.children!.find((c) => c.name === "Badge")!;
     expect(badge).toBeDefined();
-    expect(badge.visible).toBe(false);
     expect(badge.componentPropertyReferences).toEqual({ visible: "Show Badge" });
   });
 
@@ -313,8 +312,8 @@ describe("component property support", () => {
     const { traversalState } = await extractFromDesign([componentNode], allExtractors);
 
     expect(traversalState.componentPropertyDefinitions["12:1"]).toEqual({
-      "On Sale": true,
-      Title: "Product Name",
+      "On Sale": { type: "boolean", defaultValue: true },
+      Title: { type: "text", defaultValue: "Product Name" },
     });
     expect(traversalState.componentPropertyDefinitions["12:1"]).not.toHaveProperty("Icon");
   });
@@ -464,8 +463,8 @@ describe("simplifyRawFigmaObject", () => {
     const result = await simplifyRawFigmaObject(mockResponse, allExtractors);
 
     expect(result.components["20:1"].propertyDefinitions).toEqual({
-      "On Sale": true,
-      Title: "Product Name",
+      "On Sale": { type: "boolean", defaultValue: true },
+      Title: { type: "text", defaultValue: "Product Name" },
     });
   });
 });

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -4,7 +4,6 @@ import { allExtractors, collapseSvgContainers } from "~/extractors/built-in.js";
 import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
 import type { GetFileResponse, Style } from "@figma/rest-api-spec";
 import type { Node as FigmaNode } from "@figma/rest-api-spec";
-import type { GlobalVars } from "~/extractors/types.js";
 
 // Minimal Figma node factory — only the fields the walker actually reads.
 // The Figma types are deeply discriminated unions; we cast through unknown
@@ -175,13 +174,12 @@ describe("extractFromDesign", () => {
       "161:300": { name: "Heading / Large" } as Style,
     };
 
-    const globalVars = { styles: {}, extraStyles } as GlobalVars;
-
     const { nodes, globalVars: resultVars } = await extractFromDesign(
       [nodeA, nodeB],
       allExtractors,
       {},
-      globalVars,
+      { styles: {} },
+      extraStyles,
     );
 
     expect(nodes[0].textStyle).toBe("Heading / Large");

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -247,6 +247,154 @@ describe("collapseSvgContainers", () => {
   });
 });
 
+describe("component property support", () => {
+  it("rescues hidden nodes with componentPropertyReferences.visible inside components", async () => {
+    const componentNode = makeNode({
+      id: "10:1",
+      name: "Card",
+      type: "COMPONENT",
+      children: [
+        makeNode({ id: "10:2", name: "Title", type: "TEXT", characters: "Card Title" }),
+        makeNode({
+          id: "10:3",
+          name: "Badge",
+          type: "FRAME",
+          visible: false,
+          componentPropertyReferences: { visible: "Show Badge#341:0" },
+          children: [makeNode({ id: "10:4", name: "Badge Text", type: "TEXT", characters: "NEW" })],
+        }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([componentNode], allExtractors);
+
+    const card = nodes[0];
+    expect(card.children).toHaveLength(2);
+
+    const badge = card.children!.find((c) => c.name === "Badge")!;
+    expect(badge).toBeDefined();
+    expect(badge.visible).toBe(false);
+    expect(badge.componentPropertyReferences).toEqual({ visible: "Show Badge" });
+  });
+
+  it("strips hidden nodes normally inside instances", async () => {
+    const instanceNode = makeNode({
+      id: "11:1",
+      name: "Card Instance",
+      type: "INSTANCE",
+      componentId: "10:1",
+      componentProperties: {
+        "Show Badge": { type: "BOOLEAN", value: false },
+      },
+      children: [
+        makeNode({ id: "11:2", name: "Title", type: "TEXT", characters: "My Card" }),
+        makeNode({ id: "11:3", name: "Badge", type: "FRAME", visible: false }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([instanceNode], allExtractors);
+
+    const instance = nodes[0];
+    expect(instance.children).toHaveLength(1);
+    expect(instance.children![0].name).toBe("Title");
+  });
+
+  it("collects componentPropertyDefinitions into globalVars", async () => {
+    const componentNode = makeNode({
+      id: "12:1",
+      name: "Product Card",
+      type: "COMPONENT",
+      componentPropertyDefinitions: {
+        "On Sale#341:0": { type: "BOOLEAN", defaultValue: true },
+        "Title#341:1": { type: "TEXT", defaultValue: "Product Name" },
+        "Icon#341:2": { type: "INSTANCE_SWAP", defaultValue: "999:1" },
+      },
+      children: [makeNode({ id: "12:2", name: "Title", type: "TEXT", characters: "Product Name" })],
+    });
+
+    const { globalVars } = await extractFromDesign([componentNode], allExtractors);
+
+    expect(globalVars.componentPropertyDefinitions).toBeDefined();
+    expect(globalVars.componentPropertyDefinitions!["12:1"]).toBeDefined();
+    expect(globalVars.componentPropertyDefinitions!["12:1"]).toEqual({
+      "On Sale": true,
+      Title: "Product Name",
+    });
+    expect(globalVars.componentPropertyDefinitions!["12:1"]).not.toHaveProperty("Icon");
+  });
+
+  it("annotates componentPropertyReferences with characters→text rename", async () => {
+    const componentNode = makeNode({
+      id: "13:1",
+      name: "Button",
+      type: "COMPONENT",
+      children: [
+        makeNode({
+          id: "13:2",
+          name: "Label",
+          type: "TEXT",
+          characters: "Click me",
+          componentPropertyReferences: { characters: "Button Label#100:0" },
+        }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([componentNode], allExtractors);
+
+    const label = nodes[0].children![0];
+    expect(label.componentPropertyReferences).toEqual({ text: "Button Label" });
+  });
+
+  it("simplifies instance componentProperties to Record format", async () => {
+    const instanceNode = makeNode({
+      id: "14:1",
+      name: "Card Instance",
+      type: "INSTANCE",
+      componentId: "10:1",
+      componentProperties: {
+        "On Sale": { type: "BOOLEAN", value: true },
+        Title: { type: "TEXT", value: "My Product" },
+      },
+      children: [makeNode({ id: "14:2", name: "Content", type: "FRAME" })],
+    });
+
+    const { nodes } = await extractFromDesign([instanceNode], allExtractors);
+
+    expect(nodes[0].componentProperties).toEqual({
+      "On Sale": true,
+      Title: "My Product",
+    });
+  });
+
+  it("strips hidden children inside nested instances within components", async () => {
+    const componentNode = makeNode({
+      id: "15:1",
+      name: "Wrapper",
+      type: "COMPONENT",
+      children: [
+        makeNode({
+          id: "15:2",
+          name: "Nested Instance",
+          type: "INSTANCE",
+          componentId: "99:1",
+          children: [
+            makeNode({ id: "15:3", name: "Visible Child", type: "FRAME" }),
+            makeNode({ id: "15:4", name: "Hidden Child", type: "FRAME", visible: false }),
+          ],
+        }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([componentNode], allExtractors);
+
+    const nestedInstance = nodes[0].children![0];
+    expect(nestedInstance).toBeDefined();
+    expect(nestedInstance.name).toBe("Nested Instance");
+    expect(nestedInstance.children).toHaveLength(1);
+    expect(nestedInstance.children![0].name).toBe("Visible Child");
+  });
+});
+
 describe("simplifyRawFigmaObject", () => {
   it("produces a complete SimplifiedDesign from a mock API response", async () => {
     const mockResponse = {

--- a/src/transformers/component.ts
+++ b/src/transformers/component.ts
@@ -1,16 +1,11 @@
-import type { Component, ComponentPropertyType, ComponentSet } from "@figma/rest-api-spec";
-
-export interface ComponentProperties {
-  name: string;
-  value: string;
-  type: ComponentPropertyType;
-}
+import type { Component, ComponentSet } from "@figma/rest-api-spec";
 
 export interface SimplifiedComponentDefinition {
   id: string;
   key: string;
   name: string;
   componentSetId?: string;
+  propertyDefinitions?: Record<string, boolean | string>;
 }
 
 export interface SimplifiedComponentSetDefinition {
@@ -18,6 +13,68 @@ export interface SimplifiedComponentSetDefinition {
   key: string;
   name: string;
   description?: string;
+  propertyDefinitions?: Record<string, boolean | string>;
+}
+
+/**
+ * Strip the #nodeId suffix from Figma property names.
+ * "On Sale#341:0" → "On Sale"
+ */
+export function stripPropertyNameSuffix(name: string): string {
+  const hashIndex = name.indexOf("#");
+  return hashIndex === -1 ? name : name.substring(0, hashIndex);
+}
+
+/**
+ * Simplify componentPropertyDefinitions from the raw Figma format to a flat
+ * Record of property name → default value. Only extracts BOOLEAN and TEXT
+ * properties for Phase 1.
+ */
+export function simplifyPropertyDefinitions(
+  definitions: Record<string, { type: string; defaultValue: boolean | string }>,
+): Record<string, boolean | string> {
+  const result: Record<string, boolean | string> = {};
+  for (const [name, def] of Object.entries(definitions)) {
+    if (def.type === "BOOLEAN" || def.type === "TEXT") {
+      result[stripPropertyNameSuffix(name)] = def.defaultValue;
+    }
+  }
+  return result;
+}
+
+/**
+ * Simplify componentPropertyReferences from the raw Figma format.
+ * Strips #nodeId suffixes from property names and renames "characters" key to "text"
+ * to match SimplifiedNode's text field.
+ * Only handles "visible" (BOOLEAN) and "characters" (TEXT) references for Phase 1.
+ */
+export function simplifyPropertyReferences(
+  references: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(references)) {
+    if (key === "visible" || key === "characters") {
+      const outputKey = key === "characters" ? "text" : key;
+      result[outputKey] = stripPropertyNameSuffix(value);
+    }
+  }
+  return result;
+}
+
+/**
+ * Simplify instance componentProperties from the verbose Figma format to a flat
+ * Record of property name → value. Only extracts BOOLEAN and TEXT properties for Phase 1.
+ */
+export function simplifyComponentProperties(
+  properties: Record<string, { type: string; value: boolean | string }>,
+): Record<string, boolean | string> {
+  const result: Record<string, boolean | string> = {};
+  for (const [name, prop] of Object.entries(properties)) {
+    if (prop.type === "BOOLEAN" || prop.type === "TEXT") {
+      result[stripPropertyNameSuffix(name)] = prop.value;
+    }
+  }
+  return result;
 }
 
 /**
@@ -25,6 +82,7 @@ export interface SimplifiedComponentSetDefinition {
  */
 export function simplifyComponents(
   aggregatedComponents: Record<string, Component>,
+  propertyDefinitions?: Record<string, Record<string, boolean | string>>,
 ): Record<string, SimplifiedComponentDefinition> {
   return Object.fromEntries(
     Object.entries(aggregatedComponents).map(([id, comp]) => [
@@ -34,6 +92,9 @@ export function simplifyComponents(
         key: comp.key,
         name: comp.name,
         componentSetId: comp.componentSetId,
+        ...(propertyDefinitions?.[id] && {
+          propertyDefinitions: propertyDefinitions[id],
+        }),
       },
     ]),
   );
@@ -44,6 +105,7 @@ export function simplifyComponents(
  */
 export function simplifyComponentSets(
   aggregatedComponentSets: Record<string, ComponentSet>,
+  propertyDefinitions?: Record<string, Record<string, boolean | string>>,
 ): Record<string, SimplifiedComponentSetDefinition> {
   return Object.fromEntries(
     Object.entries(aggregatedComponentSets).map(([id, set]) => [
@@ -53,6 +115,9 @@ export function simplifyComponentSets(
         key: set.key,
         name: set.name,
         description: set.description,
+        ...(propertyDefinitions?.[id] && {
+          propertyDefinitions: propertyDefinitions[id],
+        }),
       },
     ]),
   );

--- a/src/transformers/component.ts
+++ b/src/transformers/component.ts
@@ -1,11 +1,16 @@
 import type { Component, ComponentSet } from "@figma/rest-api-spec";
 
+export interface SimplifiedPropertyDefinition {
+  type: string;
+  defaultValue: boolean | string;
+}
+
 export interface SimplifiedComponentDefinition {
   id: string;
   key: string;
   name: string;
   componentSetId?: string;
-  propertyDefinitions?: Record<string, boolean | string>;
+  propertyDefinitions?: Record<string, SimplifiedPropertyDefinition>;
 }
 
 export interface SimplifiedComponentSetDefinition {
@@ -13,7 +18,7 @@ export interface SimplifiedComponentSetDefinition {
   key: string;
   name: string;
   description?: string;
-  propertyDefinitions?: Record<string, boolean | string>;
+  propertyDefinitions?: Record<string, SimplifiedPropertyDefinition>;
 }
 
 /**
@@ -32,11 +37,14 @@ export function stripPropertyNameSuffix(name: string): string {
  */
 export function simplifyPropertyDefinitions(
   definitions: Record<string, { type: string; defaultValue: boolean | string }>,
-): Record<string, boolean | string> {
-  const result: Record<string, boolean | string> = {};
+): Record<string, SimplifiedPropertyDefinition> {
+  const result: Record<string, SimplifiedPropertyDefinition> = {};
   for (const [name, def] of Object.entries(definitions)) {
     if (def.type === "BOOLEAN" || def.type === "TEXT") {
-      result[stripPropertyNameSuffix(name)] = def.defaultValue;
+      result[stripPropertyNameSuffix(name)] = {
+        type: def.type.toLowerCase(),
+        defaultValue: def.defaultValue,
+      };
     }
   }
   return result;
@@ -82,7 +90,7 @@ export function simplifyComponentProperties(
  */
 export function simplifyComponents(
   aggregatedComponents: Record<string, Component>,
-  propertyDefinitions?: Record<string, Record<string, boolean | string>>,
+  propertyDefinitions?: Record<string, Record<string, SimplifiedPropertyDefinition>>,
 ): Record<string, SimplifiedComponentDefinition> {
   return Object.fromEntries(
     Object.entries(aggregatedComponents).map(([id, comp]) => [
@@ -105,7 +113,7 @@ export function simplifyComponents(
  */
 export function simplifyComponentSets(
   aggregatedComponentSets: Record<string, ComponentSet>,
-  propertyDefinitions?: Record<string, Record<string, boolean | string>>,
+  propertyDefinitions?: Record<string, Record<string, SimplifiedPropertyDefinition>>,
 ): Record<string, SimplifiedComponentSetDefinition> {
   return Object.fromEntries(
     Object.entries(aggregatedComponentSets).map(([id, set]) => [


### PR DESCRIPTION
## Summary

Today when an AI fetches a Figma component, it only sees the default state — any layers hidden by boolean properties (like "On Sale" or "Show Badge") are silently dropped. The AI has no idea those layers exist or that the component supports toggling them.

This PR fixes that:

- **Components now show their full capability.** Hidden conditional layers are included in the output, annotated with which property controls them. Property definitions list all available properties with their types and defaults.
- **Instances stay clean.** Instance output shows the resolved state with simplified property values — hidden layers are still stripped since they represent "what is" rather than "what could be."
- **Property format is AI-friendly.** Explicit `{ type, defaultValue }` on definitions, `Record<name, value>` on instances, `characters` renamed to `text` to match existing fields.

Covers BOOLEAN and TEXT properties. VARIANT and INSTANCE_SWAP are Phase 2.

## Test plan

- [x] 7 new integration tests covering rescue logic, property annotation, definition flow, and edge cases (nested instances within components)
- [x] Mutation testing verified tests catch breakage in rescue logic, suffix stripping, and definition flow
- [x] Manual verification with real Figma test file (node `341:981`)