### PR TITLE
fix(mcp): prevent late progress notifications from crashing stdio clients

### DIFF
--- a/src/mcp/progress.ts
+++ b/src/mcp/progress.ts
@@ -52,6 +52,6 @@ export function startProgressHeartbeat(
 
   return async () => {
     clearInterval(interval);
-    await lastSend?.catch(() => {});
+    await lastSend;
   };
 }

--- a/src/mcp/progress.ts
+++ b/src/mcp/progress.ts
@@ -22,22 +22,27 @@ export async function sendProgress(
 /**
  * Send periodic progress notifications during a long-running operation.
  * Keeps clients with resetTimeoutOnProgress alive during slow I/O like
- * Figma API calls that can take up to ~55 seconds. Returns a stop function
- * that must be called when the operation completes or errors.
+ * Figma API calls that can take up to ~55 seconds. Returns an async stop
+ * function that must be awaited when the operation completes or errors —
+ * it both clears the interval and waits for the most recent in-flight
+ * send so a tick that fired microseconds before stop cannot land on the
+ * wire after the tool's response (which would orphan its progressToken
+ * and crash strict clients — see issue #362).
  */
 export function startProgressHeartbeat(
   extra: ToolExtra,
   message: string | (() => string),
   intervalMs = 3_000,
-): () => void {
+): () => Promise<void> {
   const progressToken = extra._meta?.progressToken;
-  if (progressToken === undefined) return () => {};
+  if (progressToken === undefined) return async () => {};
 
   let tick = 0;
+  let lastSend: Promise<void> | undefined;
   const interval = setInterval(() => {
     tick++;
     const msg = typeof message === "function" ? message() : message;
-    extra
+    lastSend = extra
       .sendNotification({
         method: "notifications/progress",
         params: { progressToken, progress: tick, message: msg },
@@ -45,5 +50,8 @@ export function startProgressHeartbeat(
       .catch(() => clearInterval(interval));
   }, intervalMs);
 
-  return () => clearInterval(interval);
+  return async () => {
+    clearInterval(interval);
+    await lastSend?.catch(() => {});
+  };
 }

--- a/src/mcp/tools/get-figma-data-tool.ts
+++ b/src/mcp/tools/get-figma-data-tool.ts
@@ -60,36 +60,35 @@ async function getFigmaData(
       } ${fileKey}`,
     );
 
-    let stopFetchHeartbeat: (() => void) | undefined;
-    let stopSimplifyHeartbeat: (() => void) | undefined;
+    let stopFetchHeartbeat: (() => Promise<void>) | undefined;
+    let stopSimplifyHeartbeat: (() => Promise<void>) | undefined;
 
     const result = await runGetFigmaData(figmaService, { fileKey, nodeId, depth }, outputFormat, {
       onFetchStart: async () => {
-        await sendProgress(extra, 0, 4, "Fetching design data from Figma API");
+        await sendProgress(extra, 0, 3, "Fetching design data from Figma API");
         stopFetchHeartbeat = startProgressHeartbeat(extra, "Waiting for Figma API response");
       },
-      onFetchComplete: () => {
-        stopFetchHeartbeat?.();
+      onFetchComplete: async () => {
+        await stopFetchHeartbeat?.();
       },
       onSimplifyStart: async (progress) => {
-        await sendProgress(extra, 1, 4, "Fetched design data, simplifying");
+        await sendProgress(extra, 1, 3, "Fetched design data, simplifying");
         stopSimplifyHeartbeat = startProgressHeartbeat(
           extra,
           () => `Simplifying design data (${progress.getNodeCount()} nodes processed)`,
         );
       },
-      onSimplifyComplete: () => {
-        stopSimplifyHeartbeat?.();
+      onSimplifyComplete: async () => {
+        await stopSimplifyHeartbeat?.();
       },
       onSerializeStart: async () => {
-        await sendProgress(extra, 2, 4, "Simplified design, serializing response");
+        await sendProgress(extra, 2, 3, "Simplified design, serializing response");
       },
       onComplete: (outcome) =>
         captureGetFigmaDataCall(outcome, { transport, authMode, clientInfo }),
     });
 
     Logger.log(`Successfully extracted data: ${result.metrics.simplifiedNodeCount} nodes`);
-    await sendProgress(extra, 3, 4, "Serialized, sending response");
     Logger.log("Sending result to client");
 
     return {

--- a/src/services/get-figma-data.ts
+++ b/src/services/get-figma-data.ts
@@ -47,9 +47,9 @@ export type SimplifyProgress = {
 
 export type GetFigmaDataHooks = {
   onFetchStart?: () => void | Promise<void>;
-  onFetchComplete?: () => void;
+  onFetchComplete?: () => void | Promise<void>;
   onSimplifyStart?: (progress: SimplifyProgress) => void | Promise<void>;
-  onSimplifyComplete?: () => void;
+  onSimplifyComplete?: () => void | Promise<void>;
   onSerializeStart?: () => void | Promise<void>;
   /**
    * Fires exactly once per call, after the pipeline completes (success or
@@ -96,7 +96,7 @@ export async function getFigmaData(
     } catch (error) {
       tagError(error, { phase: "fetch" });
     } finally {
-      hooks.onFetchComplete?.();
+      await hooks.onFetchComplete?.();
     }
     const fetchMs = Date.now() - fetchStart;
     const rawApiResponse = rawResult.data;
@@ -114,7 +114,7 @@ export async function getFigmaData(
     } catch (error) {
       tagError(error, { phase: "simplify" });
     } finally {
-      hooks.onSimplifyComplete?.();
+      await hooks.onSimplifyComplete?.();
     }
     const simplifyMs = Date.now() - simplifyStart;
 


### PR DESCRIPTION
Closes #362.

## Summary

Two race conditions could cause a `notifications/progress` for `get_figma_data` to land on the wire after the tool's response on stdio. Strict MCP clients (notably Claude Code's SDK) treat that as a protocol violation and close the transport — every subsequent tool call has to cold-start, which surfaces as "the MCP keeps disconnecting." This affects every release from v0.8.0 through v0.11.0.

The reporter's diagnosis is in #362 and on the money about the symptom; the underlying causes are two:

1. **Redundant post-serialize notification.** The handler emitted `progress: 3, "Serialized, sending response"` immediately before returning. There's nothing in that notification the response itself doesn't already convey one line later, and on stdio it runs flush against the response. Dropped, with remaining steps renumbered to 0/3, 1/3, 2/3.

2. **Heartbeat stop didn't drain in-flight sends.** `startProgressHeartbeat`'s stop function only called `clearInterval` — a tick that fired microseconds before stop could still complete its write *after* the response. The stop function is now async, tracks the latest in-flight `sendNotification` promise, and awaits it before returning. `onFetchComplete` / `onSimplifyComplete` are now `void | Promise<void>` so the service can await the drain in its `finally` blocks.

The reporter's option 2 (fire-and-forget) was rejected because it doesn't fix late delivery — it just stops blocking the handler. Option 3 (explicit flush boundary) is brittle. Dropping the redundant notification + draining the heartbeat removes the race at the source.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (preexisting warnings in untracked `scripts/debug-fetch.ts` unrelated to this PR)
- [x] `pnpm test` — 140 passed, 1 skipped
- [ ] Manual: run several parallel `get_figma_data` calls against Claude Code's stdio transport and confirm no "unknown progress token" disconnects (reporter has the cleanest repro)