### PR TITLE
fix: throw actionable error for missing nodes, add error_category to telemetry

### DIFF
--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -7,6 +7,7 @@ import type {
   Style,
 } from "@figma/rest-api-spec";
 import { simplifyComponents, simplifyComponentSets } from "~/transformers/component.js";
+import { tagError } from "~/utils/error-meta.js";
 import type { ExtractorFn, TraversalOptions, SimplifiedDesign } from "./types.js";
 import { extractFromDesign } from "./node-walker.js";
 
@@ -54,10 +55,13 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
     // GetFileNodesResponse
     const [nodeId, nodeData] = Object.entries(data.nodes)[0];
     if (nodeData === null) {
-      throw new Error(
-        `Node ${nodeId} was not found in the Figma file. ` +
-          `It may have been deleted or the link may be outdated. ` +
-          `Try copying a fresh link from the Figma file.`,
+      tagError(
+        new Error(
+          `Node ${nodeId} was not found in the Figma file. ` +
+            `It may have been deleted or the link may be outdated. ` +
+            `Try copying a fresh link from the Figma file.`,
+        ),
+        { category: "not_found" },
       );
     }
 

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -52,19 +52,21 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
 
   if ("nodes" in data) {
     // GetFileNodesResponse
-    const nodeResponses = Object.values(data.nodes);
-    nodeResponses.forEach((nodeResponse) => {
-      if (nodeResponse.components) {
-        Object.assign(aggregatedComponents, nodeResponse.components);
-      }
-      if (nodeResponse.componentSets) {
-        Object.assign(aggregatedComponentSets, nodeResponse.componentSets);
-      }
-      if (nodeResponse.styles) {
-        Object.assign(extraStyles, nodeResponse.styles);
-      }
-    });
-    nodesToParse = nodeResponses.map((n) => n.document);
+    const [nodeId, nodeData] = Object.entries(data.nodes)[0];
+    if (nodeData === null) {
+      throw new Error(
+        `Node ${nodeId} was not found in the Figma file. ` +
+          `It may have been deleted or the link may be outdated. ` +
+          `Try copying a fresh link from the Figma file.`,
+      );
+    }
+
+    Object.assign(aggregatedComponents, nodeData.components);
+    Object.assign(aggregatedComponentSets, nodeData.componentSets);
+    if (nodeData.styles) {
+      Object.assign(extraStyles, nodeData.styles);
+    }
+    nodesToParse = [nodeData.document];
   } else {
     // GetFileResponse
     Object.assign(aggregatedComponents, data.components);

--- a/src/telemetry/capture.ts
+++ b/src/telemetry/capture.ts
@@ -23,6 +23,7 @@ function errorFields(
   | "error_type"
   | "error_message"
   | "error_phase"
+  | "error_category"
   | "http_status"
   | "network_code"
   | "fs_code"
@@ -36,6 +37,7 @@ function errorFields(
     error_type: error instanceof Error ? error.constructor.name : "Unknown",
     error_message: rawMessage,
     error_phase: meta.phase,
+    error_category: meta.category,
     http_status: meta.http_status,
     network_code: meta.network_code,
     fs_code: meta.fs_code,
@@ -127,6 +129,7 @@ export function captureValidationReject(
     error_type: "ValidationError",
     error_message: input.message,
     error_phase: "validate",
+    error_category: "invalid_input",
     validation_field: input.field,
     validation_rule: input.rule,
   };

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -45,6 +45,7 @@ export type CommonCallProps = {
   error_type?: string;
   error_message?: string;
   error_phase?: string;
+  error_category?: string;
   http_status?: number;
   network_code?: string;
   fs_code?: string;

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -6,6 +6,7 @@ import type {
   Transform,
 } from "@figma/rest-api-spec";
 import { generateCSSShorthand, isVisible } from "~/utils/common.js";
+import { tagError } from "~/utils/error-meta.js";
 import { hasValue, isStrokeWeights } from "~/utils/identity.js";
 
 export type CSSRGBAColor = `rgba(${number}, ${number}, ${number}, ${number})`;
@@ -324,7 +325,7 @@ export function parsePaint(raw: Paint, hasChildren: boolean = false): Simplified
       gradient: convertGradientToCss(raw),
     };
   } else {
-    throw new Error(`Unknown paint type: ${raw.type}`);
+    tagError(new Error(`Unknown paint type: ${raw.type}`), { category: "internal" });
   }
 }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { tagError } from "~/utils/error-meta.js";
 
 export type StyleId = `${string}_${string}` & { __brand: "StyleId" };
 
@@ -26,7 +27,9 @@ export async function downloadFigmaImage(
     const fullPath = path.resolve(path.join(localPath, fileName));
     const resolvedLocalPath = path.resolve(localPath);
     if (!fullPath.startsWith(resolvedLocalPath + path.sep)) {
-      throw new Error(`File path escapes target directory: ${fileName}`);
+      tagError(new Error(`File path escapes target directory: ${fileName}`), {
+        category: "invalid_input",
+      });
     }
 
     // Use fetch to download the image
@@ -35,7 +38,9 @@ export async function downloadFigmaImage(
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to download image: ${response.statusText}`);
+      tagError(new Error(`Failed to download image: ${response.statusText}`), {
+        category: "image_download",
+      });
     }
 
     // Create write stream
@@ -44,7 +49,7 @@ export async function downloadFigmaImage(
     // Get the response as a readable stream and pipe it to the file
     const reader = response.body?.getReader();
     if (!reader) {
-      throw new Error("Failed to get response body");
+      tagError(new Error("Failed to get response body"), { category: "image_download" });
     }
 
     return new Promise((resolve, reject) => {
@@ -81,7 +86,7 @@ export async function downloadFigmaImage(
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new Error(`Error downloading image: ${errorMessage}`);
+    throw new Error(`Error downloading image: ${errorMessage}`, { cause: error });
   }
 }
 

--- a/src/utils/error-meta.ts
+++ b/src/utils/error-meta.ts
@@ -23,8 +23,19 @@ export type ErrorPhase =
   | "download"
   | "format_response";
 
+export type ErrorCategory =
+  | "rate_limit"
+  | "auth"
+  | "not_found"
+  | "invalid_input"
+  | "network"
+  | "figma_api"
+  | "image_download"
+  | "internal";
+
 export type ErrorMeta = {
   phase?: ErrorPhase;
+  category?: ErrorCategory;
   http_status?: number;
   network_code?: string;
   fs_code?: string;

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -1,4 +1,4 @@
-import { tagError } from "~/utils/error-meta.js";
+import { tagError, type ErrorCategory } from "~/utils/error-meta.js";
 
 type RequestOptions = RequestInit & {
   /**
@@ -46,6 +46,7 @@ export async function fetchJSON<T extends { status?: number }>(
       );
       tagError(httpError, {
         http_status: response.status,
+        category: httpStatusCategory(response.status),
         is_retryable: RETRYABLE_STATUSES.has(response.status),
       });
     }
@@ -66,7 +67,7 @@ export async function fetchJSON<T extends { status?: number }>(
           `to your proxy URL (e.g. http://proxy:8080).`,
         { cause: error },
       );
-      tagError(wrapped, { network_code: networkCode, is_retryable: true });
+      tagError(wrapped, { network_code: networkCode, category: "network", is_retryable: true });
     }
     throw error;
   }
@@ -77,4 +78,10 @@ function getConnectionErrorCode(error: unknown): string | undefined {
   const cause = (error as { cause?: { code?: string } }).cause;
   if (cause?.code && CONNECTION_ERROR_CODES.has(cause.code)) return cause.code;
   return undefined;
+}
+
+function httpStatusCategory(status: number): ErrorCategory {
+  if (status === 429) return "rate_limit";
+  if (status === 401 || status === 403) return "auth";
+  return "figma_api";
 }

--- a/src/utils/figma-url.ts
+++ b/src/utils/figma-url.ts
@@ -1,3 +1,5 @@
+import { tagError } from "~/utils/error-meta.js";
+
 export interface FigmaUrlParts {
   fileKey: string;
   nodeId: string | undefined;
@@ -9,12 +11,14 @@ export function parseFigmaUrl(input: string): FigmaUrlParts {
   const url = new URL(input);
 
   if (url.hostname !== "figma.com" && !url.hostname.endsWith(".figma.com")) {
-    throw new Error(`Not a Figma URL: ${input}`);
+    tagError(new Error(`Not a Figma URL: ${input}`), { category: "invalid_input" });
   }
 
   const match = url.pathname.match(FIGMA_PATH_PATTERN);
   if (!match) {
-    throw new Error(`Could not extract file key from Figma URL: ${input}`);
+    tagError(new Error(`Could not extract file key from Figma URL: ${input}`), {
+      category: "invalid_input",
+    });
   }
 
   const fileKey = match[2];


### PR DESCRIPTION
## Summary

- When the Figma API returns `null` for a requested node ID (deleted node, stale link), throw a clear error identifying the missing node ID instead of crashing with `Cannot read properties of null (reading 'components')`
- Simplifies `GetFileNodesResponse` parsing to use the single node entry directly rather than iterating, reflecting that we only ever request one node at a time
- Adds `ErrorCategory` type and `error_category` field to telemetry, tagging every throw site so PostHog breakout charts can group errors by kind: `rate_limit`, `auth`, `not_found`, `invalid_input`, `network`, `figma_api`, `image_download`, `internal`
- Fixes `common.ts` discarding the original error's `cause` chain when re-wrapping download errors, so inner error metadata (category, http_status, etc.) now flows through to telemetry

## Test plan

- [ ] Pass a known-invalid node ID to `get_figma_data` and verify the error message is clear and actionable
- [ ] Pass a valid node ID and verify normal behavior is unchanged
- [ ] Trigger errors (bad URL, rate limit, network failure) and verify `error_category` appears in PostHog events