### PR TITLE
fix(images): support image fills copied from another Figma file

### DIFF
--- a/src/mcp/tools/download-figma-images-tool.ts
+++ b/src/mcp/tools/download-figma-images-tool.ts
@@ -1,17 +1,17 @@
 import path from "path";
 import { z } from "zod";
-import { FigmaService } from "../../services/figma.js";
-import { Logger } from "../../utils/logger.js";
 import {
-  captureDownloadImagesCall,
-  captureValidationReject,
   type AuthMode,
   type ClientInfo,
+  captureDownloadImagesCall,
+  captureValidationReject,
   type Transport,
 } from "~/telemetry/index.js";
 import { downloadFigmaImages as runDownloadFigmaImages } from "../../services/download-figma-images.js";
+import type { FigmaService } from "../../services/figma.js";
+import { type ResolveLocalPathFailureReason, resolveLocalPath } from "../../utils/local-path.js";
+import { Logger } from "../../utils/logger.js";
 import { sendProgress, startProgressHeartbeat, type ToolExtra } from "../progress.js";
-import { resolveLocalPath, type ResolveLocalPathFailureReason } from "../../utils/local-path.js";
 
 const parameters = {
   fileKey: z
@@ -31,7 +31,7 @@ const parameters = {
         .string()
         .optional()
         .describe(
-          "If a node has an imageRef fill, you must include this variable. Leave blank when downloading Vector SVG images or animated GIFs (use gifRef instead).",
+          "If a node has an imageRef fill, you must include this variable. Leave blank when downloading Vector SVG images or animated GIFs (use gifRef instead), or when an IMAGE fill is present without an imageRef — in that case the node is rendered as PNG via nodeId.",
         ),
       gifRef: z
         .string()
@@ -145,7 +145,11 @@ async function downloadFigmaImages(
           stopHeartbeat?.();
         },
         onComplete: (outcome) =>
-          captureDownloadImagesCall(outcome, { transport, authMode, clientInfo }),
+          captureDownloadImagesCall(outcome, {
+            transport,
+            authMode,
+            clientInfo,
+          }),
       },
     );
 
@@ -207,7 +211,11 @@ function rejectionDetails(
   reason: ResolveLocalPathFailureReason,
   localPath: string,
   baseDir: string,
-): { rule: ResolveLocalPathFailureReason; userMessage: string; telemetryMessage: string } {
+): {
+  rule: ResolveLocalPathFailureReason;
+  userMessage: string;
+  telemetryMessage: string;
+} {
   switch (reason) {
     case "drive_letter_on_posix":
       return {

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -27,7 +27,14 @@ export interface ColorValue {
  */
 export type SimplifiedImageFill = {
   type: "IMAGE";
-  imageRef: string;
+  /**
+   * Reference to the embedded image asset. Omitted when Figma returns a null
+   * imageRef — typically images pasted in from a file you don't own, where the
+   * asset still renders in the editor (it's reachable from the source file)
+   * but isn't registered against your file. In that case download_figma_images
+   * falls back to rendering the containing node as a PNG via its nodeId.
+   */
+  imageRef?: string;
   /**
    * Present when the fill is an animated GIF. Use this ref (instead of imageRef) when calling
    * download_figma_images to retrieve the animated GIF file; imageRef only points to a static
@@ -265,9 +272,14 @@ export function buildSimplifiedStrokes(
  */
 export function parsePaint(raw: Paint, hasChildren: boolean = false): SimplifiedFill {
   if (raw.type === "IMAGE") {
+    // Figma's spec types imageRef as a required string, but in practice it can
+    // come back null for IMAGE paints whose asset lives in another file (e.g.
+    // pasted from a file you don't own). Omit the field in that case so the
+    // LLM doesn't pass a null/"null" through to download_figma_images — the
+    // downloader will fall back to rendering the containing node by nodeId.
     const baseImageFill: SimplifiedImageFill = {
       type: "IMAGE",
-      imageRef: raw.imageRef,
+      ...(raw.imageRef ? { imageRef: raw.imageRef } : {}),
       ...(raw.gifRef ? { gifRef: raw.gifRef } : {}),
       scaleMode: raw.scaleMode as "FILL" | "FIT" | "TILE" | "STRETCH",
       scalingFactor: raw.scalingFactor,


### PR DESCRIPTION
## What was broken
When a designer copies content from one Figma file and pastes it into another, image fills in the pasted layers don't get re-uploaded — they keep referencing the source file's assets. The Figma editor still renders them fine, so to a designer everything looks normal. But when an LLM fetches that file through this MCP, those images came back unusable: every distinct image collapsed into a single shared style entry, and `download_figma_images` had no way to retrieve any of them. The end result was an LLM either skipping the images entirely or hallucinating placeholders.

This pattern is common — pasting from shared templates, design system files, marketing files owned by another team, or screenshots dragged in from a teammate's file. It usually isn't obvious to the designer that anything is wrong, which made the failure mode confusing to debug.

## What now works
Designs that include cross-file-pasted images now flow through end-to-end. The MCP recognizes when Figma can't surface a usable image reference and routes those nodes through the existing PNG-render path instead, so the LLM gets a real, downloadable image for each one. Distinct images stay distinct in the simplified output, so each layer gets its own image rather than every pasted image collapsing into one.

There is one caveat worth knowing: the fallback returns the node as Figma's renderer composes it (with effects, corner radius, and any crop baked in), not the raw original asset. The raw asset isn't reachable in this case anyway, so this is strictly better than the previous "download fails" behavior — but it's a different shape of output than a normal image fill, and worth flagging for downstream consumers.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm test`
- [x] Manual: fetch a file containing both an owned image and an image pasted from another file; confirm the owned one still resolves normally and the pasted one downloads as a rendered PNG