### PR TITLE
fix: canonicalize imageDir boundary checks before download

### DIFF
--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -1,8 +1,8 @@
 import path from "path";
+import fs from "fs";
 import { z } from "zod";
 import { FigmaService } from "../../services/figma.js";
 import { Logger } from "../../utils/logger.js";
-import { canonicalizePath, isWithinDirectory } from "~/utils/common.js";
 import {
   captureDownloadImagesCall,
   captureValidationReject,
@@ -90,6 +90,29 @@ const parameters = {
 
 const parametersSchema = z.object(parameters);
 export type DownloadImagesParams = z.infer<typeof parametersSchema>;
+
+function canonicalizePath(inputPath: string): string {
+  const resolvedPath = path.resolve(inputPath);
+  let existingPath = resolvedPath;
+  const missingSegments: string[] = [];
+
+  while (!fs.existsSync(existingPath)) {
+    const parent = path.dirname(existingPath);
+    if (parent === existingPath) break;
+    missingSegments.unshift(path.basename(existingPath));
+    existingPath = parent;
+  }
+
+  const realExistingPath = fs.realpathSync(existingPath);
+  return missingSegments.length > 0
+    ? path.join(realExistingPath, ...missingSegments)
+    : realExistingPath;
+}
+
+function isWithinDirectory(basePath: string, candidatePath: string): boolean {
+  const relative = path.relative(basePath, candidatePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
 
 async function downloadFigmaImages(
   params: DownloadImagesParams,

--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { z } from "zod";
 import { FigmaService } from "../../services/figma.js";
 import { Logger } from "../../utils/logger.js";
+import { canonicalizePath, isWithinDirectory } from "~/utils/common.js";
 import {
   captureDownloadImagesCall,
   captureValidationReject,
@@ -109,9 +110,9 @@ async function downloadFigmaImages(
     // than in the shared core.
     const baseDir = imageDir ?? process.cwd();
     const resolvedPath = path.resolve(path.join(baseDir, localPath));
-    // Drive roots (e.g. E:\) already end with a separator — avoid doubling it
-    const baseDirPrefix = baseDir.endsWith(path.sep) ? baseDir : baseDir + path.sep;
-    if (resolvedPath !== baseDir && !resolvedPath.startsWith(baseDirPrefix)) {
+    const canonicalBaseDir = canonicalizePath(baseDir);
+    const canonicalResolvedPath = canonicalizePath(resolvedPath);
+    if (!isWithinDirectory(canonicalBaseDir, canonicalResolvedPath)) {
       // Path-traversal rejection happens after schema validation, so the SDK
       // wrapper in mcp/index.ts never sees it. Capture it here as a validation
       // reject so we can track how often LLMs trip over the localPath contract.

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -1,4 +1,6 @@
 import path from "path";
+import fs from "fs";
+import os from "os";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("~/telemetry/index.js", async (importOriginal) => {
@@ -136,6 +138,28 @@ describe("download path validation", () => {
     );
 
     expect(result.isError).toBeUndefined();
+  });
+
+  it("rejects localPath when a symlinked segment escapes imageDir", async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-base-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-outside-"));
+    fs.symlinkSync(outside, path.join(base, "linked"), "dir");
+
+    const result = await downloadFigmaImagesTool.handler(
+      { ...validParams, localPath: "linked" },
+      stubFigmaService,
+      base,
+      "stdio",
+      "api_key",
+      undefined,
+      stubExtra,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("resolves outside the allowed image directory");
+
+    fs.rmSync(base, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   });
 });
 

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -161,6 +161,29 @@ describe("download path validation", () => {
     fs.rmSync(base, { recursive: true, force: true });
     fs.rmSync(outside, { recursive: true, force: true });
   });
+
+  it("rejects localPath when an intermediate symlinked segment escapes imageDir", async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-base-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-outside-"));
+    fs.mkdirSync(path.join(base, "nested"), { recursive: true });
+    fs.symlinkSync(outside, path.join(base, "nested", "linked"), "dir");
+
+    const result = await downloadFigmaImagesTool.handler(
+      { ...validParams, localPath: "nested/linked/assets" },
+      stubFigmaService,
+      base,
+      "stdio",
+      "api_key",
+      undefined,
+      stubExtra,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("resolves outside the allowed image directory");
+
+    fs.rmSync(base, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
 });
 
 describe("downloadFigmaImage filename validation", () => {

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -140,6 +140,24 @@ describe("download path validation", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("accepts a non-existent nested path whose existing prefix stays within imageDir", async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-base-"));
+
+    const result = await downloadFigmaImagesTool.handler(
+      { ...validParams, localPath: "nested/assets/icons" },
+      stubFigmaService,
+      base,
+      "stdio",
+      "api_key",
+      undefined,
+      stubExtra,
+    );
+
+    expect(result.isError).toBeUndefined();
+
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
   it("rejects localPath when a symlinked segment escapes imageDir", async () => {
     const base = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-base-"));
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-outside-"));

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -25,9 +25,8 @@ export async function downloadFigmaImage(
 
     // Build the complete file path and verify it stays within localPath
     const fullPath = path.resolve(path.join(localPath, fileName));
-    const canonicalFullPath = canonicalizePath(fullPath);
-    const canonicalLocalPath = canonicalizePath(localPath);
-    if (!isWithinDirectory(canonicalLocalPath, canonicalFullPath)) {
+    const resolvedLocalPath = path.resolve(localPath);
+    if (!fullPath.startsWith(resolvedLocalPath + path.sep)) {
       tagError(new Error(`File path escapes target directory: ${fileName}`), {
         category: "invalid_input",
       });
@@ -132,34 +131,6 @@ export function removeEmptyKeys<T>(input: T): T {
   }
 
   return result;
-}
-
-/**
- * Resolve a path while following symlinks in the portion that already exists.
- * Missing tail segments are preserved lexically so callers can validate paths
- * before creating new directories or files.
- */
-export function canonicalizePath(inputPath: string): string {
-  const resolvedPath = path.resolve(inputPath);
-  let existingPath = resolvedPath;
-  const missingSegments: string[] = [];
-
-  while (!fs.existsSync(existingPath)) {
-    const parent = path.dirname(existingPath);
-    if (parent === existingPath) break;
-    missingSegments.unshift(path.basename(existingPath));
-    existingPath = parent;
-  }
-
-  const realExistingPath = fs.realpathSync(existingPath);
-  return missingSegments.length > 0
-    ? path.join(realExistingPath, ...missingSegments)
-    : realExistingPath;
-}
-
-export function isWithinDirectory(basePath: string, candidatePath: string): boolean {
-  const relative = path.relative(basePath, candidatePath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 /**

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -25,8 +25,9 @@ export async function downloadFigmaImage(
 
     // Build the complete file path and verify it stays within localPath
     const fullPath = path.resolve(path.join(localPath, fileName));
-    const resolvedLocalPath = path.resolve(localPath);
-    if (!fullPath.startsWith(resolvedLocalPath + path.sep)) {
+    const canonicalFullPath = canonicalizePath(fullPath);
+    const canonicalLocalPath = canonicalizePath(localPath);
+    if (!isWithinDirectory(canonicalLocalPath, canonicalFullPath)) {
       tagError(new Error(`File path escapes target directory: ${fileName}`), {
         category: "invalid_input",
       });
@@ -131,6 +132,34 @@ export function removeEmptyKeys<T>(input: T): T {
   }
 
   return result;
+}
+
+/**
+ * Resolve a path while following symlinks in the portion that already exists.
+ * Missing tail segments are preserved lexically so callers can validate paths
+ * before creating new directories or files.
+ */
+export function canonicalizePath(inputPath: string): string {
+  const resolvedPath = path.resolve(inputPath);
+  let existingPath = resolvedPath;
+  const missingSegments: string[] = [];
+
+  while (!fs.existsSync(existingPath)) {
+    const parent = path.dirname(existingPath);
+    if (parent === existingPath) break;
+    missingSegments.unshift(path.basename(existingPath));
+    existingPath = parent;
+  }
+
+  const realExistingPath = fs.realpathSync(existingPath);
+  return missingSegments.length > 0
+    ? path.join(realExistingPath, ...missingSegments)
+    : realExistingPath;
+}
+
+export function isWithinDirectory(basePath: string, candidatePath: string): boolean {
+  const relative = path.relative(basePath, candidatePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #353

- Canonicalizes existing path segments before checking whether `localPath` stays inside `imageDir`
- Keeps support for non-existent tail segments, so callers can still create new nested directories inside the boundary
- Adds regression coverage for both top-level and nested symlinked segments that previously redirected writes outside the configured image directory

The change stays at the tool edge where `imageDir` is known, which matches the project's existing boundary-validation approach.

## Why this scope

This keeps the fix narrow and aligned with the path-hardening work already shipped in `#297` and `#301`: the public API is unchanged, the validation contract is clearer, and the patch only touches the containment check plus tests.

## Test plan

- [x] `./node_modules/.bin/vitest run src/tests/path-validation.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint src/mcp/tools/download-figma-images-tool.ts src/tests/path-validation.test.ts`
- [ ] Full `pnpm test`
- [ ] Cross-platform symlink validation on Windows
