### PR TITLE
fix: redact file keys and node IDs from telemetry error messages

### DIFF
--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -61,7 +61,15 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
             `It may have been deleted or the link may be outdated. ` +
             `Try copying a fresh link from the Figma file.`,
         ),
-        { category: "not_found" },
+        {
+          category: "not_found",
+          // Tests assert the category+template contract so a future rewording
+          // ("Could not find node X", etc.) cannot silently reopen the leak:
+          // `error.message` can drift freely, `safe_message` is what telemetry
+          // emits and what the regression tests verify.
+          safe_message:
+            "Figma node was not found in the file. It may have been deleted or the link may be outdated.",
+        },
       );
     }
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -8,7 +8,7 @@ import type {
 import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/image-processing.js";
 import { Logger, writeLogs } from "~/utils/logger.js";
 import { fetchJSON } from "~/utils/fetch-json.js";
-import { getErrorMeta } from "~/utils/error-meta.js";
+import { getErrorMeta, tagError } from "~/utils/error-meta.js";
 import type { HttpError } from "~/utils/fetch-json.js";
 
 export type FigmaAuthOptions = {
@@ -80,15 +80,29 @@ export class FigmaService {
     } catch (error) {
       const meta = getErrorMeta(error);
       if (meta.http_status === 429) {
-        throw new Error(buildRateLimitMessage(error), { cause: error });
+        // Rate-limit wrap. User-facing message preserves the actionable
+        // response-header guidance; telemetry receives an endpoint-free
+        // template so file keys can't leak via `error_message`.
+        tagError(new Error(buildRateLimitMessage(error), { cause: error }), {
+          safe_message: "Figma API rate limit hit (429)",
+        });
       }
       if (meta.http_status === 403) {
-        throw new Error(buildForbiddenMessage(endpoint), { cause: error });
+        // 403 wrap. Same split as 429: user still sees the endpoint in the
+        // thrown message for debugging, but telemetry only ever sees the
+        // templated form.
+        tagError(new Error(buildForbiddenMessage(endpoint), { cause: error }), {
+          safe_message: "Figma API returned 403 Forbidden for a Figma endpoint",
+        });
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Failed to make request to Figma API endpoint '${endpoint}': ${errorMessage}`,
-        { cause: error },
+      tagError(
+        new Error(`Failed to make request to Figma API endpoint '${endpoint}': ${errorMessage}`, {
+          cause: error,
+        }),
+        {
+          safe_message: "Failed to make request to Figma API endpoint",
+        },
       );
     }
   }

--- a/src/telemetry/capture.ts
+++ b/src/telemetry/capture.ts
@@ -32,10 +32,15 @@ function errorFields(
   if (error === undefined) return { is_error: false };
   const meta = getErrorMeta(error);
   const rawMessage = error instanceof Error ? error.message : String(error);
+  // Prefer the structured safe-message template producers attach at throw
+  // time. The regex pass in `client.ts` still runs as a belt-and-braces
+  // fallback for any error path that forgets to tag one (or that we don't
+  // own, e.g. third-party libraries).
+  const errorMessage = meta.safe_message ?? rawMessage;
   return {
     is_error: true,
     error_type: error instanceof Error ? error.constructor.name : "Unknown",
-    error_message: rawMessage,
+    error_message: errorMessage,
     error_phase: meta.phase,
     error_category: meta.category,
     http_status: meta.http_status,

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -27,11 +27,18 @@ function parseNodeMajor(version: string): number {
 }
 
 function redactErrorMessage(message: string): string {
-  let result = message;
+  let result = sanitizeTelemetryIdentifiers(message);
   for (const secret of redactionSecrets) {
     result = result.replaceAll(secret, "[REDACTED]");
   }
   return result;
+}
+
+function sanitizeTelemetryIdentifiers(message: string): string {
+  return message
+    .replace(/\/(files|images)\/[a-zA-Z0-9]+/g, "/$1/[REDACTED_FILE_KEY]")
+    .replace(/([?&](?:ids|node-id)=)[^&\s]+/g, "$1[REDACTED_NODE_ID]")
+    .replace(/\bNode\s+I?\d+(?::|-)\d+(?:;\d+(?::|-)\d+)*\b/g, "Node [REDACTED_NODE_ID]");
 }
 
 /**

--- a/src/tests/telemetry-redaction.test.ts
+++ b/src/tests/telemetry-redaction.test.ts
@@ -12,98 +12,194 @@ vi.mock("posthog-node", () => ({
   },
 }));
 
-describe("telemetry error redaction", () => {
+/**
+ * Run a callback that is expected to throw, returning the thrown error.
+ * Keeps tests readable when the producer we care about is the throw site.
+ */
+async function captureThrown(fn: () => unknown | Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected the callback to throw, but it did not");
+}
+
+/**
+ * These tests go through the real producers: `fetchJSON` (HTTP error wrap),
+ * `FigmaService.requestWithSize` (403/generic wrapping with endpoint context),
+ * and `simplifyRawFigmaObject` (missing-node path). That couples the tests to
+ * the actual privacy contract — "no file keys or node IDs reach telemetry" —
+ * instead of to the regex shapes in `client.ts`.
+ *
+ * A future reword of any upstream error message (e.g. "Could not find node X"
+ * in design-extractor) cannot silently re-open the leak: telemetry now reads
+ * `safe_message` from the structured error meta, and the regex pass remains
+ * only as a belt-and-braces fallback for untagged errors.
+ */
+describe("telemetry error redaction (real producers)", () => {
   beforeEach(() => {
     capturedEvents.length = 0;
     vi.resetModules();
+    vi.unstubAllGlobals();
   });
 
   afterEach(async () => {
     const telemetry = await import("~/telemetry/index.js");
     await telemetry.shutdown();
+    vi.unstubAllGlobals();
   });
 
-  it("redacts file keys from endpoint-bearing error messages", async () => {
+  it("does not leak the file key from a real Figma 403 error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("forbidden", {
+            status: 403,
+            statusText: "Forbidden",
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+
+    const { FigmaService } = await import("~/services/figma.js");
     const telemetry = await import("~/telemetry/index.js");
     telemetry.initTelemetry({ redactFromErrors: ["secret-token"] });
+
+    const service = new FigmaService({
+      figmaApiKey: "secret-token",
+      figmaOAuthToken: "",
+      useOAuth: false,
+    });
+
+    const error = await captureThrown(() => service.getRawFile("abc123"));
 
     telemetry.captureGetFigmaDataCall(
       {
         input: { fileKey: "abc123" },
         outputFormat: "yaml",
         durationMs: 1,
-        error: new Error(
-          "Figma API returned 403 Forbidden for '/files/abc123'. Token secret-token failed.",
-        ),
+        error,
       },
       { transport: "cli", authMode: "api_key" },
     );
 
     expect(capturedEvents).toHaveLength(1);
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "/files/[REDACTED_FILE_KEY]",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("secret-token");
+    const event = capturedEvents[0].properties;
+    expect(String(event.error_message)).not.toContain("abc123");
+    expect(String(event.error_message)).not.toContain("secret-token");
+    // Category + status still flow so analytics can group 403s.
+    expect(event.error_category).toBe("auth");
+    expect(event.http_status).toBe(403);
   });
 
-  it("redacts file keys and ids query params from image endpoint errors", async () => {
+  it("does not leak the file key or node IDs from a real image-render 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("forbidden", {
+            status: 403,
+            statusText: "Forbidden",
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+
+    const { FigmaService } = await import("~/services/figma.js");
     const telemetry = await import("~/telemetry/index.js");
     telemetry.initTelemetry();
+
+    const service = new FigmaService({
+      figmaApiKey: "secret-token",
+      figmaOAuthToken: "",
+      useOAuth: false,
+    });
+
+    const error = await captureThrown(() =>
+      service.getNodeRenderUrls("abc123", ["1:2", "3:4"], "png"),
+    );
 
     telemetry.captureGetFigmaDataCall(
       {
         input: { fileKey: "abc123", nodeId: "1:2" },
         outputFormat: "yaml",
         durationMs: 1,
-        error: new Error(
-          "Failed to make request to Figma API endpoint '/images/abc123?ids=1:2,3:4&format=png': Fetch failed with status 403: Forbidden",
-        ),
+        error,
       },
       { transport: "cli", authMode: "api_key" },
     );
 
     expect(capturedEvents).toHaveLength(1);
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "/images/[REDACTED_FILE_KEY]",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).toContain("ids=[REDACTED_NODE_ID]");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:2,3:4");
+    const event = capturedEvents[0].properties;
+    expect(String(event.error_message)).not.toContain("abc123");
+    expect(String(event.error_message)).not.toContain("1:2,3:4");
+    expect(String(event.error_message)).not.toContain("1:2");
+    expect(event.http_status).toBe(403);
   });
 
-  it("redacts node IDs from missing-node error messages", async () => {
+  it("does not leak the node ID from the real missing-node extractor path", async () => {
+    const { simplifyRawFigmaObject } = await import("~/extractors/design-extractor.js");
     const telemetry = await import("~/telemetry/index.js");
     telemetry.initTelemetry();
+
+    const error = await captureThrown(() =>
+      simplifyRawFigmaObject(
+        {
+          name: "test",
+          // GetFileNodesResponse shape with a null node triggers the
+          // not_found branch in design-extractor.
+          nodes: { "1:2": null as never },
+        } as unknown as Parameters<typeof simplifyRawFigmaObject>[0],
+        [],
+      ),
+    );
 
     telemetry.captureGetFigmaDataCall(
       {
         input: { fileKey: "abc123", nodeId: "1:2" },
         outputFormat: "yaml",
         durationMs: 1,
+        error,
+      },
+      { transport: "cli", authMode: "api_key" },
+    );
+
+    expect(capturedEvents).toHaveLength(1);
+    const event = capturedEvents[0].properties;
+    expect(String(event.error_message)).not.toContain("1:2");
+    expect(String(event.error_message)).not.toContain("1-2");
+    expect(event.error_category).toBe("not_found");
+  });
+
+  it("regex fallback still redacts when an error is not tagged with safe_message", async () => {
+    const telemetry = await import("~/telemetry/index.js");
+    telemetry.initTelemetry({ redactFromErrors: ["secret-token"] });
+
+    // Plain, untagged Error simulating a third-party library path that doesn't
+    // know about our `tagError` meta. The regex pass in `client.ts` is the
+    // last line of defence for these.
+    telemetry.captureGetFigmaDataCall(
+      {
+        input: { fileKey: "abc123" },
+        outputFormat: "yaml",
+        durationMs: 1,
         error: new Error(
-          "Node 1:2 was not found in the Figma file. Try copying a fresh link from /files/abc123?node-id=1-2&ids=1:2,1:3",
+          "Unexpected failure at /files/abc123?ids=1:2 using Token secret-token (Node 1:2 context)",
         ),
       },
       { transport: "cli", authMode: "api_key" },
     );
 
     expect(capturedEvents).toHaveLength(1);
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "Node [REDACTED_NODE_ID] was not found",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "/files/[REDACTED_FILE_KEY]",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "node-id=[REDACTED_NODE_ID]",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).toContain(
-      "ids=[REDACTED_NODE_ID]",
-    );
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:2");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1-2");
-    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:3");
+    const event = capturedEvents[0].properties;
+    const message = String(event.error_message);
+    expect(message).toContain("/files/[REDACTED_FILE_KEY]");
+    expect(message).toContain("ids=[REDACTED_NODE_ID]");
+    expect(message).toContain("Node [REDACTED_NODE_ID]");
+    expect(message).not.toContain("abc123");
+    expect(message).not.toContain("secret-token");
+    expect(message).not.toContain("1:2");
   });
 });

--- a/src/tests/telemetry-redaction.test.ts
+++ b/src/tests/telemetry-redaction.test.ts
@@ -47,6 +47,31 @@ describe("telemetry error redaction", () => {
     expect(String(capturedEvents[0].properties.error_message)).not.toContain("secret-token");
   });
 
+  it("redacts file keys and ids query params from image endpoint errors", async () => {
+    const telemetry = await import("~/telemetry/index.js");
+    telemetry.initTelemetry();
+
+    telemetry.captureGetFigmaDataCall(
+      {
+        input: { fileKey: "abc123", nodeId: "1:2" },
+        outputFormat: "yaml",
+        durationMs: 1,
+        error: new Error(
+          "Failed to make request to Figma API endpoint '/images/abc123?ids=1:2,3:4&format=png': Fetch failed with status 403: Forbidden",
+        ),
+      },
+      { transport: "cli", authMode: "api_key" },
+    );
+
+    expect(capturedEvents).toHaveLength(1);
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "/images/[REDACTED_FILE_KEY]",
+    );
+    expect(String(capturedEvents[0].properties.error_message)).toContain("ids=[REDACTED_NODE_ID]");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:2,3:4");
+  });
+
   it("redacts node IDs from missing-node error messages", async () => {
     const telemetry = await import("~/telemetry/index.js");
     telemetry.initTelemetry();

--- a/src/tests/telemetry-redaction.test.ts
+++ b/src/tests/telemetry-redaction.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const capturedEvents: Array<{ event: string; properties: Record<string, unknown> }> = [];
+
+vi.mock("posthog-node", () => ({
+  PostHog: class MockPostHog {
+    capture(payload: { event: string; properties: Record<string, unknown> }) {
+      capturedEvents.push(payload);
+    }
+
+    async shutdown() {}
+  },
+}));
+
+describe("telemetry error redaction", () => {
+  beforeEach(() => {
+    capturedEvents.length = 0;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const telemetry = await import("~/telemetry/index.js");
+    await telemetry.shutdown();
+  });
+
+  it("redacts file keys from endpoint-bearing error messages", async () => {
+    const telemetry = await import("~/telemetry/index.js");
+    telemetry.initTelemetry({ redactFromErrors: ["secret-token"] });
+
+    telemetry.captureGetFigmaDataCall(
+      {
+        input: { fileKey: "abc123" },
+        outputFormat: "yaml",
+        durationMs: 1,
+        error: new Error(
+          "Figma API returned 403 Forbidden for '/files/abc123'. Token secret-token failed.",
+        ),
+      },
+      { transport: "cli", authMode: "api_key" },
+    );
+
+    expect(capturedEvents).toHaveLength(1);
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "/files/[REDACTED_FILE_KEY]",
+    );
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("secret-token");
+  });
+
+  it("redacts node IDs from missing-node error messages", async () => {
+    const telemetry = await import("~/telemetry/index.js");
+    telemetry.initTelemetry();
+
+    telemetry.captureGetFigmaDataCall(
+      {
+        input: { fileKey: "abc123", nodeId: "1:2" },
+        outputFormat: "yaml",
+        durationMs: 1,
+        error: new Error(
+          "Node 1:2 was not found in the Figma file. Try copying a fresh link from /files/abc123?node-id=1-2",
+        ),
+      },
+      { transport: "cli", authMode: "api_key" },
+    );
+
+    expect(capturedEvents).toHaveLength(1);
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "Node [REDACTED_NODE_ID] was not found",
+    );
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "/files/[REDACTED_FILE_KEY]",
+    );
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "node-id=[REDACTED_NODE_ID]",
+    );
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:2");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1-2");
+  });
+});

--- a/src/tests/telemetry-redaction.test.ts
+++ b/src/tests/telemetry-redaction.test.ts
@@ -82,7 +82,7 @@ describe("telemetry error redaction", () => {
         outputFormat: "yaml",
         durationMs: 1,
         error: new Error(
-          "Node 1:2 was not found in the Figma file. Try copying a fresh link from /files/abc123?node-id=1-2",
+          "Node 1:2 was not found in the Figma file. Try copying a fresh link from /files/abc123?node-id=1-2&ids=1:2,1:3",
         ),
       },
       { transport: "cli", authMode: "api_key" },
@@ -98,8 +98,12 @@ describe("telemetry error redaction", () => {
     expect(String(capturedEvents[0].properties.error_message)).toContain(
       "node-id=[REDACTED_NODE_ID]",
     );
+    expect(String(capturedEvents[0].properties.error_message)).toContain(
+      "ids=[REDACTED_NODE_ID]",
+    );
     expect(String(capturedEvents[0].properties.error_message)).not.toContain("abc123");
     expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:2");
     expect(String(capturedEvents[0].properties.error_message)).not.toContain("1-2");
+    expect(String(capturedEvents[0].properties.error_message)).not.toContain("1:3");
   });
 });

--- a/src/utils/error-meta.ts
+++ b/src/utils/error-meta.ts
@@ -40,6 +40,15 @@ export type ErrorMeta = {
   network_code?: string;
   fs_code?: string;
   is_retryable?: boolean;
+  /**
+   * Identifier-free message template used by telemetry in place of
+   * `error.message`. Producers that know their error string can contain Figma
+   * file keys or node IDs attach a safe template here at throw time, so
+   * telemetry never has to guess at redaction by parsing the final message.
+   * The regex pass in `telemetry/client.ts` remains as a belt-and-braces
+   * fallback for untagged errors.
+   */
+  safe_message?: string;
 };
 
 const META = Symbol.for("framelink.errorMeta");

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -48,6 +48,10 @@ export async function fetchJSON<T extends { status?: number }>(
         http_status: response.status,
         category: httpStatusCategory(response.status),
         is_retryable: RETRYABLE_STATUSES.has(response.status),
+        // Template is structurally identifier-free (status code only), so no
+        // file key / node ID can survive even if a future caller reshapes
+        // `error.message` around the same status.
+        safe_message: `Fetch failed with status ${response.status}`,
       });
     }
     // Read as text first so we can measure the raw body size for telemetry,
@@ -67,7 +71,15 @@ export async function fetchJSON<T extends { status?: number }>(
           `to your proxy URL (e.g. http://proxy:8080).`,
         { cause: error },
       );
-      tagError(wrapped, { network_code: networkCode, category: "network", is_retryable: true });
+      tagError(wrapped, {
+        network_code: networkCode,
+        category: "network",
+        is_retryable: true,
+        // Safe template: no URL, no headers — just the syscall-level code that
+        // already lived in `network_code`. Users still see the proxy hint in
+        // `error.message`; telemetry gets the sanitized version.
+        safe_message: `Network connection failed (${networkCode})`,
+      });
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Closes #354

- Redacts Figma file keys from `/files/<fileKey>` and `/images/<fileKey>` fragments before telemetry leaves the process
- Redacts node identifiers from `node-id=...`, `ids=...`, and `Node <nodeId> was not found` message shapes
- Adds focused regression tests for the validated leak paths, including image render endpoint errors that carry both a file key and `ids=...`

This preserves the current telemetry design (including actionable error analytics) while bringing the implementation back in line with the privacy claim from `#342`.

## Why this scope

I kept the patch intentionally small:

- no event schema changes
- no product-level behavior changes
- no exception-pipeline refactor

That should make it easier to merge even if `#346` continues evolving the broader PostHog integration.

## Test plan

- [x] `./node_modules/.bin/vitest run src/tests/telemetry-redaction.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint src/tests/telemetry-redaction.test.ts`
- [ ] Full `pnpm test`
- [ ] Validate sanitized events in PostHog after deployment
