### PR TITLE
fix: surface Figma 403 response body, defer resolution steps to docs

### DIFF
--- a/src/services/errors/forbidden.ts
+++ b/src/services/errors/forbidden.ts
@@ -1,0 +1,58 @@
+import { HttpError } from "~/utils/fetch-json.js";
+import { proxyMode, type ProxyMode } from "~/utils/proxy-env.js";
+
+const FORBIDDEN_CAUSES = [
+  "- The access token is missing required scopes (File content: Read, Dev resources: Read)",
+  "- The access token has been revoked, mistyped, or (for OAuth) expired — PATs don't expire, OAuth tokens do",
+  "- The access token doesn't have permission to this specific file — it must be owned by or shared with the token's account, and for team/org files the account must belong to that team",
+  "- The file's share settings don't allow viewers to copy/share/export",
+  "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma",
+];
+
+const FORBIDDEN_CAUSES_HEADER_WITH_BODY =
+  "Depending on the specific error message above, the issue may be one of the following:";
+const FORBIDDEN_CAUSES_HEADER_WITHOUT_BODY = "The issue is typically one of the following:";
+
+const TROUBLESHOOTING_GUIDE =
+  "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file";
+
+const LLM_INSTRUCTIONS =
+  "Instructions: explain the specific reason from the response body above to the user in plain language and walk them through resolving it.";
+
+const PROXY_HINTS: Record<ProxyMode, string | undefined> = {
+  none: undefined,
+  explicit:
+    "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it, change it to --proxy=none, or bypass it for this host.",
+  env: "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com, pass --proxy=none, or unset HTTP_PROXY/HTTPS_PROXY.",
+};
+
+/**
+ * Build a user-facing 403 message. Figma returns distinct `err` strings for
+ * distinct causes (missing PAT scopes, expired OAuth token, un-exportable
+ * file, etc.) and each has a different fix. We surface the response body
+ * verbatim when we have it and list the common causes it could map to —
+ * rather than string-matching here (fragile as Figma's wording drifts) or
+ * dumping only a canned list (which is often generic for the specific case).
+ * Full per-error resolution steps live in the docs so they can be updated
+ * without a release.
+ */
+export function buildForbiddenMessage(endpoint: string, error: unknown): string {
+  const body = error instanceof HttpError ? error.responseBody : undefined;
+  const proxyHint = PROXY_HINTS[proxyMode()];
+  const causesHeader = body
+    ? FORBIDDEN_CAUSES_HEADER_WITH_BODY
+    : FORBIDDEN_CAUSES_HEADER_WITHOUT_BODY;
+
+  const sections: string[][] = [
+    [
+      `Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`,
+      ...(body ? [`Response body: ${body}`] : []),
+    ],
+    [causesHeader, ...FORBIDDEN_CAUSES],
+    [TROUBLESHOOTING_GUIDE],
+    ...(body ? [[LLM_INSTRUCTIONS]] : []),
+    ...(proxyHint ? [[proxyHint]] : []),
+  ];
+
+  return sections.map((section) => section.join("\n")).join("\n\n");
+}

--- a/src/services/errors/index.ts
+++ b/src/services/errors/index.ts
@@ -1,0 +1,2 @@
+export { buildForbiddenMessage } from "./forbidden.js";
+export { buildRateLimitMessage } from "./rate-limit.js";

--- a/src/services/errors/rate-limit.ts
+++ b/src/services/errors/rate-limit.ts
@@ -1,0 +1,38 @@
+import { HttpError } from "~/utils/fetch-json.js";
+
+/**
+ * Build a user-facing 429 message from the Figma rate-limit response headers.
+ * Figma includes plan tier, seat-level limit type, retry-after, and an upgrade
+ * link — all of which let us give targeted guidance instead of a generic
+ * "try again later."
+ *
+ * See https://developers.figma.com/docs/rest-api/rate-limits/
+ */
+export function buildRateLimitMessage(error: unknown): string {
+  const headers = error instanceof HttpError ? error.responseHeaders : {};
+  const retryAfter = headers["retry-after"];
+  const planTier = headers["x-figma-plan-tier"];
+  const limitType = headers["x-figma-rate-limit-type"];
+  const upgradeLink = headers["x-figma-upgrade-link"];
+
+  let message = "Figma API rate limit hit (429).";
+
+  if (retryAfter) {
+    message += ` Retry after ${retryAfter} seconds.`;
+  }
+
+  if (limitType === "low") {
+    message += " Your Figma seat type (Viewer or Collaborator) has a lower API rate limit.";
+  }
+
+  if (planTier === "starter" || planTier === "student") {
+    message += ` Your ${planTier} plan has limited API access.`;
+  }
+
+  if (upgradeLink) {
+    message += ` Upgrade: ${upgradeLink}`;
+  }
+
+  message += " See https://developers.figma.com/docs/rest-api/rate-limits/";
+  return message;
+}

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -7,9 +7,9 @@ import type {
 } from "@figma/rest-api-spec";
 import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/image-processing.js";
 import { Logger, writeLogs } from "~/utils/logger.js";
