### PR TITLE
fix: stop routing all traffic through EnvHttpProxyAgent by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "js-yaml": "^4.1.1",
     "posthog-node": "^5.29.2",
     "remeda": "^2.20.1",
-    "undici": "^6.24.1",
+    "undici": "^7.25.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^2.20.1
         version: 2.20.1
       undici:
-        specifier: ^6.24.1
-        version: 6.24.1
+        specifier: ^7.25.0
+        version: 7.25.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1777,9 +1777,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
-    engines: {node: '>=18.17'}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3508,7 +3508,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.24.1: {}
+  undici@7.25.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -44,7 +44,8 @@ const argv = cli({
     },
     proxy: {
       type: String,
-      description: "HTTP proxy URL for networks that require a proxy (e.g. http://proxy:8080)",
+      description:
+        "HTTP proxy URL for networks that require a proxy (e.g. http://proxy:8080). Pass 'none' to ignore HTTP_PROXY/HTTPS_PROXY from the environment and connect directly.",
     },
     stdio: {
       type: Boolean,

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,12 @@ const activeConnections = new Set<ActiveConnection>();
  * Start the MCP server in either stdio or HTTP mode.
  */
 export async function startServer(config: ServerConfig): Promise<void> {
-  if (config.proxy) {
+  if (config.proxy === "none") {
+    // Explicit opt-out: caller wants Node's default dispatcher regardless of
+    // what's in HTTP_PROXY/HTTPS_PROXY. Useful when a system-level proxy is
+    // misbehaving for api.figma.com specifically and the user can't easily
+    // unset it (MCP client config, inherited shell env, etc).
+  } else if (config.proxy) {
     setGlobalDispatcher(new ProxyAgent(config.proxy));
     setProxyMode("explicit");
   } else if (hasProxyEnv()) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { Server } from "http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ProxyAgent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { Logger } from "./utils/logger.js";
-import { hasProxyEnv } from "./utils/proxy-env.js";
+import { hasProxyEnv, setProxyMode } from "./utils/proxy-env.js";
 import { createServer } from "./mcp/index.js";
 import type { ServerConfig } from "./config.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -26,6 +26,7 @@ const activeConnections = new Set<ActiveConnection>();
 export async function startServer(config: ServerConfig): Promise<void> {
   if (config.proxy) {
     setGlobalDispatcher(new ProxyAgent(config.proxy));
+    setProxyMode("explicit");
   } else if (hasProxyEnv()) {
     // EnvHttpProxyAgent automatically respects HTTP_PROXY/HTTPS_PROXY/NO_PROXY
     // env vars. We only swap Node's default dispatcher when at least one of
@@ -40,6 +41,7 @@ export async function startServer(config: ServerConfig): Promise<void> {
     process.emitWarning = () => {};
     setGlobalDispatcher(new EnvHttpProxyAgent());
     process.emitWarning = emitWarning;
+    setProxyMode("env");
   }
 
   const telemetryEnabled = telemetry.initTelemetry({

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,9 +25,14 @@ const activeConnections = new Set<ActiveConnection>();
 export async function startServer(config: ServerConfig): Promise<void> {
   if (config.proxy) {
     setGlobalDispatcher(new ProxyAgent(config.proxy));
-  } else {
+  } else if (hasProxyEnv()) {
     // EnvHttpProxyAgent automatically respects HTTP_PROXY/HTTPS_PROXY/NO_PROXY
-    // env vars when present, and falls through to direct connections when absent.
+    // env vars. We only swap Node's default dispatcher when at least one of
+    // these is actually set — otherwise a stale or incidental proxy var in
+    // the user's shell (from a VPN client, old dev setup, etc.) would silently
+    // route Figma API traffic through an intermediary that can return 403.
+    // See issue #358.
+    //
     // Suppress the UNDICI-EHPA experimental warning — the API is stable
     // enough for our use case and the warning is noise for end users.
     const { emitWarning } = process;
@@ -192,4 +197,9 @@ export async function stopHttpServer(): Promise<void> {
     });
     httpServer!.closeAllConnections();
   });
+}
+
+function hasProxyEnv(): boolean {
+  const names = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
+  return names.some((n) => !!process.env[n] || !!process.env[n.toLowerCase()]);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { Server } from "http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ProxyAgent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { Logger } from "./utils/logger.js";
+import { hasProxyEnv } from "./utils/proxy-env.js";
 import { createServer } from "./mcp/index.js";
 import type { ServerConfig } from "./config.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -197,9 +198,4 @@ export async function stopHttpServer(): Promise<void> {
     });
     httpServer!.closeAllConnections();
   });
-}
-
-function hasProxyEnv(): boolean {
-  const names = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
-  return names.some((n) => !!process.env[n] || !!process.env[n.toLowerCase()]);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,28 +24,20 @@ const activeConnections = new Set<ActiveConnection>();
  * Start the MCP server in either stdio or HTTP mode.
  */
 export async function startServer(config: ServerConfig): Promise<void> {
-  if (config.proxy === "none") {
-    // Explicit opt-out: caller wants Node's default dispatcher regardless of
-    // what's in HTTP_PROXY/HTTPS_PROXY. Useful when a system-level proxy is
-    // misbehaving for api.figma.com specifically and the user can't easily
-    // unset it (MCP client config, inherited shell env, etc).
-  } else if (config.proxy) {
+  // Three outcomes: explicit proxy URL → ProxyAgent; no proxy but env vars set
+  // → EnvHttpProxyAgent; otherwise Node's default (includes `--proxy=none`,
+  // which lets users opt out of system-level proxy vars misbehaving for
+  // api.figma.com — see issue #358).
+  //
+  // We deliberately do NOT install EnvHttpProxyAgent when no proxy vars are
+  // present, so a stale or incidental var in the user's shell (VPN client,
+  // old dev setup) can't silently route Figma traffic through an intermediary
+  // that may return 403.
+  if (config.proxy && config.proxy !== "none") {
     setGlobalDispatcher(new ProxyAgent(config.proxy));
     setProxyMode("explicit");
-  } else if (hasProxyEnv()) {
-    // EnvHttpProxyAgent automatically respects HTTP_PROXY/HTTPS_PROXY/NO_PROXY
-    // env vars. We only swap Node's default dispatcher when at least one of
-    // these is actually set — otherwise a stale or incidental proxy var in
-    // the user's shell (from a VPN client, old dev setup, etc.) would silently
-    // route Figma API traffic through an intermediary that can return 403.
-    // See issue #358.
-    //
-    // Suppress the UNDICI-EHPA experimental warning — the API is stable
-    // enough for our use case and the warning is noise for end users.
-    const { emitWarning } = process;
-    process.emitWarning = () => {};
+  } else if (!config.proxy && hasProxyEnv()) {
     setGlobalDispatcher(new EnvHttpProxyAgent());
-    process.emitWarning = emitWarning;
     setProxyMode("env");
   }
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -76,6 +76,7 @@ export class FigmaService {
 
       return await fetchJSON<T & { status?: number }>(`${this.baseUrl}${endpoint}`, {
         headers,
+        redactFromErrorBody: [this.apiKey, this.oauthToken],
       });
     } catch (error) {
       const meta = getErrorMeta(error);

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -84,7 +84,7 @@ export class FigmaService {
         throw new Error(buildRateLimitMessage(error), { cause: error });
       }
       if (meta.http_status === 403) {
-        throw new Error(buildForbiddenMessage(endpoint), { cause: error });
+        throw new Error(buildForbiddenMessage(endpoint, error), { cause: error });
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new Error(
@@ -344,15 +344,21 @@ export class FigmaService {
  *
  * See https://developers.figma.com/docs/rest-api/rate-limits/
  */
-function buildForbiddenMessage(endpoint: string): string {
-  return [
-    `Figma API returned 403 Forbidden for '${endpoint}'.`,
-    "This usually means one of:",
+function buildForbiddenMessage(endpoint: string, error: unknown): string {
+  const body = (error as HttpError)?.responseBody;
+  const parts = [`Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`];
+  if (body) {
+    parts.push(`Response body: ${body}`);
+  }
+  parts.push(
+    "This is typically one of:",
     "- The access token doesn't have permission to this file (it must be owned by or explicitly shared with the token's account)",
     "- The file's share settings don't allow viewers to copy/share/export",
     "- For team/org files, the API token may not have access to that team",
+    "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma — check the response body above for clues",
     "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
-  ].join("\n");
+  );
+  return parts.join("\n");
 }
 
 function buildRateLimitMessage(error: unknown): string {

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -9,6 +9,7 @@ import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/ima
 import { Logger, writeLogs } from "~/utils/logger.js";
 import { fetchJSON } from "~/utils/fetch-json.js";
 import { getErrorMeta } from "~/utils/error-meta.js";
+import { proxyMode } from "~/utils/proxy-env.js";
 import type { HttpError } from "~/utils/fetch-json.js";
 
 export type FigmaAuthOptions = {
@@ -358,6 +359,15 @@ function buildForbiddenMessage(endpoint: string, error: unknown): string {
     "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma — check the response body above for clues",
     "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
   );
+  const mode = proxyMode();
+  if (mode !== "none") {
+    parts.push(
+      "",
+      mode === "explicit"
+        ? "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it or bypass it for this host."
+        : "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com or unset HTTP_PROXY/HTTPS_PROXY.",
+    );
+  }
   return parts.join("\n");
 }
 

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -338,19 +338,15 @@ export class FigmaService {
 }
 
 /**
- * Build a user-facing 429 message from the Figma rate-limit response headers.
- * Figma includes plan tier, seat-level limit type, retry-after, and an upgrade
- * link — all of which let us give targeted guidance instead of a generic
- * "try again later."
- *
- * See https://developers.figma.com/docs/rest-api/rate-limits/
+ * Build a user-facing 403 message. Includes the raw response body (redacted +
+ * truncated by fetchJSON) because corporate proxies/firewalls frequently
+ * reject requests with their own 403 HTML before they ever reach Figma, and
+ * that body is the fastest way for a user to recognize "oh, this is Zscaler."
  */
 function buildForbiddenMessage(endpoint: string, error: unknown): string {
-  const body = (error as HttpError)?.responseBody;
+  const body = (error as HttpError).responseBody;
   const parts = [`Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`];
-  if (body) {
-    parts.push(`Response body: ${body}`);
-  }
+  if (body) parts.push(`Response body: ${body}`);
   parts.push(
     "This is typically one of:",
     "- The access token doesn't have permission to this file (it must be owned by or explicitly shared with the token's account)",
@@ -360,19 +356,30 @@ function buildForbiddenMessage(endpoint: string, error: unknown): string {
     "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
   );
   const mode = proxyMode();
-  if (mode !== "none") {
+  if (mode === "explicit") {
     parts.push(
       "",
-      mode === "explicit"
-        ? "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it, change it to --proxy=none, or bypass it for this host."
-        : "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com, pass --proxy=none, or unset HTTP_PROXY/HTTPS_PROXY.",
+      "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it, change it to --proxy=none, or bypass it for this host.",
+    );
+  } else if (mode === "env") {
+    parts.push(
+      "",
+      "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com, pass --proxy=none, or unset HTTP_PROXY/HTTPS_PROXY.",
     );
   }
   return parts.join("\n");
 }
 
+/**
+ * Build a user-facing 429 message from the Figma rate-limit response headers.
+ * Figma includes plan tier, seat-level limit type, retry-after, and an upgrade
+ * link — all of which let us give targeted guidance instead of a generic
+ * "try again later."
+ *
+ * See https://developers.figma.com/docs/rest-api/rate-limits/
+ */
 function buildRateLimitMessage(error: unknown): string {
-  const headers = (error as HttpError)?.responseHeaders ?? {};
+  const headers = (error as HttpError).responseHeaders ?? {};
   const retryAfter = headers["retry-after"];
   const planTier = headers["x-figma-plan-tier"];
   const limitType = headers["x-figma-rate-limit-type"];

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -364,8 +364,8 @@ function buildForbiddenMessage(endpoint: string, error: unknown): string {
     parts.push(
       "",
       mode === "explicit"
-        ? "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it or bypass it for this host."
-        : "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com or unset HTTP_PROXY/HTTPS_PROXY.",
+        ? "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it, change it to --proxy=none, or bypass it for this host."
+        : "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com, pass --proxy=none, or unset HTTP_PROXY/HTTPS_PROXY.",
     );
   }
   return parts.join("\n");

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { PostHog } from "posthog-node";
+import { hasProxyEnv } from "~/utils/proxy-env.js";
 import type { InitTelemetryOptions } from "./types.js";
 
 // Write-only project key for the Framelink MCP analytics project.
@@ -13,6 +14,13 @@ type CommonProperties = {
   os_platform: NodeJS.Platform;
   nodejs_major: number;
   is_ci: boolean;
+  /**
+   * Whether the host has any of HTTP_PROXY/HTTPS_PROXY/NO_PROXY set. Lets us
+   * correlate failure rates (especially auth-category 403s — see issue #358)
+   * with the presence of proxy configuration in the user's environment,
+   * without logging the proxy URL itself.
+   */
+  proxy_env_set: boolean;
 };
 
 let client: PostHog | undefined;
@@ -72,6 +80,7 @@ export function initTelemetry(opts?: InitTelemetryOptions): boolean {
     os_platform: process.platform,
     nodejs_major: parseNodeMajor(process.versions.node),
     is_ci: Boolean(process.env.CI),
+    proxy_env_set: hasProxyEnv(),
   };
 
   // disableGeoip: false is load-bearing — the Node SDK defaults GeoIP to off,

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { PostHog } from "posthog-node";
-import { hasProxyEnv } from "~/utils/proxy-env.js";
+import { proxyMode, type ProxyMode } from "~/utils/proxy-env.js";
 import type { InitTelemetryOptions } from "./types.js";
 
 // Write-only project key for the Framelink MCP analytics project.
@@ -15,12 +15,15 @@ type CommonProperties = {
   nodejs_major: number;
   is_ci: boolean;
   /**
-   * Whether the host has any of HTTP_PROXY/HTTPS_PROXY/NO_PROXY set. Lets us
-   * correlate failure rates (especially auth-category 403s — see issue #358)
-   * with the presence of proxy configuration in the user's environment,
-   * without logging the proxy URL itself.
+   * Which dispatcher the server installed for outbound fetches:
+   * `none` (Node default), `explicit` (--proxy/FIGMA_PROXY), or `env`
+   * (EnvHttpProxyAgent driven by HTTP_PROXY/HTTPS_PROXY/NO_PROXY).
+   *
+   * Lets us correlate failure rates (especially auth-category 403s — see
+   * issue #358) with the proxy configuration a user was actually running
+   * under, without logging the proxy URL itself.
    */
-  proxy_env_set: boolean;
+  proxy_mode: ProxyMode;
 };
 
 let client: PostHog | undefined;
@@ -80,7 +83,7 @@ export function initTelemetry(opts?: InitTelemetryOptions): boolean {
     os_platform: process.platform,
     nodejs_major: parseNodeMajor(process.versions.node),
     is_ci: Boolean(process.env.CI),
-    proxy_env_set: hasProxyEnv(),
+    proxy_mode: proxyMode(),
   };
 
   // disableGeoip: false is load-bearing — the Node SDK defaults GeoIP to off,

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -47,7 +47,7 @@ export async function fetchJSON<T extends { status?: number }>(
   url: string,
   options: RequestOptions = {},
 ): Promise<{ data: T; rawSize: number }> {
-  const { redactFromErrorBody, ...fetchOptions } = options;
+  const { redactFromErrorBody = [], ...fetchOptions } = options;
   try {
     const response = await fetch(url, fetchOptions);
 
@@ -56,7 +56,7 @@ export async function fetchJSON<T extends { status?: number }>(
       response.headers.forEach((value, key) => {
         responseHeaders[key] = value;
       });
-      const responseBody = await readErrorBody(response, redactFromErrorBody);
+      const responseBody = await readErrorBody(response, redactFromErrorBody.filter(Boolean));
       const bodySuffix = responseBody ? `\nResponse body: ${responseBody}` : "";
       const httpError: HttpError = Object.assign(
         new Error(
@@ -108,11 +108,11 @@ function httpStatusCategory(status: number): ErrorCategory {
 
 async function readErrorBody(
   response: Response,
-  redactSecrets: string[] | undefined,
+  redactSecrets: string[],
 ): Promise<string | undefined> {
-  // Body read can fail if the connection is killed mid-response; that's
-  // fine — we'd rather throw the status/headers we already have than mask
-  // the HTTP error with a body-read error.
+  // Body read can fail if the connection is killed mid-response; we'd rather
+  // surface the status/headers we already have than mask it with a body-read
+  // error.
   let text: string;
   try {
     text = await response.text();
@@ -121,13 +121,10 @@ async function readErrorBody(
   }
   if (!text) return undefined;
 
-  // Collapse whitespace so HTML error pages read as one line when surfaced
-  // in an error message.
+  // Collapse whitespace so HTML error pages read as one line in error messages.
   let result = text.replace(/\s+/g, " ").trim();
-  if (redactSecrets) {
-    for (const secret of redactSecrets) {
-      if (secret) result = result.replaceAll(secret, "[REDACTED]");
-    }
+  for (const secret of redactSecrets) {
+    result = result.replaceAll(secret, "[REDACTED]");
   }
   if (result.length > MAX_ERROR_BODY_CHARS) {
     result = result.slice(0, MAX_ERROR_BODY_CHARS) + "… [truncated]";

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -7,14 +7,25 @@ type RequestOptions = RequestInit & {
    * Avoids complexity of needing to deal with `instanceof Headers`, which is not supported in some environments.
    */
   headers?: Record<string, string>;
+  /**
+   * Secrets to scrub from the response body attached to thrown HTTP errors.
+   * Defense in depth: api.figma.com never echoes credentials, but HTTP
+   * intermediaries (corporate proxies, MITM filters) sometimes mirror
+   * request metadata into error pages.
+   */
+  redactFromErrorBody?: string[];
 };
 
 /**
  * Error thrown on HTTP failures. Carries response headers so callers (e.g.
  * figma.ts) can read rate-limit metadata without needing access to the
- * original Response object.
+ * original Response object, plus the (possibly-truncated, redacted) response
+ * body so callers can distinguish Figma errors from proxy/intermediary errors.
  */
-export type HttpError = Error & { responseHeaders?: Record<string, string> };
+export type HttpError = Error & {
+  responseHeaders?: Record<string, string>;
+  responseBody?: string;
+};
 
 const CONNECTION_ERROR_CODES = new Set([
   "ECONNRESET",
@@ -28,21 +39,30 @@ const CONNECTION_ERROR_CODES = new Set([
 // server-side failures. 4xx other than 429 are caller errors and not retryable.
 const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
+// Cap the attached error body. Corp-firewall HTML blocks can be 50KB+;
+// we only need enough to identify the origin ("Blocked by Zscaler", etc.).
+const MAX_ERROR_BODY_CHARS = 500;
+
 export async function fetchJSON<T extends { status?: number }>(
   url: string,
   options: RequestOptions = {},
 ): Promise<{ data: T; rawSize: number }> {
+  const { redactFromErrorBody, ...fetchOptions } = options;
   try {
-    const response = await fetch(url, options);
+    const response = await fetch(url, fetchOptions);
 
     if (!response.ok) {
       const responseHeaders: Record<string, string> = {};
       response.headers.forEach((value, key) => {
         responseHeaders[key] = value;
       });
+      const responseBody = await readErrorBody(response, redactFromErrorBody);
+      const bodySuffix = responseBody ? `\nResponse body: ${responseBody}` : "";
       const httpError: HttpError = Object.assign(
-        new Error(`Fetch failed with status ${response.status}: ${response.statusText}`),
-        { responseHeaders },
+        new Error(
+          `Fetch failed with status ${response.status}: ${response.statusText}${bodySuffix}`,
+        ),
+        { responseHeaders, responseBody },
       );
       tagError(httpError, {
         http_status: response.status,
@@ -84,4 +104,33 @@ function httpStatusCategory(status: number): ErrorCategory {
   if (status === 429) return "rate_limit";
   if (status === 401 || status === 403) return "auth";
   return "figma_api";
+}
+
+async function readErrorBody(
+  response: Response,
+  redactSecrets: string[] | undefined,
+): Promise<string | undefined> {
+  // Body read can fail if the connection is killed mid-response; that's
+  // fine — we'd rather throw the status/headers we already have than mask
+  // the HTTP error with a body-read error.
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    return undefined;
+  }
+  if (!text) return undefined;
+
+  // Collapse whitespace so HTML error pages read as one line when surfaced
+  // in an error message.
+  let result = text.replace(/\s+/g, " ").trim();
+  if (redactSecrets) {
+    for (const secret of redactSecrets) {
+      if (secret) result = result.replaceAll(secret, "[REDACTED]");
+    }
+  }
+  if (result.length > MAX_ERROR_BODY_CHARS) {
+    result = result.slice(0, MAX_ERROR_BODY_CHARS) + "… [truncated]";
+  }
+  return result;
 }

--- a/src/utils/proxy-env.ts
+++ b/src/utils/proxy-env.ts
@@ -1,24 +1,21 @@
 /**
- * Whether the host environment has any HTTP proxy var set.
- *
- * Single source of truth so `server.ts` (deciding whether to install
- * EnvHttpProxyAgent), `telemetry/client.ts` (reporting the proxy mode
- * dimension), and `figma.ts` (403 error hints) agree on what counts
- * as "proxy env".
- */
-export function hasProxyEnv(): boolean {
-  const names = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
-  return names.some((n) => !!process.env[n] || !!process.env[n.toLowerCase()]);
-}
-
-/**
- * Which dispatcher is installed on the global fetch.
- *
- * `env` mode means EnvHttpProxyAgent is routing: a specific request may
- * still go direct when NO_PROXY matches. Consumers should treat this as
- * configuration state, not as "was this request proxied."
+ * Which dispatcher is installed on the global fetch. `env` means
+ * EnvHttpProxyAgent is routing, but a specific request may still go direct
+ * when NO_PROXY matches — treat this as configuration state, not as
+ * "was this request proxied."
  */
 export type ProxyMode = "none" | "explicit" | "env";
+
+const PROXY_ENV_VARS = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
+
+/**
+ * Whether the host environment has any HTTP proxy var set (case-insensitive).
+ * Shared so server.ts, telemetry/client.ts, and figma.ts agree on what counts
+ * as "proxy env" — don't inline this check.
+ */
+export function hasProxyEnv(): boolean {
+  return PROXY_ENV_VARS.some((n) => process.env[n] || process.env[n.toLowerCase()]);
+}
 
 let currentMode: ProxyMode = "none";
 

--- a/src/utils/proxy-env.ts
+++ b/src/utils/proxy-env.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether the host environment has any HTTP proxy var set.
+ *
+ * Single source of truth so `server.ts` (deciding whether to install
+ * EnvHttpProxyAgent) and `telemetry/client.ts` (reporting the
+ * `proxy_env_set` dimension) agree on what counts as "proxy env".
+ */
+export function hasProxyEnv(): boolean {
+  const names = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
+  return names.some((n) => !!process.env[n] || !!process.env[n.toLowerCase()]);
+}

--- a/src/utils/proxy-env.ts
+++ b/src/utils/proxy-env.ts
@@ -2,10 +2,30 @@
  * Whether the host environment has any HTTP proxy var set.
  *
  * Single source of truth so `server.ts` (deciding whether to install
- * EnvHttpProxyAgent) and `telemetry/client.ts` (reporting the
- * `proxy_env_set` dimension) agree on what counts as "proxy env".
+ * EnvHttpProxyAgent), `telemetry/client.ts` (reporting the proxy mode
+ * dimension), and `figma.ts` (403 error hints) agree on what counts
+ * as "proxy env".
  */
 export function hasProxyEnv(): boolean {
   const names = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"];
   return names.some((n) => !!process.env[n] || !!process.env[n.toLowerCase()]);
+}
+
+/**
+ * Which dispatcher is installed on the global fetch.
+ *
+ * `env` mode means EnvHttpProxyAgent is routing: a specific request may
+ * still go direct when NO_PROXY matches. Consumers should treat this as
+ * configuration state, not as "was this request proxied."
+ */
+export type ProxyMode = "none" | "explicit" | "env";
+
+let currentMode: ProxyMode = "none";
+
+export function setProxyMode(mode: ProxyMode): void {
+  currentMode = mode;
+}
+
+export function proxyMode(): ProxyMode {
+  return currentMode;
 }


### PR DESCRIPTION
Relates to #358.

## What users will see

- Users with no proxy env vars set: we no longer install `EnvHttpProxyAgent` unconditionally at startup. Their `fetch` runs on Node's default dispatcher, as it did before #338. If undici 6.x's empty-state dispatcher was the root cause of #358, this plus the undici 6→7 bump resolves it.
- Users with `HTTPS_PROXY`/`HTTP_PROXY` set — whether legitimately or because a proxy happens to misbehave for `api.figma.com`: routing is unchanged by default, but the 403 message now includes the actual response body (truncated, secrets scrubbed) so a real Figma 403 ("Invalid scope") is distinguishable from a proxy/firewall 403 ("Blocked by Zscaler") at a glance, and points to the right bypass (`NO_PROXY=api.figma.com`, `--proxy=none`, or unsetting `--proxy`/`FIGMA_PROXY` depending on mode).
- New `--proxy=none` (also accepted as `FIGMA_PROXY=none`): explicitly skips both `ProxyAgent` and `EnvHttpProxyAgent`, leaving Node's default dispatcher in place regardless of environment. Reuses the existing flag — no new surface.

## Notes

- Operators and self-hosters: telemetry gains a `proxy_mode: "none" | "explicit" | "env"` dimension on every event so future triage can correlate failure categories with proxy configuration without logging proxy URLs.
- Undici bumped 6.x → 7.x; our `engines.node >=20.20.0` already satisfies 7.x's `>=20.18.1`.