### PR TITLE
fix: reject ambiguous localPath inputs in download_figma_images

### DIFF
--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -84,7 +84,7 @@ const parameters = {
   localPath: z
     .string()
     .describe(
-      "The directory to save images in. Provide a path relative to the server's image directory (e.g., 'public/images' or 'assets/icons') using forward slashes. Absolute paths are accepted only if they point inside the image directory. The directory is created if missing.",
+      "The directory to save images in. Provide a path relative to the server's image directory (e.g., 'public/images' or 'assets/icons'). Either separator works. Absolute paths are accepted only if they point inside the image directory. The directory is created if missing.",
     ),
 };
 
@@ -153,7 +153,6 @@ async function downloadFigmaImages(
 
     const imagesList = downloads
       .map(({ result, requestedFileNames }) => {
-        // path.basename, not split("/"), so this works with backslash paths on Windows.
         const fileName = path.basename(result.filePath);
         const dimensions = `${result.finalDimensions.width}x${result.finalDimensions.height}`;
         const cropStatus = result.wasCropped ? " (cropped)" : "";
@@ -210,13 +209,13 @@ function rejectionDetails(
   baseDir: string,
 ): { rule: ResolveLocalPathFailureReason; userMessage: string; telemetryMessage: string } {
   switch (reason) {
-    case "windows_path_on_posix":
+    case "drive_letter_on_posix":
       return {
         rule: reason,
-        telemetryMessage: `Windows-style path on POSIX server: ${localPath}`,
+        telemetryMessage: `Drive-letter path on POSIX server: ${localPath}`,
         userMessage:
-          `Invalid path: "${localPath}" looks like a Windows path (backslash separator or drive letter), but this server is running on POSIX where those aren't path separators. ` +
-          `Use forward slashes only. The server's image directory is "${baseDir}"; pass a path relative to it (e.g., "public/images").`,
+          `Invalid path: "${localPath}" starts with a Windows drive letter, but this server is running on POSIX where drive letters don't exist. ` +
+          `The server's image directory is "${baseDir}"; pass a path relative to it (e.g., "public/images").`,
       };
     case "outside_image_dir": {
       // Leading-slash inputs used to be silently re-interpreted as relative

--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -11,6 +11,7 @@ import {
 } from "~/telemetry/index.js";
 import { downloadFigmaImages as runDownloadFigmaImages } from "../../services/download-figma-images.js";
 import { sendProgress, startProgressHeartbeat, type ToolExtra } from "../progress.js";
+import { resolveLocalPath } from "../../utils/local-path.js";
 
 const parameters = {
   fileKey: z
@@ -83,7 +84,7 @@ const parameters = {
   localPath: z
     .string()
     .describe(
-      "The path to the directory where images should be saved, relative to the project root. If the directory does not exist, it will be created. Use forward slashes for path separators (e.g., 'public/images' or 'assets/icons').",
+      "The directory to save images in. Provide a path relative to the server's image directory (e.g., 'public/images' or 'assets/icons') using forward slashes. Absolute paths are accepted only if they point inside the image directory. The directory is created if missing.",
     ),
 };
 
@@ -102,25 +103,23 @@ async function downloadFigmaImages(
   try {
     const { fileKey, nodes, localPath, pngScale } = parametersSchema.parse(params);
 
-    // Resolve localPath relative to the configured image directory.
-    // path.join (not path.resolve) so a leading "/" is treated as relative, not absolute —
-    // LLMs frequently produce paths like "/public/images" when they mean "public/images".
-    // This is a security boundary tied to server config, so it lives at the edge rather
-    // than in the shared core.
+    // Resolve localPath against the configured image directory. The resolver
+    // accepts relative paths and absolute paths that fall under imageDir; it
+    // rejects absolute paths pointing elsewhere (which would silently miswrite
+    // under the previous join-based logic). See utils/local-path.ts.
     const baseDir = imageDir ?? process.cwd();
-    const resolvedPath = path.resolve(path.join(baseDir, localPath));
-    // Drive roots (e.g. E:\) already end with a separator — avoid doubling it
-    const baseDirPrefix = baseDir.endsWith(path.sep) ? baseDir : baseDir + path.sep;
-    if (resolvedPath !== baseDir && !resolvedPath.startsWith(baseDirPrefix)) {
+    const resolution = resolveLocalPath(localPath, baseDir);
+    if (!resolution.ok) {
       // Path-traversal rejection happens after schema validation, so the SDK
       // wrapper in mcp/index.ts never sees it. Capture it here as a validation
       // reject so we can track how often LLMs trip over the localPath contract.
+      const ruleAndMessage = rejectionDetails(resolution.reason, localPath, baseDir);
       captureValidationReject(
         {
           tool: "download_figma_images",
           field: "localPath",
-          rule: "path_traversal",
-          message: `Path resolves outside allowed image directory: ${localPath}`,
+          rule: ruleAndMessage.rule,
+          message: ruleAndMessage.telemetryMessage,
         },
         { transport, authMode, clientInfo },
       );
@@ -129,11 +128,12 @@ async function downloadFigmaImages(
         content: [
           {
             type: "text" as const,
-            text: `Invalid path: "${localPath}" resolves outside the allowed image directory. The server's image directory is "${baseDir}". Provide a path relative to this directory (e.g., "public/images" or "assets/icons").`,
+            text: ruleAndMessage.userMessage,
           },
         ],
       };
     }
+    const resolvedPath = resolution.resolvedPath;
 
     await sendProgress(extra, 0, 3, "Resolving image downloads");
 
@@ -158,7 +158,8 @@ async function downloadFigmaImages(
 
     const imagesList = downloads
       .map(({ result, requestedFileNames }) => {
-        const fileName = result.filePath.split("/").pop() || result.filePath;
+        // path.basename, not split("/"), so this works with backslash paths on Windows.
+        const fileName = path.basename(result.filePath);
         const dimensions = `${result.finalDimensions.width}x${result.finalDimensions.height}`;
         const cropStatus = result.wasCropped ? " (cropped)" : "";
 
@@ -179,7 +180,12 @@ async function downloadFigmaImages(
       content: [
         {
           type: "text" as const,
-          text: `Downloaded ${successCount} images:\n${imagesList}`,
+          // Echo the absolute resolved path so callers can immediately verify
+          // where files landed. If imageDir defaulted to a server cwd that
+          // doesn't match the user's project, this surfaces the mismatch
+          // instead of letting it look like a successful no-op. Code-fenced
+          // so markdown-rendering clients don't fight separator characters.
+          text: `Downloaded ${successCount} images to \`${resolvedPath}\`:\n${imagesList}`,
         },
       ],
     };
@@ -201,6 +207,40 @@ async function downloadFigmaImages(
 function getDescription(imageDir?: string) {
   const baseDir = imageDir ?? process.cwd();
   return `Download SVG and PNG images used in a Figma file based on the IDs of image or icon nodes. Images will be saved relative to the server's image directory: ${baseDir}`;
+}
+
+type RejectionDetails = { rule: string; userMessage: string; telemetryMessage: string };
+
+function rejectionDetails(
+  reason: "outside_image_dir" | "windows_path_on_posix",
+  localPath: string,
+  baseDir: string,
+): RejectionDetails {
+  if (reason === "windows_path_on_posix") {
+    return {
+      rule: "windows_path_on_posix",
+      telemetryMessage: `Windows-style path on POSIX server: ${localPath}`,
+      userMessage:
+        `Invalid path: "${localPath}" looks like a Windows path (backslash separator or drive letter), but this server is running on POSIX where those aren't path separators. ` +
+        `Use forward slashes only. The server's image directory is "${baseDir}"; pass a path relative to it (e.g., "public/images").`,
+    };
+  }
+
+  // Leading-slash inputs used to be silently re-interpreted as relative under
+  // the old path.join hack. They now reject; spell out the retry so an LLM
+  // doesn't have to guess that "/public/images" should have been "public/images".
+  const leadingSlashHint = /^[/\\]/.test(localPath)
+    ? ` If you meant a directory inside the image directory, drop the leading slash (e.g., use "${localPath.replace(/^[/\\]+/, "")}").`
+    : "";
+
+  return {
+    rule: "outside_image_dir",
+    telemetryMessage: `Path resolves outside allowed image directory: ${localPath}`,
+    userMessage:
+      `Invalid path: "${localPath}" resolves outside the allowed image directory. ` +
+      `The server's image directory is "${baseDir}". Provide a path relative to this directory (e.g., "public/images" or "assets/icons").` +
+      leadingSlashHint,
+  };
 }
 
 // Export tool configuration

--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -11,7 +11,7 @@ import {
 } from "~/telemetry/index.js";
 import { downloadFigmaImages as runDownloadFigmaImages } from "../../services/download-figma-images.js";
 import { sendProgress, startProgressHeartbeat, type ToolExtra } from "../progress.js";
-import { resolveLocalPath } from "../../utils/local-path.js";
+import { resolveLocalPath, type ResolveLocalPathFailureReason } from "../../utils/local-path.js";
 
 const parameters = {
   fileKey: z
@@ -113,24 +113,19 @@ async function downloadFigmaImages(
       // Path-traversal rejection happens after schema validation, so the SDK
       // wrapper in mcp/index.ts never sees it. Capture it here as a validation
       // reject so we can track how often LLMs trip over the localPath contract.
-      const ruleAndMessage = rejectionDetails(resolution.reason, localPath, baseDir);
+      const details = rejectionDetails(resolution.reason, localPath, baseDir);
       captureValidationReject(
         {
           tool: "download_figma_images",
           field: "localPath",
-          rule: ruleAndMessage.rule,
-          message: ruleAndMessage.telemetryMessage,
+          rule: details.rule,
+          message: details.telemetryMessage,
         },
         { transport, authMode, clientInfo },
       );
       return {
         isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: ruleAndMessage.userMessage,
-          },
-        ],
+        content: [{ type: "text" as const, text: details.userMessage }],
       };
     }
     const resolvedPath = resolution.resolvedPath;
@@ -209,38 +204,38 @@ function getDescription(imageDir?: string) {
   return `Download SVG and PNG images used in a Figma file based on the IDs of image or icon nodes. Images will be saved relative to the server's image directory: ${baseDir}`;
 }
 
-type RejectionDetails = { rule: string; userMessage: string; telemetryMessage: string };
-
 function rejectionDetails(
-  reason: "outside_image_dir" | "windows_path_on_posix",
+  reason: ResolveLocalPathFailureReason,
   localPath: string,
   baseDir: string,
-): RejectionDetails {
-  if (reason === "windows_path_on_posix") {
-    return {
-      rule: "windows_path_on_posix",
-      telemetryMessage: `Windows-style path on POSIX server: ${localPath}`,
-      userMessage:
-        `Invalid path: "${localPath}" looks like a Windows path (backslash separator or drive letter), but this server is running on POSIX where those aren't path separators. ` +
-        `Use forward slashes only. The server's image directory is "${baseDir}"; pass a path relative to it (e.g., "public/images").`,
-    };
+): { rule: ResolveLocalPathFailureReason; userMessage: string; telemetryMessage: string } {
+  switch (reason) {
+    case "windows_path_on_posix":
+      return {
+        rule: reason,
+        telemetryMessage: `Windows-style path on POSIX server: ${localPath}`,
+        userMessage:
+          `Invalid path: "${localPath}" looks like a Windows path (backslash separator or drive letter), but this server is running on POSIX where those aren't path separators. ` +
+          `Use forward slashes only. The server's image directory is "${baseDir}"; pass a path relative to it (e.g., "public/images").`,
+      };
+    case "outside_image_dir": {
+      // Leading-slash inputs used to be silently re-interpreted as relative
+      // under the old path.join hack. They now reject; spell out the retry so
+      // an LLM doesn't have to guess that "/public/images" should have been
+      // "public/images".
+      const leadingSlashHint = /^[/\\]/.test(localPath)
+        ? ` If you meant a directory inside the image directory, drop the leading slash (e.g., use "${localPath.replace(/^[/\\]+/, "")}").`
+        : "";
+      return {
+        rule: reason,
+        telemetryMessage: `Path resolves outside allowed image directory: ${localPath}`,
+        userMessage:
+          `Invalid path: "${localPath}" resolves outside the allowed image directory. ` +
+          `The server's image directory is "${baseDir}". Provide a path relative to this directory (e.g., "public/images" or "assets/icons").` +
+          leadingSlashHint,
+      };
+    }
   }
-
-  // Leading-slash inputs used to be silently re-interpreted as relative under
-  // the old path.join hack. They now reject; spell out the retry so an LLM
-  // doesn't have to guess that "/public/images" should have been "public/images".
-  const leadingSlashHint = /^[/\\]/.test(localPath)
-    ? ` If you meant a directory inside the image directory, drop the leading slash (e.g., use "${localPath.replace(/^[/\\]+/, "")}").`
-    : "";
-
-  return {
-    rule: "outside_image_dir",
-    telemetryMessage: `Path resolves outside allowed image directory: ${localPath}`,
-    userMessage:
-      `Invalid path: "${localPath}" resolves outside the allowed image directory. ` +
-      `The server's image directory is "${baseDir}". Provide a path relative to this directory (e.g., "public/images" or "assets/icons").` +
-      leadingSlashHint,
-  };
 }
 
 // Export tool configuration

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,9 @@ export async function startServer(config: ServerConfig): Promise<void> {
     // MCP clients spawn stdio servers with whatever cwd they were started in,
     // which is rarely the user's project root. Warn so a missing --image-dir
     // doesn't silently send images to e.g. the client's install directory.
-    if (config.configSources.imageDir === "default") {
+    // Gated on !skipImageDownloads — without the download tool the warning
+    // is misleading.
+    if (config.configSources.imageDir === "default" && !config.skipImageDownloads) {
       process.stderr.write(
         `Warning: --image-dir not set; download_figma_images will save under the server's cwd (${config.imageDir}). ` +
           `MCP clients often launch the server outside your project root — set IMAGE_DIR or pass --image-dir to make this explicit.\n`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,6 +63,15 @@ export async function startServer(config: ServerConfig): Promise<void> {
   };
 
   if (config.isStdioMode) {
+    // MCP clients spawn stdio servers with whatever cwd they were started in,
+    // which is rarely the user's project root. Warn so a missing --image-dir
+    // doesn't silently send images to e.g. the client's install directory.
+    if (config.configSources.imageDir === "default") {
+      process.stderr.write(
+        `Warning: --image-dir not set; download_figma_images will save under the server's cwd (${config.imageDir}). ` +
+          `MCP clients often launch the server outside your project root — set IMAGE_DIR or pass --image-dir to make this explicit.\n`,
+      );
+    }
     const server = createServer(config.auth, serverOptions);
     const transport = new StdioServerTransport();
     await server.connect(transport);

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -157,24 +157,24 @@ describe("resolveLocalPath", () => {
       expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
     });
 
-    it("rejects backslash paths because backslashes aren't separators on POSIX", () => {
+    it("rejects backslash drive-letter paths on POSIX", () => {
       const result = resolveLocalPath("C:\\Users\\xl\\Desktop\\figma\\public", base, posix);
-      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+      expect(result).toEqual({ ok: false, reason: "drive_letter_on_posix" });
     });
 
     it("rejects forward-slash drive-letter paths on POSIX", () => {
       // path.posix.isAbsolute("C:/Users/...") returns false, so without an
       // explicit check this would resolve to "<base>/C:/Users/..." and miswrite.
       const result = resolveLocalPath("C:/Users/xl/Desktop/figma/public", base, posix);
-      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+      expect(result).toEqual({ ok: false, reason: "drive_letter_on_posix" });
     });
 
-    it("rejects relative paths with backslashes on POSIX", () => {
-      // Without the guard, path.posix.resolve("/home/user/project", "local\\root")
-      // produces "/home/user/project/local\root" — one literal directory
-      // named "local\root". Same silent-miswrite class as the absolute case.
-      const result = resolveLocalPath("local\\root", base, posix);
-      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+    it("normalizes backslashes in relative paths to forward slashes on POSIX", () => {
+      // LLMs frequently send Windows-style separators regardless of host OS.
+      // Drive-letter paths still reject (above) — only pure separator
+      // mismatches normalize.
+      const result = resolveLocalPath("local\\nested\\dir", base, posix);
+      expect(result).toEqual({ ok: true, resolvedPath: "/project/root/local/nested/dir" });
     });
   });
 

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -168,6 +168,14 @@ describe("resolveLocalPath", () => {
       const result = resolveLocalPath("C:/Users/xl/Desktop/figma/public", base, posix);
       expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
     });
+
+    it("rejects relative paths with backslashes on POSIX", () => {
+      // Without the guard, path.posix.resolve("/home/user/project", "local\\root")
+      // produces "/home/user/project/local\root" — one literal directory
+      // named "local\root". Same silent-miswrite class as the absolute case.
+      const result = resolveLocalPath("local\\root", base, posix);
+      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+    });
   });
 
   describe("with Windows semantics (path.win32)", () => {
@@ -197,6 +205,17 @@ describe("resolveLocalPath", () => {
       expect(result).toEqual({
         ok: true,
         resolvedPath: "C:\\Users\\xl\\Desktop\\figma\\public\\images",
+      });
+    });
+
+    it("normalizes forward slashes from the LLM into Windows separators", () => {
+      // LLMs frequently emit forward slashes regardless of host OS.
+      // path.win32.resolve normalizes them — verify the joined path is
+      // backslash-canonical and lands inside base.
+      const result = resolveLocalPath("public/images/icons", base, win32);
+      expect(result).toEqual({
+        ok: true,
+        resolvedPath: "C:\\Users\\xl\\Desktop\\figma\\public\\images\\icons",
       });
     });
 

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -11,6 +11,7 @@ vi.mock("~/telemetry/index.js", async (importOriginal) => {
 
 import { downloadFigmaImagesTool } from "~/mcp/tools/download-figma-images-tool.js";
 import { downloadFigmaImage } from "~/utils/common.js";
+import { resolveLocalPath, isWithin } from "~/utils/local-path.js";
 import type { ToolExtra } from "~/mcp/progress.js";
 import * as telemetry from "~/telemetry/index.js";
 
@@ -29,8 +30,8 @@ const validParams = {
   pngScale: 2,
 };
 
-describe("download path validation", () => {
-  const imageDir = "/project/root";
+describe("download path validation (handler)", () => {
+  const imageDir = path.resolve("/project/root");
 
   beforeEach(() => {
     vi.mocked(telemetry.captureValidationReject).mockClear();
@@ -47,16 +48,14 @@ describe("download path validation", () => {
       stubExtra,
     );
 
-    // The handler still returns the existing user-facing error
     expect(result.isError).toBe(true);
 
-    // And the rejection is recorded with structured field/rule
     const captureSpy = vi.mocked(telemetry.captureValidationReject);
     expect(captureSpy).toHaveBeenCalledOnce();
     const [input, context] = captureSpy.mock.calls[0];
     expect(input.tool).toBe("download_figma_images");
     expect(input.field).toBe("localPath");
-    expect(input.rule).toBe("path_traversal");
+    expect(input.rule).toBe("outside_image_dir");
     expect(context.transport).toBe("stdio");
     expect(context.authMode).toBe("api_key");
   });
@@ -77,9 +76,9 @@ describe("download path validation", () => {
     expect(result.content[0].text).toContain(imageDir);
   });
 
-  it("rejects traversal with leading slash", async () => {
+  it("hints at the relative form when a leading slash takes the path outside imageDir", async () => {
     const result = await downloadFigmaImagesTool.handler(
-      { ...validParams, localPath: "/../../etc" },
+      { ...validParams, localPath: "/some/elsewhere" },
       stubFigmaService,
       imageDir,
       "stdio",
@@ -89,7 +88,8 @@ describe("download path validation", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("resolves outside the allowed image directory");
+    expect(result.content[0].text).toContain("drop the leading slash");
+    expect(result.content[0].text).toContain('"some/elsewhere"');
   });
 
   it("accepts valid relative path within imageDir", async () => {
@@ -107,9 +107,9 @@ describe("download path validation", () => {
   });
 
   it("accepts valid path when imageDir is a drive root", async () => {
-    // Windows drive roots (E:\, D:\) already end with a separator.
-    // path.resolve on posix treats this as a regular directory, which is fine
-    // — the logic under test is the prefix check, not actual Windows I/O.
+    // Drive roots already end with a separator. The unified containment check
+    // uses path.relative, so the trailing separator no longer causes false
+    // rejection (the previous startsWith(base + sep) check did).
     const driveRoot = path.resolve("/");
     const result = await downloadFigmaImagesTool.handler(
       { ...validParams, localPath: "project/src/static/images/test" },
@@ -123,19 +123,118 @@ describe("download path validation", () => {
 
     expect(result.isError).toBeUndefined();
   });
+});
 
-  it("accepts path with leading slash as relative", async () => {
-    const result = await downloadFigmaImagesTool.handler(
-      { ...validParams, localPath: "/public/images" },
-      stubFigmaService,
-      imageDir,
-      "stdio",
-      "api_key",
-      undefined,
-      stubExtra,
-    );
+describe("resolveLocalPath", () => {
+  describe("with POSIX semantics (path.posix)", () => {
+    const base = "/project/root";
+    const posix = path.posix;
 
-    expect(result.isError).toBeUndefined();
+    it("resolves a relative path under base", () => {
+      const result = resolveLocalPath("public/images", base, posix);
+      expect(result).toEqual({ ok: true, resolvedPath: "/project/root/public/images" });
+    });
+
+    it("rejects a relative path that traverses out", () => {
+      const result = resolveLocalPath("../etc", base, posix);
+      expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
+    });
+
+    it("accepts an absolute path inside base", () => {
+      const inside = "/project/root/public/images";
+      const result = resolveLocalPath(inside, base, posix);
+      expect(result).toEqual({ ok: true, resolvedPath: inside });
+    });
+
+    it("rejects an absolute path outside base", () => {
+      const result = resolveLocalPath("/some/other/place", base, posix);
+      expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
+    });
+
+    it("rejects a leading-slash path that would have doubled under the legacy join hack", () => {
+      // Used to be silently accepted as "<base>/Users/xl/Desktop/figma/public/images".
+      const result = resolveLocalPath("/Users/xl/Desktop/figma/public/images", base, posix);
+      expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
+    });
+
+    it("rejects backslash paths because backslashes aren't separators on POSIX", () => {
+      const result = resolveLocalPath("C:\\Users\\xl\\Desktop\\figma\\public", base, posix);
+      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+    });
+
+    it("rejects forward-slash drive-letter paths on POSIX", () => {
+      // path.posix.isAbsolute("C:/Users/...") returns false, so without an
+      // explicit check this would resolve to "<base>/C:/Users/..." and miswrite.
+      const result = resolveLocalPath("C:/Users/xl/Desktop/figma/public", base, posix);
+      expect(result).toEqual({ ok: false, reason: "windows_path_on_posix" });
+    });
+  });
+
+  describe("with Windows semantics (path.win32)", () => {
+    const base = "C:\\Users\\xl\\Desktop\\figma";
+    const win32 = path.win32;
+
+    it("accepts an absolute Windows path inside base", () => {
+      const inside = "C:\\Users\\xl\\Desktop\\figma\\public\\figma-assets\\retry-final";
+      const result = resolveLocalPath(inside, base, win32);
+      expect(result).toEqual({ ok: true, resolvedPath: inside });
+    });
+
+    it("rejects an absolute Windows path on a different drive", () => {
+      const result = resolveLocalPath("D:\\elsewhere\\images", base, win32);
+      expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
+    });
+
+    // Note on the "LLM stripped the drive letter" scenario from issue #364:
+    // path.win32.resolve("/Users/...") drive-roots the path on the runtime's
+    // *current* Windows drive, which doesn't exist on POSIX hosts running
+    // path.win32. So that specific scenario can't be deterministically
+    // unit-tested without a Windows runner. The drive-letter-inside-base
+    // test below covers the primary issue #364 input shape.
+
+    it("accepts a relative path under base", () => {
+      const result = resolveLocalPath("public\\images", base, win32);
+      expect(result).toEqual({
+        ok: true,
+        resolvedPath: "C:\\Users\\xl\\Desktop\\figma\\public\\images",
+      });
+    });
+
+    it("rejects '..' traversal", () => {
+      const result = resolveLocalPath("..\\..\\Windows\\System32", base, win32);
+      expect(result).toEqual({ ok: false, reason: "outside_image_dir" });
+    });
+
+    it("does not apply the POSIX backslash rule", () => {
+      // On Windows backslashes are valid separators, so this is just a
+      // relative path (assuming it's within base).
+      const result = resolveLocalPath("public\\nested\\images", base, win32);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("isWithin (containment helper)", () => {
+    it("treats base itself as within", () => {
+      expect(isWithin("/project/root", "/project/root", path.posix)).toBe(true);
+    });
+
+    it("accepts descendants", () => {
+      expect(isWithin("/project/root", "/project/root/public/images", path.posix)).toBe(true);
+    });
+
+    it("rejects siblings", () => {
+      expect(isWithin("/project/root", "/project/sibling", path.posix)).toBe(false);
+    });
+
+    it("rejects ancestors", () => {
+      expect(isWithin("/project/root", "/project", path.posix)).toBe(false);
+    });
+
+    it("works for Windows drive roots without double-counting separators", () => {
+      // The previous startsWith(base + sep) check would reject this because
+      // "C:\\" + "\\" produces "C:\\\\" which doesn't prefix "C:\\public".
+      expect(isWithin("C:\\", "C:\\public\\images", path.win32)).toBe(true);
+    });
   });
 });
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { tagError } from "~/utils/error-meta.js";
+import { isWithin } from "~/utils/local-path.js";
 
 export type StyleId = `${string}_${string}` & { __brand: "StyleId" };
 
@@ -23,10 +24,12 @@ export async function downloadFigmaImage(
       fs.mkdirSync(localPath, { recursive: true });
     }
 
-    // Build the complete file path and verify it stays within localPath
+    // Build the complete file path and verify it stays within localPath.
+    // isWithin uses path.relative — correct for drive roots where
+    // startsWith(localPath + path.sep) would double-count the trailing
+    // separator and falsely reject valid paths.
     const fullPath = path.resolve(path.join(localPath, fileName));
-    const resolvedLocalPath = path.resolve(localPath);
-    if (!fullPath.startsWith(resolvedLocalPath + path.sep)) {
+    if (!isWithin(localPath, fullPath)) {
       tagError(new Error(`File path escapes target directory: ${fileName}`), {
         category: "invalid_input",
       });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -24,10 +24,6 @@ export async function downloadFigmaImage(
       fs.mkdirSync(localPath, { recursive: true });
     }
 
-    // Build the complete file path and verify it stays within localPath.
-    // isWithin uses path.relative — correct for drive roots where
-    // startsWith(localPath + path.sep) would double-count the trailing
-    // separator and falsely reject valid paths.
     const fullPath = path.resolve(path.join(localPath, fileName));
     if (!isWithin(localPath, fullPath)) {
       tagError(new Error(`File path escapes target directory: ${fileName}`), {

--- a/src/utils/local-path.ts
+++ b/src/utils/local-path.ts
@@ -1,0 +1,87 @@
+import path from "path";
+
+export type ResolveLocalPathSuccess = { ok: true; resolvedPath: string };
+export type ResolveLocalPathFailure = {
+  ok: false;
+  reason: "outside_image_dir" | "windows_path_on_posix";
+};
+export type ResolveLocalPathResult = ResolveLocalPathSuccess | ResolveLocalPathFailure;
+
+/**
+ * Subset of the `path` module we actually use. Both `path.posix` and
+ * `path.win32` satisfy this shape, so callers (mostly tests) can exercise
+ * cross-platform behavior on a single host.
+ */
+export type PathImpl = Pick<typeof path, "sep" | "resolve" | "isAbsolute" | "relative">;
+
+/**
+ * Resolve a user-supplied path against an allowed base directory, accepting
+ * absolute inputs only when they lexically resolve inside the base.
+ *
+ * The previous implementation used `path.join(base, raw)` so that a leading
+ * slash from the LLM ("/public/images") would be silently treated as a
+ * relative path. That hack hid a class of cross-OS bugs: an absolute Windows
+ * path mangled by the LLM into POSIX shape (e.g. drive letter stripped) was
+ * also "silently treated as relative," concatenated onto the base, and
+ * resulted in a doubled-up directory structure under imageDir. The tool
+ * reported success and the file was never where the user expected.
+ *
+ * This resolver makes ambiguous inputs loud:
+ *   - On POSIX servers, backslashes are not separators and drive letters
+ *     ("C:/...") are not recognized as absolute. Either form would otherwise
+ *     resolve to a literal "C:" directory under the base. Reject both.
+ *   - Absolute paths must lexically resolve inside the base directory.
+ *     Naturally accepts "user pasted a full path that happens to be inside
+ *     the project" while rejecting absolute paths pointing elsewhere.
+ *   - Containment is computed via path.relative — a single source of truth
+ *     replacing ad-hoc startsWith(base + sep) checks that mishandle drive
+ *     roots on Windows.
+ *
+ * Not a defense against symlinks/junctions: the check is lexical, so a
+ * symlink under the base that points outside is not detected. If a real
+ * filesystem boundary is needed later, compare `realpath` of base and
+ * candidate's existing parent.
+ */
+export function resolveLocalPath(
+  rawPath: string,
+  baseDir: string,
+  pathImpl: PathImpl = path,
+): ResolveLocalPathResult {
+  if (pathImpl.sep === "/") {
+    // Backslashes on POSIX are valid filename characters, not separators —
+    // a "Windows path" would become a single literal directory name.
+    if (rawPath.includes("\\")) {
+      return { ok: false, reason: "windows_path_on_posix" };
+    }
+    // Drive letters with forward slashes ("C:/Users/...") aren't recognized
+    // as absolute by POSIX path.isAbsolute, so they'd resolve to
+    // "<base>/C:/Users/..." and silently miswrite. Treat them like the
+    // backslash case for the same reason.
+    if (/^[A-Za-z]:[/\\]/.test(rawPath)) {
+      return { ok: false, reason: "windows_path_on_posix" };
+    }
+  }
+
+  const base = pathImpl.resolve(baseDir);
+  const candidate = pathImpl.isAbsolute(rawPath)
+    ? pathImpl.resolve(rawPath)
+    : pathImpl.resolve(base, rawPath);
+
+  if (!isWithin(base, candidate, pathImpl)) {
+    return { ok: false, reason: "outside_image_dir" };
+  }
+
+  return { ok: true, resolvedPath: candidate };
+}
+
+/**
+ * True when `candidate` is `base` itself or a descendant of `base`.
+ *
+ * Uses path.relative rather than `startsWith(base + sep)` because the latter
+ * mishandles drive roots on Windows (where `base` already ends with a
+ * separator and concatenating another would double it).
+ */
+export function isWithin(base: string, candidate: string, pathImpl: PathImpl = path): boolean {
+  const rel = pathImpl.relative(base, candidate);
+  return rel === "" || (!rel.startsWith("..") && !pathImpl.isAbsolute(rel));
+}

--- a/src/utils/local-path.ts
+++ b/src/utils/local-path.ts
@@ -1,6 +1,6 @@
 import path from "path";
 
-export type ResolveLocalPathFailureReason = "outside_image_dir" | "windows_path_on_posix";
+export type ResolveLocalPathFailureReason = "outside_image_dir" | "drive_letter_on_posix";
 export type ResolveLocalPathResult =
   | { ok: true; resolvedPath: string }
   | { ok: false; reason: ResolveLocalPathFailureReason };
@@ -23,9 +23,11 @@ type PathImpl = Pick<typeof path, "sep" | "resolve" | "isAbsolute" | "relative">
  * reported success and the file was never where the user expected.
  *
  * This resolver makes ambiguous inputs loud:
- *   - On POSIX servers, backslashes are not separators and drive letters
- *     ("C:/...") are not recognized as absolute. Either form would otherwise
- *     resolve to a literal "C:" directory under the base. Reject both.
+ *   - On POSIX servers, backslashes are normalized to forward slashes so an
+ *     LLM can use either separator. Drive-letter prefixes ("C:/..." or
+ *     "C:\\...") still reject loudly though — they aren't recognized as
+ *     absolute by path.posix.isAbsolute, so they'd otherwise resolve to
+ *     "<base>/C:/..." and silently miswrite.
  *   - Absolute paths must lexically resolve inside the base directory.
  *     Naturally accepts "user pasted a full path that happens to be inside
  *     the project" while rejecting absolute paths pointing elsewhere.
@@ -43,25 +45,26 @@ export function resolveLocalPath(
   baseDir: string,
   pathImpl: PathImpl = path,
 ): ResolveLocalPathResult {
+  let normalized = rawPath;
   if (pathImpl.sep === "/") {
-    // Backslashes on POSIX are valid filename characters, not separators —
-    // a "Windows path" would become a single literal directory name.
-    if (rawPath.includes("\\")) {
-      return { ok: false, reason: "windows_path_on_posix" };
-    }
-    // Drive letters with forward slashes ("C:/Users/...") aren't recognized
-    // as absolute by POSIX path.isAbsolute, so they'd resolve to
-    // "<base>/C:/Users/..." and silently miswrite. Treat them like the
-    // backslash case for the same reason.
+    // Drive-letter prefixes aren't recognized as absolute by path.posix, so
+    // "C:\\Users\\..." or "C:/Users/..." would resolve to "<base>/C:/Users/..."
+    // and silently miswrite. The path is meaningless on POSIX regardless.
     if (/^[A-Za-z]:[/\\]/.test(rawPath)) {
-      return { ok: false, reason: "windows_path_on_posix" };
+      return { ok: false, reason: "drive_letter_on_posix" };
     }
+    // Otherwise normalize backslashes to forward slashes so an LLM can use
+    // either separator without thinking about host OS. Backslashes are valid
+    // filename characters on POSIX in theory, but real-world filenames
+    // virtually never contain them and the common case (LLM mixing styles)
+    // is far more important.
+    normalized = rawPath.replace(/\\/g, "/");
   }
 
   const base = pathImpl.resolve(baseDir);
-  const candidate = pathImpl.isAbsolute(rawPath)
-    ? pathImpl.resolve(rawPath)
-    : pathImpl.resolve(base, rawPath);
+  const candidate = pathImpl.isAbsolute(normalized)
+    ? pathImpl.resolve(normalized)
+    : pathImpl.resolve(base, normalized);
 
   if (!isWithin(base, candidate, pathImpl)) {
     return { ok: false, reason: "outside_image_dir" };

--- a/src/utils/local-path.ts
+++ b/src/utils/local-path.ts
@@ -1,18 +1,14 @@
 import path from "path";
 
-export type ResolveLocalPathSuccess = { ok: true; resolvedPath: string };
-export type ResolveLocalPathFailure = {
-  ok: false;
-  reason: "outside_image_dir" | "windows_path_on_posix";
-};
-export type ResolveLocalPathResult = ResolveLocalPathSuccess | ResolveLocalPathFailure;
+export type ResolveLocalPathFailureReason = "outside_image_dir" | "windows_path_on_posix";
+export type ResolveLocalPathResult =
+  | { ok: true; resolvedPath: string }
+  | { ok: false; reason: ResolveLocalPathFailureReason };
 
-/**
- * Subset of the `path` module we actually use. Both `path.posix` and
- * `path.win32` satisfy this shape, so callers (mostly tests) can exercise
- * cross-platform behavior on a single host.
- */
-export type PathImpl = Pick<typeof path, "sep" | "resolve" | "isAbsolute" | "relative">;
+// Subset of the `path` module we use. Both `path.posix` and `path.win32`
+// satisfy this shape, so tests can exercise cross-platform behavior on a
+// single host.
+type PathImpl = Pick<typeof path, "sep" | "resolve" | "isAbsolute" | "relative">;
 
 /**
  * Resolve a user-supplied path against an allowed base directory, accepting


### PR DESCRIPTION
## Summary

Fixes #364. The `download_figma_images` tool was reporting success while writing files to wrong-but-valid locations. Two failure modes both produced this same symptom:

- **POSIX server + Windows-style path**: `path.posix.resolve` treats backslashes as filename characters, so `localPath: "C:\\Users\\...\\figma\\public"` becomes a single literal directory name with backslashes inside. The reporter's mixed-slash output (`...retry-final/retry-vector-...svg` — backslashes in the directory portion, POSIX `/` before the filename) is the smoking gun for this.
- **Windows server + LLM-mangled path**: An LLM that strips the drive letter from `C:\Users\xl\...` and sends `/Users/xl/...` got silently re-interpreted as relative under the previous `path.join` hack, producing a doubled `<imageDir>/Users/xl/...` directory under imageDir.

Both fall into "valid path containment but completely wrong location."

## What changed

- New `src/utils/local-path.ts` with `resolveLocalPath` + `isWithin`. Absolute paths must lexically resolve inside imageDir; otherwise reject. Relative paths join under imageDir as before. POSIX servers reject backslash and forward-slash drive-letter inputs that would otherwise become single literal directory names.
- Containment unified onto `isWithin` (uses `path.relative`), fixing a drive-root edge case in the inline check that lived in `utils/common.ts`.
- Success message echoes the resolved absolute path so a wrong-cwd config surfaces immediately instead of looking like a successful no-op.
- Rejection messages include the configured imageDir and, for leading-slash inputs, an explicit "drop the leading slash" retry hint.
- stdio mode warns to stderr when `imageDir` came from the default (server cwd), since MCP clients rarely launch from the user's project root.
- `rejectionDetails` switches on a typed reason union, so adding a third failure reason is a compile error.

## Test plan

- [x] `pnpm test` (158 passed, 1 skipped — no regressions)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (only pre-existing warnings in untracked `scripts/debug-fetch.ts`)
- [x] Cross-platform path semantics covered via `path.posix` and `path.win32` test suites
- [ ] Verify on a real Windows host that issue #364's input now lands in the expected directory (cannot reproduce on macOS — the LLM-strips-drive-letter scenario depends on a real Windows current-drive context that `path.win32` on POSIX can't simulate)

## Notes on what's not in this PR

- Symlink defense — containment is lexical, not canonical. If `imageDir` is ever a real security boundary against untrusted clients, a follow-up should compare `realpath` of base and candidate parent. Documented inline.
- Windows CI — the cross-platform unit tests cover most of the resolver behavior, but a real Windows runner would let us assert the issue #364 scenario directly.