-import { fetchJSON, HttpError } from "~/utils/fetch-json.js";
+import { fetchJSON } from "~/utils/fetch-json.js";
 import { getErrorMeta } from "~/utils/error-meta.js";
-import { proxyMode } from "~/utils/proxy-env.js";
+import { buildForbiddenMessage, buildRateLimitMessage } from "./errors/index.js";
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -334,91 +334,4 @@ export class FigmaService {
 
     return result;
   }
-}
-
-/**
- * Build a user-facing 403 message. Figma returns distinct `err` strings for
- * distinct causes (missing PAT scopes, expired OAuth token, un-exportable
- * file, etc.) and each has a different fix. We surface the response body
- * verbatim when we have it and list the common causes it could map to —
- * rather than string-matching here (fragile as Figma's wording drifts) or
- * dumping only a canned list (which is often generic for the specific case).
- * Full per-error resolution steps live in the docs so they can be updated
- * without a release.
- */
-function buildForbiddenMessage(endpoint: string, error: unknown): string {
-  const body = error instanceof HttpError ? error.responseBody : undefined;
-  const parts = [`Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`];
-  if (body) {
-    parts.push(`Response body: ${body}`);
-  }
-  parts.push(
-    "",
-    body
-      ? "Depending on the specific error message above, the issue may be one of the following:"
-      : "The issue is typically one of the following:",
-    "- The access token is missing required scopes (File content: Read, Dev resources: Read)",
-    "- The access token has been revoked, mistyped, or (for OAuth) expired — PATs don't expire, OAuth tokens do",
-    "- The access token doesn't have permission to this specific file — it must be owned by or shared with the token's account, and for team/org files the account must belong to that team",
-    "- The file's share settings don't allow viewers to copy/share/export",
-    "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma",
-    "",
-    "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
-  );
-  if (body) {
-    parts.push(
-      "",
-      "Instructions: explain the specific reason from the response body above to the user in plain language and walk them through resolving it.",
-    );
-  }
-  const mode = proxyMode();
-  if (mode === "explicit") {
-    parts.push(
-      "",
-      "Note: this server is configured to route requests through an explicit proxy (--proxy/FIGMA_PROXY). If the proxy may be the source of the 403, unset it, change it to --proxy=none, or bypass it for this host.",
-    );
-  } else if (mode === "env") {
-    parts.push(
-      "",
-      "Note: this server picked up a proxy from HTTP_PROXY/HTTPS_PROXY in your environment. If the proxy may be the source of the 403, set NO_PROXY=api.figma.com, pass --proxy=none, or unset HTTP_PROXY/HTTPS_PROXY.",
-    );
-  }
-  return parts.join("\n");
-}
-
-/**
- * Build a user-facing 429 message from the Figma rate-limit response headers.
- * Figma includes plan tier, seat-level limit type, retry-after, and an upgrade
- * link — all of which let us give targeted guidance instead of a generic
- * "try again later."
- *
- * See https://developers.figma.com/docs/rest-api/rate-limits/
- */
-function buildRateLimitMessage(error: unknown): string {
-  const headers = error instanceof HttpError ? error.responseHeaders : {};
-  const retryAfter = headers["retry-after"];
-  const planTier = headers["x-figma-plan-tier"];
-  const limitType = headers["x-figma-rate-limit-type"];
-  const upgradeLink = headers["x-figma-upgrade-link"];
-
-  let message = "Figma API rate limit hit (429).";
-
-  if (retryAfter) {
-    message += ` Retry after ${retryAfter} seconds.`;
-  }
-
-  if (limitType === "low") {
-    message += " Your Figma seat type (Viewer or Collaborator) has a lower API rate limit.";
-  }
-
-  if (planTier === "starter" || planTier === "student") {
-    message += ` Your ${planTier} plan has limited API access.`;
-  }
-
-  if (upgradeLink) {
-    message += ` Upgrade: ${upgradeLink}`;
-  }
-
-  message += " See https://developers.figma.com/docs/rest-api/rate-limits/";
-  return message;
 }

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -7,10 +7,9 @@ import type {
 } from "@figma/rest-api-spec";
 import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/image-processing.js";
 import { Logger, writeLogs } from "~/utils/logger.js";
