### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. **GitHub Security Advisories**: [Report privately](https://github.com/GLips/Figma-Context-MCP/security/advisories/new)
+2. **Email**: Contact the maintainers directly
+
+### Response Timeline
+
+- Acknowledgment: 48 hours
+- Assessment: 1 week
+- Fix: Based on severity
+
+## Supported Versions
+
+| Version | Supported |
+|---------|:---------:|
+| Latest  | ✅        |
+
+## MCP Security Best Practices
+
+1. Review server permissions before connecting
+2. Use environment variables for secrets
+3. Limit server access to required tools only
+4. Keep dependencies updated


### PR DESCRIPTION
Add security policy for responsible vulnerability disclosure. This 14.5K+ star project currently has no security policy, making it unclear how researchers should report findings privately.