-import { fetchJSON } from "~/utils/fetch-json.js";
+import { fetchJSON, HttpError } from "~/utils/fetch-json.js";
 import { getErrorMeta } from "~/utils/error-meta.js";
 import { proxyMode } from "~/utils/proxy-env.js";
-import type { HttpError } from "~/utils/fetch-json.js";
 
 export type FigmaAuthOptions = {
   figmaApiKey: string;
@@ -77,7 +76,7 @@ export class FigmaService {
 
       return await fetchJSON<T & { status?: number }>(`${this.baseUrl}${endpoint}`, {
         headers,
-        redactFromErrorBody: [this.apiKey, this.oauthToken],
+        redactFromResponseBody: [this.apiKey, this.oauthToken],
       });
     } catch (error) {
       const meta = getErrorMeta(error);
@@ -340,29 +339,36 @@ export class FigmaService {
 /**
  * Build a user-facing 403 message. Figma returns distinct `err` strings for
  * distinct causes (missing PAT scopes, expired OAuth token, un-exportable
- * file, etc.) and each has a different fix. When we have the response body,
- * we surface it verbatim and direct the consuming LLM to act on it — rather
- * than string-matching here (fragile as Figma's wording drifts) or dumping a
- * canned list of guesses (often wrong for the specific case). The generic
- * fallback only runs when the body was unavailable.
+ * file, etc.) and each has a different fix. We surface the response body
+ * verbatim when we have it and list the common causes it could map to —
+ * rather than string-matching here (fragile as Figma's wording drifts) or
+ * dumping only a canned list (which is often generic for the specific case).
+ * Full per-error resolution steps live in the docs so they can be updated
+ * without a release.
  */
 function buildForbiddenMessage(endpoint: string, error: unknown): string {
-  const body = (error as HttpError).responseBody;
+  const body = error instanceof HttpError ? error.responseBody : undefined;
   const parts = [`Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`];
   if (body) {
+    parts.push(`Response body: ${body}`);
+  }
+  parts.push(
+    "",
+    body
+      ? "Depending on the specific error message above, the issue may be one of the following:"
+      : "The issue is typically one of the following:",
+    "- The access token is missing required scopes (File content: Read, Dev resources: Read)",
+    "- The access token has been revoked, mistyped, or (for OAuth) expired — PATs don't expire, OAuth tokens do",
+    "- The access token doesn't have permission to this specific file — it must be owned by or shared with the token's account, and for team/org files the account must belong to that team",
+    "- The file's share settings don't allow viewers to copy/share/export",
+    "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma",
+    "",
+    "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
+  );
+  if (body) {
     parts.push(
-      `Response body: ${body}`,
       "",
-      "Instructions: explain the specific reason from the response body above to the user in plain language and walk them through resolving it. See https://www.framelink.ai/docs/troubleshooting#cannot-access-file for current, per-error resolution steps.",
-    );
-  } else {
-    parts.push(
-      "This is typically one of:",
-      "- The access token doesn't have permission to this file (it must be owned by or explicitly shared with the token's account)",
-      "- The file's share settings don't allow viewers to copy/share/export",
-      "- For team/org files, the API token may not have access to that team",
-      "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma",
-      "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
+      "Instructions: explain the specific reason from the response body above to the user in plain language and walk them through resolving it.",
     );
   }
   const mode = proxyMode();
@@ -389,7 +395,7 @@ function buildForbiddenMessage(endpoint: string, error: unknown): string {
  * See https://developers.figma.com/docs/rest-api/rate-limits/
  */
 function buildRateLimitMessage(error: unknown): string {
-  const headers = (error as HttpError).responseHeaders ?? {};
+  const headers = error instanceof HttpError ? error.responseHeaders : {};
   const retryAfter = headers["retry-after"];
   const planTier = headers["x-figma-plan-tier"];
   const limitType = headers["x-figma-rate-limit-type"];

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -338,23 +338,33 @@ export class FigmaService {
 }
 
 /**
- * Build a user-facing 403 message. Includes the raw response body (redacted +
- * truncated by fetchJSON) because corporate proxies/firewalls frequently
- * reject requests with their own 403 HTML before they ever reach Figma, and
- * that body is the fastest way for a user to recognize "oh, this is Zscaler."
+ * Build a user-facing 403 message. Figma returns distinct `err` strings for
+ * distinct causes (missing PAT scopes, expired OAuth token, un-exportable
+ * file, etc.) and each has a different fix. When we have the response body,
+ * we surface it verbatim and direct the consuming LLM to act on it — rather
+ * than string-matching here (fragile as Figma's wording drifts) or dumping a
+ * canned list of guesses (often wrong for the specific case). The generic
+ * fallback only runs when the body was unavailable.
  */
 function buildForbiddenMessage(endpoint: string, error: unknown): string {
   const body = (error as HttpError).responseBody;
   const parts = [`Request to Figma API endpoint '${endpoint}' returned 403 Forbidden.`];
-  if (body) parts.push(`Response body: ${body}`);
-  parts.push(
-    "This is typically one of:",
-    "- The access token doesn't have permission to this file (it must be owned by or explicitly shared with the token's account)",
-    "- The file's share settings don't allow viewers to copy/share/export",
-    "- For team/org files, the API token may not have access to that team",
-    "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma — check the response body above for clues",
-    "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
-  );
+  if (body) {
+    parts.push(
+      `Response body: ${body}`,
+      "",
+      "Instructions: explain the specific reason from the response body above to the user in plain language and walk them through resolving it. See https://www.framelink.ai/docs/troubleshooting#cannot-access-file for current, per-error resolution steps.",
+    );
+  } else {
+    parts.push(
+      "This is typically one of:",
+      "- The access token doesn't have permission to this file (it must be owned by or explicitly shared with the token's account)",
+      "- The file's share settings don't allow viewers to copy/share/export",
+      "- For team/org files, the API token may not have access to that team",
+      "- An HTTP intermediary (corporate proxy, firewall, VPN) rejected the request before it reached Figma",
+      "Troubleshooting guide: https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
+    );
+  }
   const mode = proxyMode();
   if (mode === "explicit") {
     parts.push(

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -8,24 +8,37 @@ type RequestOptions = RequestInit & {
    */
   headers?: Record<string, string>;
   /**
-   * Secrets to scrub from the response body attached to thrown HTTP errors.
-   * Defense in depth: api.figma.com never echoes credentials, but HTTP
-   * intermediaries (corporate proxies, MITM filters) sometimes mirror
+   * Secrets to scrub from the response body before it's attached to a thrown
+   * HttpError. Defense in depth: api.figma.com never echoes credentials, but
+   * HTTP intermediaries (corporate proxies, MITM filters) sometimes mirror
    * request metadata into error pages.
    */
-  redactFromErrorBody?: string[];
+  redactFromResponseBody?: string[];
 };
 
 /**
- * Error thrown on HTTP failures. Carries response headers so callers (e.g.
- * figma.ts) can read rate-limit metadata without needing access to the
- * original Response object, plus the (possibly-truncated, redacted) response
- * body so callers can distinguish Figma errors from proxy/intermediary errors.
+ * Error thrown on HTTP failures. Carries the response headers so callers can
+ * read rate-limit metadata without needing the original Response object, plus
+ * the (whitespace-collapsed, secret-redacted, truncated) response body so
+ * callers can distinguish Figma errors from proxy/intermediary errors.
+ *
+ * Modeled as a class rather than a structural Error extension so consumers
+ * get a real `instanceof HttpError` check instead of an unsafe cast.
  */
-export type HttpError = Error & {
-  responseHeaders?: Record<string, string>;
-  responseBody?: string;
-};
+export class HttpError extends Error {
+  readonly responseHeaders: Record<string, string>;
+  readonly responseBody: string | undefined;
+
+  constructor(
+    message: string,
+    opts: { responseHeaders: Record<string, string>; responseBody: string | undefined },
+  ) {
+    super(message);
+    this.name = "HttpError";
+    this.responseHeaders = opts.responseHeaders;
+    this.responseBody = opts.responseBody;
+  }
+}
 
 const CONNECTION_ERROR_CODES = new Set([
   "ECONNRESET",
@@ -39,15 +52,15 @@ const CONNECTION_ERROR_CODES = new Set([
 // server-side failures. 4xx other than 429 are caller errors and not retryable.
 const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
-// Cap the attached error body. Corp-firewall HTML blocks can be 50KB+;
+// Cap the attached response body. Corp-firewall HTML blocks can be 50KB+;
 // we only need enough to identify the origin ("Blocked by Zscaler", etc.).
-const MAX_ERROR_BODY_CHARS = 500;
+const MAX_RESPONSE_BODY_CHARS = 500;
 
 export async function fetchJSON<T extends { status?: number }>(
   url: string,
   options: RequestOptions = {},
 ): Promise<{ data: T; rawSize: number }> {
-  const { redactFromErrorBody = [], ...fetchOptions } = options;
+  const { redactFromResponseBody = [], ...fetchOptions } = options;
   try {
     const response = await fetch(url, fetchOptions);
 
@@ -56,12 +69,10 @@ export async function fetchJSON<T extends { status?: number }>(
       response.headers.forEach((value, key) => {
         responseHeaders[key] = value;
       });
-      const responseBody = await readErrorBody(response, redactFromErrorBody.filter(Boolean));
+      const responseBody = await readResponseBody(response, redactFromResponseBody.filter(Boolean));
       const bodySuffix = responseBody ? `\nResponse body: ${responseBody}` : "";
-      const httpError: HttpError = Object.assign(
-        new Error(
-          `Fetch failed with status ${response.status}: ${response.statusText}${bodySuffix}`,
-        ),
+      const httpError = new HttpError(
+        `Fetch failed with status ${response.status}: ${response.statusText}${bodySuffix}`,
         { responseHeaders, responseBody },
       );
       tagError(httpError, {
@@ -106,7 +117,7 @@ function httpStatusCategory(status: number): ErrorCategory {
   return "figma_api";
 }
 
-async function readErrorBody(
+async function readResponseBody(
   response: Response,
   redactSecrets: string[],
 ): Promise<string | undefined> {
@@ -126,8 +137,8 @@ async function readErrorBody(
   for (const secret of redactSecrets) {
     result = result.replaceAll(secret, "[REDACTED]");
   }
-  if (result.length > MAX_ERROR_BODY_CHARS) {
-    result = result.slice(0, MAX_ERROR_BODY_CHARS) + "… [truncated]";
+  if (result.length > MAX_RESPONSE_BODY_CHARS) {
+    result = result.slice(0, MAX_RESPONSE_BODY_CHARS) + "… [truncated]";
   }
   return result;
 }


### PR DESCRIPTION
Follow-up to #359.

## What users will see

- When Figma returns a 403, the MCP tool error now includes Figma's specific reason (e.g. "Invalid scope(s): …", "Token expired", "File not exportable", "Invalid token") verbatim, along with an instruction for the consuming LLM to explain that reason to the user and walk them through fixing it.
- The link in the error points at Framelink's troubleshooting docs, which now have a dedicated subsection per error body with the correct fix for each.
- The old canned "typical causes" list remains only as a fallback for the rare case where the response body couldn't be read.

## Why

We started surfacing response bodies on 403s in #359. With that visibility came the observation that Figma has at least four distinct 403 variants, each with a different fix, and our blanket four-bullet list was often misleading for the specific case. Alternative of string-matching on Figma's `err` text in code is fragile — Figma owns that wording and can change it. Pushing the mapping into docs means it can stay current without a release cycle, and the LLM is plenty capable of reading the body verbatim.

Docs update landed separately on the framelink-site repo `main`.