### PR TITLE
feat(serialize): add tree output format

### DIFF
--- a/scripts/benchmark-simplify.ts
+++ b/scripts/benchmark-simplify.ts
@@ -1,20 +1,10 @@
-/**
- * Benchmark script for the design simplification pipeline.
- *
- * Reads a raw Figma API response from logs/figma-raw.json and profiles
- * simplifyRawFigmaObject + serialization, reporting wall time, memory,
- * node counts, and output size.
- *
- * Usage:
- *   pnpm benchmark:simplify              # run benchmark
- *   pnpm benchmark:simplify --profile    # run with CPU profiler, writes .cpuprofile
- */
+// Benchmark the design simplification pipeline. Run with --help for flags.
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { Session } from "node:inspector/promises";
-import yaml from "js-yaml";
+import { cli } from "cleye";
 import {
   simplifyRawFigmaObject,
   layoutExtractor,
@@ -22,12 +12,33 @@ import {
   visualsExtractor,
   componentExtractor,
   collapseSvgContainers,
-  getNodesProcessed,
 } from "../src/extractors/index.js";
 import type { ExtractorFn, SimplifiedNode } from "../src/extractors/index.js";
+import { serializeResult } from "../src/utils/serialize.js";
+import { wrapForSerialization } from "../src/utils/serializable-design.js";
 
-const INPUT_PATH = resolve("logs/figma-raw.json");
-const PROFILE_FLAG = process.argv.includes("--profile");
+const argv = cli({
+  name: "benchmark-simplify",
+  flags: {
+    input: {
+      type: String,
+      description: "Path to raw Figma API response JSON",
+      default: "logs/figma-raw.json",
+    },
+    profile: {
+      type: Boolean,
+      description: "Run with the V8 CPU profiler; writes logs/benchmark.cpuprofile",
+      default: false,
+    },
+  },
+  help: {
+    description:
+      "Benchmark the design simplification pipeline. Reads a raw Figma API response and reports wall time, memory, node counts, and output size for YAML/JSON/tree serialization.",
+  },
+});
+
+const INPUT_PATH = resolve(argv.flags.input);
+const PROFILE_FLAG = argv.flags.profile;
 
 interface ExtractorTiming {
   name: string;
@@ -135,32 +146,36 @@ async function main() {
     return out;
   };
 
+  const nodeCounter = { count: 0 };
   const simplifyStart = performance.now();
   const result = await simplifyRawFigmaObject(apiResponse, timedExtractors, {
     afterChildren: timedAfterChildren,
+    nodeCounter,
   });
   const simplifyMs = performance.now() - simplifyStart;
 
   const extractorTotal = extractorTimings.reduce((sum, t) => sum + t.totalMs, 0);
   const overhead = simplifyMs - extractorTotal - afterChildrenTiming.totalMs;
 
-  const nodesProcessed = getNodesProcessed();
+  const nodesProcessed = nodeCounter.count;
   const outputNodeCount = countOutputNodes(result.nodes);
 
+  const wrapped = wrapForSerialization(result);
+
   const yamlStart = performance.now();
-  const yamlOutput = yaml.dump(result, {
-    noRefs: true,
-    lineWidth: -1,
-    noCompatMode: true,
-    schema: yaml.JSON_SCHEMA,
-  });
+  const yamlOutput = serializeResult(wrapped, "yaml");
   const yamlMs = performance.now() - yamlStart;
   const yamlBytes = Buffer.byteLength(yamlOutput, "utf-8");
 
   const jsonStart = performance.now();
-  const jsonOutput = JSON.stringify(result, null, 2);
+  const jsonOutput = serializeResult(wrapped, "json");
   const jsonMs = performance.now() - jsonStart;
   const jsonBytes = Buffer.byteLength(jsonOutput, "utf-8");
+
+  const treeStart = performance.now();
+  const treeOutput = serializeResult(wrapped, "tree");
+  const treeMs = performance.now() - treeStart;
+  const treeBytes = Buffer.byteLength(treeOutput, "utf-8");
 
   const memAfter = process.memoryUsage();
 
@@ -202,9 +217,11 @@ async function main() {
   separator();
   row("YAML serialization", formatMs(yamlMs));
   row("JSON serialization", formatMs(jsonMs));
+  row("Tree serialization", formatMs(treeMs));
   separator();
   row("YAML output size", formatBytes(yamlBytes));
   row("JSON output size", formatBytes(jsonBytes));
+  row("Tree output size", formatBytes(treeBytes));
   separator();
   row("RSS (max sampled)", formatBytes(maxRss));
   row("RSS growth", rssGrowthStr);

--- a/scripts/compare-formats.ts
+++ b/scripts/compare-formats.ts
@@ -1,0 +1,66 @@
+/**
+ * Compare serialization formats on a real simplified-design fixture.
+ *
+ * Usage: pnpm tsx scripts/compare-formats.ts [path/to/figma-simplified.json]
+ *
+ * Reads a SimplifiedDesign JSON, renders it as yaml / json / tree, prints
+ * byte counts and ratios. Also writes each output next to the fixture so the
+ * tree format can be eyeballed.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { serializeResult } from "../src/utils/serialize.js";
+import type { SimplifiedDesign, SimplifiedNode } from "../src/extractors/types.js";
+
+const inputPath = resolve(process.argv[2] ?? "logs/figma-simplified.json");
+const design = JSON.parse(readFileSync(inputPath, "utf8")) as SimplifiedDesign;
+
+const yamlOut = serializeResult(design, "yaml");
+const jsonOut = serializeResult(design, "json");
+const treeOut = serializeResult(design, "tree");
+
+const outDir = dirname(inputPath);
+const stem = basename(inputPath, ".json");
+writeFileSync(resolve(outDir, `${stem}.yaml`), yamlOut);
+writeFileSync(resolve(outDir, `${stem}.tree`), treeOut);
+
+const yamlBytes = Buffer.byteLength(yamlOut, "utf8");
+const jsonBytes = Buffer.byteLength(jsonOut, "utf8");
+const treeBytes = Buffer.byteLength(treeOut, "utf8");
+
+const nodeCount = countNodes(design.nodes);
+const styleCount = Object.keys(design.globalVars.styles).length;
+const componentCount = Object.keys(design.components).length;
+
+console.log(`Fixture: ${inputPath}`);
+console.log(`  nodes: ${nodeCount}`);
+console.log(`  globalVars styles: ${styleCount}`);
+console.log(`  components: ${componentCount}`);
+console.log();
+
+const fmt = (n: number) => n.toLocaleString().padStart(10);
+const pct = (n: number, base: number) => `${((n / base - 1) * 100).toFixed(1).padStart(6)}%`;
+
+console.log(`Format   ${"bytes".padStart(10)}   vs YAML   vs JSON`);
+console.log(
+  `yaml     ${fmt(yamlBytes)}   ${pct(yamlBytes, yamlBytes)}   ${pct(yamlBytes, jsonBytes)}`,
+);
+console.log(
+  `json     ${fmt(jsonBytes)}   ${pct(jsonBytes, yamlBytes)}   ${pct(jsonBytes, jsonBytes)}`,
+);
+console.log(
+  `tree     ${fmt(treeBytes)}   ${pct(treeBytes, yamlBytes)}   ${pct(treeBytes, jsonBytes)}`,
+);
+console.log();
+
+const yamlSavings = ((1 - treeBytes / yamlBytes) * 100).toFixed(1);
+console.log(`tree saves ${yamlSavings}% over yaml on this fixture (byte count, not tokens)`);
+
+function countNodes(nodes: SimplifiedNode[]): number {
+  let total = 0;
+  for (const n of nodes) {
+    total += 1;
+    if (n.children) total += countNodes(n.children);
+  }
+  return total;
+}

--- a/scripts/compare-formats.ts
+++ b/scripts/compare-formats.ts
@@ -10,14 +10,16 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
 import { serializeResult } from "../src/utils/serialize.js";
+import { wrapForSerialization } from "../src/utils/serializable-design.js";
 import type { SimplifiedDesign, SimplifiedNode } from "../src/extractors/types.js";
 
 const inputPath = resolve(process.argv[2] ?? "logs/figma-simplified.json");
 const design = JSON.parse(readFileSync(inputPath, "utf8")) as SimplifiedDesign;
+const wrapped = wrapForSerialization(design);
 
-const yamlOut = serializeResult(design, "yaml");
-const jsonOut = serializeResult(design, "json");
-const treeOut = serializeResult(design, "tree");
+const yamlOut = serializeResult(wrapped, "yaml");
+const jsonOut = serializeResult(wrapped, "json");
+const treeOut = serializeResult(wrapped, "tree");
 
 const outDir = dirname(inputPath);
 const stem = basename(inputPath, ".json");

--- a/scripts/render-fixture.ts
+++ b/scripts/render-fixture.ts
@@ -1,0 +1,41 @@
+/**
+ * Render a saved SimplifiedDesign fixture in a chosen output format.
+ * Used to feed pre-rendered design data to sub-agents during /trial benchmarks
+ * without forcing the parent conversation to ingest the multi-MB JSON.
+ *
+ * Usage:
+ *   pnpm tsx scripts/render-fixture.ts --input <path> --format <yaml|json|tree> --output <path>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { serializeResult, type OutputFormat } from "../src/utils/serialize.js";
+import type { SimplifiedDesign } from "../src/extractors/types.js";
+
+const { values } = parseArgs({
+  options: {
+    input: { type: "string" },
+    format: { type: "string", default: "yaml" },
+    output: { type: "string" },
+  },
+});
+
+if (!values.input || !values.output) {
+  console.error(
+    "Usage: render-fixture.ts --input <path> --format <yaml|json|tree> --output <path>",
+  );
+  process.exit(1);
+}
+
+const format = values.format as OutputFormat;
+if (!["yaml", "json", "tree"].includes(format)) {
+  console.error(`Invalid format: ${format}`);
+  process.exit(1);
+}
+
+const design = JSON.parse(readFileSync(values.input, "utf8")) as SimplifiedDesign;
+const output = serializeResult(design, format);
+writeFileSync(values.output, output);
+
+console.error(
+  `Rendered ${values.input} as ${format} → ${values.output} (${output.length.toLocaleString()} bytes)`,
+);

--- a/scripts/render-fixture.ts
+++ b/scripts/render-fixture.ts
@@ -39,5 +39,5 @@ const output = serializeResult(wrapForSerialization(design), values.format);
 writeFileSync(values.output, output);
 
 console.error(
-  `Rendered ${values.input} as ${format} → ${values.output} (${output.length.toLocaleString()} bytes)`,
+  `Rendered ${values.input} as ${values.format} → ${values.output} (${output.length.toLocaleString()} bytes)`,
 );

--- a/scripts/render-fixture.ts
+++ b/scripts/render-fixture.ts
@@ -8,7 +8,8 @@
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { parseArgs } from "node:util";
-import { serializeResult, type OutputFormat } from "../src/utils/serialize.js";
+import { serializeResult, isOutputFormat, VALID_OUTPUT_FORMATS } from "../src/utils/serialize.js";
+import { wrapForSerialization } from "../src/utils/serializable-design.js";
 import type { SimplifiedDesign } from "../src/extractors/types.js";
 
 const { values } = parseArgs({
@@ -26,14 +27,15 @@ if (!values.input || !values.output) {
   process.exit(1);
 }
 
-const format = values.format as OutputFormat;
-if (!["yaml", "json", "tree"].includes(format)) {
-  console.error(`Invalid format: ${format}`);
+if (!isOutputFormat(values.format!)) {
+  console.error(
+    `Invalid format: ${values.format}. Expected one of: ${VALID_OUTPUT_FORMATS.join(", ")}`,
+  );
   process.exit(1);
 }
 
 const design = JSON.parse(readFileSync(values.input, "utf8")) as SimplifiedDesign;
-const output = serializeResult(design, format);
+const output = serializeResult(wrapForSerialization(design), values.format);
 writeFileSync(values.output, output);
 
 console.error(

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -31,7 +31,13 @@ const argv = cli({
     },
     json: {
       type: Boolean,
-      description: "Output data from tools in JSON format instead of YAML",
+      description:
+        "Output data from tools in JSON format instead of YAML. Back-compat alias for --format=json.",
+    },
+    format: {
+      type: String,
+      description:
+        "Output format for design data: yaml (default), json, or tree (experimental compact format).",
     },
     skipImageDownloads: {
       type: Boolean,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -69,7 +69,13 @@ const argv = cli({
 if (!argv.command) {
   // NODE_ENV=cli is a legacy backdoor for stdio mode
   const isStdio = argv.flags.stdio === true || process.env.NODE_ENV === "cli";
-  const config = getServerConfig({ ...argv.flags, stdio: isStdio });
+  let config;
+  try {
+    config = getServerConfig({ ...argv.flags, stdio: isStdio });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
   startServer(config).catch((error) => {
     console.error("Failed to start server:", error);
     process.exit(1);

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,5 +1,5 @@
 import { type Command, command } from "cleye";
-import { loadEnvFile, resolveAuth } from "~/config.js";
+import { loadEnvFile, parseOutputFormat, resolveAuth } from "~/config.js";
 import { FigmaService } from "~/services/figma.js";
 import { parseFigmaUrl } from "~/utils/figma-url.js";
 import {
@@ -9,6 +9,7 @@ import {
   type AuthMode,
 } from "~/telemetry/index.js";
 import { getFigmaData } from "~/services/get-figma-data.js";
+import type { OutputFormat } from "~/utils/serialize.js";
 
 export const fetchCommand: Command = command(
   {
@@ -30,7 +31,11 @@ export const fetchCommand: Command = command(
       },
       json: {
         type: Boolean,
-        description: "Output JSON instead of YAML",
+        description: "Output JSON instead of YAML. Back-compat alias for --format=json.",
+      },
+      format: {
+        type: String,
+        description: "Output format: yaml (default), json, or tree (experimental).",
       },
       figmaApiKey: {
         type: String,
@@ -66,6 +71,7 @@ async function run(
     nodeId?: string;
     depth?: number;
     json?: boolean;
+    format?: string;
     figmaApiKey?: string;
     figmaOauthToken?: string;
     env?: string;
@@ -105,7 +111,8 @@ async function run(
   });
 
   const authMode: AuthMode = auth.useOAuth ? "oauth" : "api_key";
-  const outputFormat = flags.json ? "json" : "yaml";
+  const outputFormat: OutputFormat =
+    parseOutputFormat(flags.format, "--format") ?? (flags.json ? "json" : "yaml");
 
   const result = await getFigmaData(
     new FigmaService(auth),

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,14 +147,10 @@ export function getServerConfig(flags: ServerFlags): ServerConfig {
 
   // --format wins; --json is a back-compat alias for --format=json. Invalid
   // user-supplied values fail loudly at startup rather than silently coercing.
-  const formatFromFlag = parseOutputFormat(flags.format, "--format");
-  const formatFromJsonFlag: OutputFormat | undefined = flags.json ? "json" : undefined;
+  const formatFromFlag =
+    parseOutputFormat(flags.format, "--format") ?? (flags.json ? "json" : undefined);
   const formatFromEnv = parseOutputFormat(envStr("OUTPUT_FORMAT"), "OUTPUT_FORMAT");
-  const outputFormat = resolve<OutputFormat>(
-    formatFromFlag ?? formatFromJsonFlag,
-    formatFromEnv,
-    "yaml",
-  );
+  const outputFormat = resolve<OutputFormat>(formatFromFlag, formatFromEnv, "yaml");
 
   const isStdioMode = flags.stdio === true;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { config as loadEnv } from "dotenv";
 import { resolve as resolvePath } from "path";
 import type { FigmaAuthOptions } from "./services/figma.js";
 import { resolveTelemetryEnabled } from "./telemetry/index.js";
-import type { OutputFormat } from "./utils/serialize.js";
+import { VALID_OUTPUT_FORMATS, isOutputFormat, type OutputFormat } from "./utils/serialize.js";
 
 export type Source = "cli" | "env" | "default";
 
@@ -65,20 +65,19 @@ export function envBool(name: string): boolean | undefined {
   return undefined;
 }
 
-const VALID_OUTPUT_FORMATS: readonly OutputFormat[] = ["yaml", "json", "tree"];
-
+// Throws on invalid input so callers control how the failure surfaces — the
+// server entry point exits the process, but the `fetch` CLI command needs to
+// run its `finally` (telemetry shutdown) before exiting, which `process.exit`
+// would bypass.
 export function parseOutputFormat(
   value: string | undefined,
   source: string,
 ): OutputFormat | undefined {
   if (value === undefined) return undefined;
-  if ((VALID_OUTPUT_FORMATS as readonly string[]).includes(value)) {
-    return value as OutputFormat;
-  }
-  console.error(
+  if (isOutputFormat(value)) return value;
+  throw new Error(
     `Invalid ${source} value '${value}'. Expected one of: ${VALID_OUTPUT_FORMATS.join(", ")}`,
   );
-  process.exit(1);
 }
 
 function maskApiKey(key: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { config as loadEnv } from "dotenv";
 import { resolve as resolvePath } from "path";
 import type { FigmaAuthOptions } from "./services/figma.js";
 import { resolveTelemetryEnabled } from "./telemetry/index.js";
+import type { OutputFormat } from "./utils/serialize.js";
 
 export type Source = "cli" | "env" | "default";
 
@@ -17,6 +18,7 @@ export interface ServerFlags {
   port?: number;
   host?: string;
   json?: boolean;
+  format?: string;
   skipImageDownloads?: boolean;
   imageDir?: string;
   proxy?: string;
@@ -29,7 +31,7 @@ export interface ServerConfig {
   port: number;
   host: string;
   proxy: string | undefined;
-  outputFormat: "yaml" | "json";
+  outputFormat: OutputFormat;
   skipImageDownloads: boolean;
   imageDir: string;
   isStdioMode: boolean;
@@ -61,6 +63,22 @@ export function envBool(name: string): boolean | undefined {
   if (val === "true") return true;
   if (val === "false") return false;
   return undefined;
+}
+
+const VALID_OUTPUT_FORMATS: readonly OutputFormat[] = ["yaml", "json", "tree"];
+
+export function parseOutputFormat(
+  value: string | undefined,
+  source: string,
+): OutputFormat | undefined {
+  if (value === undefined) return undefined;
+  if ((VALID_OUTPUT_FORMATS as readonly string[]).includes(value)) {
+    return value as OutputFormat;
+  }
+  console.error(
+    `Invalid ${source} value '${value}'. Expected one of: ${VALID_OUTPUT_FORMATS.join(", ")}`,
+  );
+  process.exit(1);
 }
 
 function maskApiKey(key: string): string {
@@ -128,10 +146,14 @@ export function getServerConfig(flags: ServerFlags): ServerConfig {
   // correctly respects NO_PROXY exclusions.
   const proxy = resolve(flags.proxy, envStr("FIGMA_PROXY"), undefined);
 
-  // --json maps to a string enum
-  const outputFormat = resolve<"yaml" | "json">(
-    flags.json ? "json" : undefined,
-    envStr("OUTPUT_FORMAT") as "yaml" | "json" | undefined,
+  // --format wins; --json is a back-compat alias for --format=json. Invalid
+  // user-supplied values fail loudly at startup rather than silently coercing.
+  const formatFromFlag = parseOutputFormat(flags.format, "--format");
+  const formatFromJsonFlag: OutputFormat | undefined = flags.json ? "json" : undefined;
+  const formatFromEnv = parseOutputFormat(envStr("OUTPUT_FORMAT"), "OUTPUT_FORMAT");
+  const outputFormat = resolve<OutputFormat>(
+    formatFromFlag ?? formatFromJsonFlag,
+    formatFromEnv,
     "yaml",
   );
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { FigmaService, type FigmaAuthOptions } from "../services/figma.js";
 import { Logger } from "../utils/logger.js";
 import { type AuthMode, type ClientInfo, type Transport } from "~/telemetry/index.js";
+import type { OutputFormat } from "~/utils/serialize.js";
 import { installValidationRejectCapture } from "./validation-capture.js";
 import type { ToolExtra } from "./progress.js";
 import {
@@ -22,7 +23,7 @@ type ServerTransport = Extract<Transport, "stdio" | "http">;
 
 type CreateServerOptions = {
   transport: ServerTransport;
-  outputFormat?: "yaml" | "json";
+  outputFormat?: OutputFormat;
   skipImageDownloads?: boolean;
   imageDir?: string;
 };
@@ -60,7 +61,7 @@ function createServer(
 type RegisterToolsOptions = {
   transport: ServerTransport;
   authMode: AuthMode;
-  outputFormat: "yaml" | "json";
+  outputFormat: OutputFormat;
   skipImageDownloads: boolean;
   imageDir?: string;
   getClientInfo: () => ClientInfo | undefined;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -51,7 +51,7 @@ function createServer(
     getClientInfo,
   });
 
-  installValidationRejectCapture(server, { transport, authMode, getClientInfo });
+  installValidationRejectCapture(server, { transport, authMode, outputFormat, getClientInfo });
 
   Logger.isHTTP = transport !== "stdio";
 

--- a/src/mcp/tools/get-figma-data-tool.ts
+++ b/src/mcp/tools/get-figma-data-tool.ts
@@ -9,6 +9,7 @@ import {
   type Transport,
 } from "~/telemetry/index.js";
 import { getFigmaData as runGetFigmaData } from "~/services/get-figma-data.js";
+import type { OutputFormat } from "~/utils/serialize.js";
 
 const parameters = {
   fileKey: z
@@ -41,7 +42,7 @@ export type GetFigmaDataParams = z.infer<typeof parametersSchema>;
 async function getFigmaData(
   params: GetFigmaDataParams,
   figmaService: FigmaService,
-  outputFormat: "yaml" | "json",
+  outputFormat: OutputFormat,
   transport: Transport,
   authMode: AuthMode,
   clientInfo: ClientInfo | undefined,

--- a/src/mcp/validation-capture.ts
+++ b/src/mcp/validation-capture.ts
@@ -6,6 +6,7 @@ import {
   type Transport,
   type AuthMode,
 } from "~/telemetry/index.js";
+import type { OutputFormat } from "~/utils/serialize.js";
 
 /**
  * The MCP SDK validates tool input against the registered zod schema BEFORE
@@ -37,6 +38,7 @@ export function installValidationRejectCapture(
   context: {
     transport: Transport;
     authMode: AuthMode;
+    outputFormat: OutputFormat;
     getClientInfo: () => ClientInfo | undefined;
   },
 ): void {
@@ -77,6 +79,7 @@ export function installValidationRejectCapture(
               field: normalizeFieldPath(issue?.path),
               rule: issue?.code ?? "unknown",
               message: issue?.message ?? error.message,
+              outputFormat: context.outputFormat,
             },
             {
               transport: context.transport,

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ export async function startServer(config: ServerConfig): Promise<void> {
 
   const serverOptions = {
     transport: config.isStdioMode ? ("stdio" as const) : ("http" as const),
-    outputFormat: config.outputFormat as "yaml" | "json",
+    outputFormat: config.outputFormat,
     skipImageDownloads: config.skipImageDownloads,
     imageDir: config.imageDir,
   };

--- a/src/services/get-figma-data.ts
+++ b/src/services/get-figma-data.ts
@@ -7,6 +7,7 @@ import {
 } from "~/extractors/index.js";
 import { writeLogs } from "~/utils/logger.js";
 import { serializeResult, type OutputFormat } from "~/utils/serialize.js";
+import { wrapForSerialization } from "~/utils/serializable-design.js";
 import { tagError } from "~/utils/error-meta.js";
 import {
   type GetFigmaDataMetrics,
@@ -129,9 +130,7 @@ export async function getFigmaData(
     const serializeStart = Date.now();
     let formatted: string;
     try {
-      const { nodes, globalVars, ...metadata } = simplifiedDesign;
-      const result = { metadata, nodes, globalVars };
-      formatted = serializeResult(result, outputFormat);
+      formatted = serializeResult(wrapForSerialization(simplifiedDesign), outputFormat);
     } catch (error) {
       tagError(error, { phase: "serialize" });
     }

--- a/src/services/get-figma-data.ts
+++ b/src/services/get-figma-data.ts
@@ -6,7 +6,7 @@ import {
   collapseSvgContainers,
 } from "~/extractors/index.js";
 import { writeLogs } from "~/utils/logger.js";
-import { serializeResult } from "~/utils/serialize.js";
+import { serializeResult, type OutputFormat } from "~/utils/serialize.js";
 import { tagError } from "~/utils/error-meta.js";
 import {
   type GetFigmaDataMetrics,
@@ -30,7 +30,7 @@ export type GetFigmaDataResult = {
 
 export type GetFigmaDataOutcome = {
   input: GetFigmaDataInput;
-  outputFormat: "yaml" | "json";
+  outputFormat: OutputFormat;
   durationMs: number;
   metrics?: GetFigmaDataMetrics;
   error?: unknown;
@@ -72,7 +72,7 @@ export type GetFigmaDataHooks = {
 export async function getFigmaData(
   figmaService: FigmaService,
   input: GetFigmaDataInput,
-  outputFormat: "yaml" | "json",
+  outputFormat: OutputFormat,
   hooks: GetFigmaDataHooks = {},
 ): Promise<GetFigmaDataResult> {
   const { fileKey, nodeId, depth } = input;

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,3 +1,5 @@
+import type { OutputFormat } from "~/utils/serialize.js";
+
 export type Transport = "stdio" | "http" | "cli";
 export type AuthMode = "oauth" | "api_key";
 export type ClientInfo = { name?: string; version?: string };
@@ -30,7 +32,7 @@ export type ValidationRejectInput = {
   field: string;
   rule: string;
   message: string;
-  outputFormat?: "yaml" | "json";
+  outputFormat?: OutputFormat;
 };
 
 // Event schemas — used by capture.ts for shaping PostHog events.
@@ -56,7 +58,7 @@ export type CommonCallProps = {
 
 export type GetFigmaDataCall = CommonCallProps & {
   tool: "get_figma_data";
-  output_format: "yaml" | "json";
+  output_format: OutputFormat;
   raw_size_kb?: number;
   simplified_size_kb?: number;
   raw_node_count?: number;

--- a/src/tests/serialization.test.ts
+++ b/src/tests/serialization.test.ts
@@ -122,9 +122,10 @@ describe("result serialization", () => {
       expect(output).toMatch(/\[FRAME\] "Card" #1:1 borderRadius=12px/);
     });
 
-    // Figma allows free-form component property names. A name with whitespace
-    // would break the space-delimited `key=value` contract on the node line.
-    it("encodes componentProperties safely when keys contain whitespace", () => {
+    // Figma allows free-form component property names like "On Sale". The
+    // value must serialize as readable JSON — earlier attempts escaped
+    // whitespace to \uXXXX, which is hostile to the LLM consumer.
+    it("emits componentProperties as readable JSON even when keys contain whitespace", () => {
       const design: SimplifiedDesign = {
         name: "Test",
         components: {},
@@ -142,15 +143,8 @@ describe("result serialization", () => {
       };
 
       const output = serializeResult(wrapForSerialization(design), "tree");
-      const nodeLine = output.split("\n").find((l) => l.includes("[INSTANCE]"))!;
-      // The whole field=value pair must be one whitespace-free token, so
-      // splitting the line on whitespace correctly isolates it.
-      const tokens = nodeLine.trim().split(/\s+/);
-      const propsToken = tokens.find((t) => t.startsWith("componentProperties="))!;
-      expect(propsToken).toBeDefined();
-      // Round-trip the inner value to confirm the data survives encoding.
-      const rawValue = propsToken.slice("componentProperties=".length);
-      expect(JSON.parse(rawValue)).toEqual({ "On Sale": true, Size: "md" });
+
+      expect(output).toContain('componentProperties={"On Sale":true,"Size":"md"}');
     });
   });
 });

--- a/src/tests/serialization.test.ts
+++ b/src/tests/serialization.test.ts
@@ -1,5 +1,7 @@
 import yaml from "js-yaml";
 import { serializeResult } from "~/utils/serialize.js";
+import { wrapForSerialization } from "~/utils/serializable-design.js";
+import type { SimplifiedDesign } from "~/extractors/types.js";
 
 describe("result serialization", () => {
   describe("YAML format", () => {
@@ -90,6 +92,65 @@ describe("result serialization", () => {
       const parsed = JSON.parse(output);
 
       expect(parsed).toEqual(data);
+    });
+  });
+
+  describe("tree format", () => {
+    // The production pipeline wraps the SimplifiedDesign before calling
+    // serializeResult. The tree renderer must read from that wrapped shape;
+    // a regression here silently broke the production --format=tree path.
+    it("renders the wrapped design shape produced by getFigmaData", () => {
+      const design: SimplifiedDesign = {
+        name: "Test File",
+        components: {},
+        componentSets: {},
+        globalVars: { styles: {} },
+        nodes: [
+          {
+            id: "1:1",
+            name: "Card",
+            type: "FRAME",
+            borderRadius: "12px",
+          },
+        ],
+      };
+
+      const output = serializeResult(wrapForSerialization(design), "tree");
+
+      expect(output).toContain('NAME: "Test File"');
+      expect(output).toContain("NODES:");
+      expect(output).toMatch(/\[FRAME\] "Card" #1:1 borderRadius=12px/);
+    });
+
+    // Figma allows free-form component property names. A name with whitespace
+    // would break the space-delimited `key=value` contract on the node line.
+    it("encodes componentProperties safely when keys contain whitespace", () => {
+      const design: SimplifiedDesign = {
+        name: "Test",
+        components: {},
+        componentSets: {},
+        globalVars: { styles: {} },
+        nodes: [
+          {
+            id: "1:1",
+            name: "Btn",
+            type: "INSTANCE",
+            componentId: "abc",
+            componentProperties: { "On Sale": true, Size: "md" },
+          },
+        ],
+      };
+
+      const output = serializeResult(wrapForSerialization(design), "tree");
+      const nodeLine = output.split("\n").find((l) => l.includes("[INSTANCE]"))!;
+      // The whole field=value pair must be one whitespace-free token, so
+      // splitting the line on whitespace correctly isolates it.
+      const tokens = nodeLine.trim().split(/\s+/);
+      const propsToken = tokens.find((t) => t.startsWith("componentProperties="))!;
+      expect(propsToken).toBeDefined();
+      // Round-trip the inner value to confirm the data survives encoding.
+      const rawValue = propsToken.slice("componentProperties=".length);
+      expect(JSON.parse(rawValue)).toEqual({ "On Sale": true, Size: "md" });
     });
   });
 });

--- a/src/utils/serializable-design.ts
+++ b/src/utils/serializable-design.ts
@@ -1,29 +1,8 @@
-import type {
-  SimplifiedComponentDefinition,
-  SimplifiedComponentSetDefinition,
-} from "~/transformers/component.js";
-import type { SimplifiedDesign, SimplifiedNode, GlobalVars } from "~/extractors/types.js";
+import type { SimplifiedDesign } from "~/extractors/types.js";
 
-/**
- * Wrapped shape consumed by `serializeResult`. A `SimplifiedDesign` carries
- * `name`/`components`/`componentSets` flat at the top, but every serializer
- * sees the design with metadata pulled into its own sub-object so structural
- * fields (`nodes`, `globalVars`) sit alongside a single `metadata` block in
- * the YAML/JSON output. Tree format reads from the same wrapped shape so all
- * serializers share one input contract — earlier the tree renderer expected
- * the unwrapped shape and silently broke on the production path.
- */
-export interface SerializableDesign {
-  metadata: {
-    name: string;
-    components: Record<string, SimplifiedComponentDefinition>;
-    componentSets: Record<string, SimplifiedComponentSetDefinition>;
-  };
-  nodes: SimplifiedNode[];
-  globalVars: GlobalVars;
-}
-
-export function wrapForSerialization(design: SimplifiedDesign): SerializableDesign {
+export function wrapForSerialization(design: SimplifiedDesign) {
   const { nodes, globalVars, ...metadata } = design;
   return { metadata, nodes, globalVars };
 }
+
+export type SerializableDesign = ReturnType<typeof wrapForSerialization>;

--- a/src/utils/serializable-design.ts
+++ b/src/utils/serializable-design.ts
@@ -1,0 +1,29 @@
+import type {
+  SimplifiedComponentDefinition,
+  SimplifiedComponentSetDefinition,
+} from "~/transformers/component.js";
+import type { SimplifiedDesign, SimplifiedNode, GlobalVars } from "~/extractors/types.js";
+
+/**
+ * Wrapped shape consumed by `serializeResult`. A `SimplifiedDesign` carries
+ * `name`/`components`/`componentSets` flat at the top, but every serializer
+ * sees the design with metadata pulled into its own sub-object so structural
+ * fields (`nodes`, `globalVars`) sit alongside a single `metadata` block in
+ * the YAML/JSON output. Tree format reads from the same wrapped shape so all
+ * serializers share one input contract — earlier the tree renderer expected
+ * the unwrapped shape and silently broke on the production path.
+ */
+export interface SerializableDesign {
+  metadata: {
+    name: string;
+    components: Record<string, SimplifiedComponentDefinition>;
+    componentSets: Record<string, SimplifiedComponentSetDefinition>;
+  };
+  nodes: SimplifiedNode[];
+  globalVars: GlobalVars;
+}
+
+export function wrapForSerialization(design: SimplifiedDesign): SerializableDesign {
+  const { nodes, globalVars, ...metadata } = design;
+  return { metadata, nodes, globalVars };
+}

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -76,10 +76,10 @@ function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {
   if (node.styles !== undefined) parts.push(`styles=${maybeQuote(node.styles)}`);
   if (node.componentId !== undefined) parts.push(`componentId=${node.componentId}`);
   if (node.componentProperties !== undefined) {
-    parts.push(`componentProperties=${encodeRecord(node.componentProperties)}`);
+    parts.push(`componentProperties=${JSON.stringify(node.componentProperties)}`);
   }
   if (node.componentPropertyReferences !== undefined) {
-    parts.push(`componentPropertyReferences=${encodeRecord(node.componentPropertyReferences)}`);
+    parts.push(`componentPropertyReferences=${JSON.stringify(node.componentPropertyReferences)}`);
   }
   if (node.textStyle !== undefined) parts.push(`textStyle=${node.textStyle}`);
   if (node.boldWeight !== undefined) parts.push(`boldWeight=${node.boldWeight}`);
@@ -104,16 +104,4 @@ function quote(s: string): string {
 // `key=value` parse — keeps short scalar refs (`layout_ABC`, `12px`) unquoted.
 function maybeQuote(s: string): string {
   return /[\s"]/.test(s) ? JSON.stringify(s) : s;
-}
-
-// Encode a record as compact JSON, escaping any whitespace inside keys/values
-// to `\uXXXX` so the result is a single whitespace-free token. Figma allows
-// free-form component property names like "On Sale" — without this, a literal
-// space inside the JSON breaks the space-delimited node-line parse contract.
-// The consumer round-trips by passing the value to `JSON.parse` directly.
-function encodeRecord(record: Record<string, string | boolean>): string {
-  return JSON.stringify(record).replace(
-    /\s/g,
-    (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
-  );
 }

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -1,6 +1,6 @@
-import yaml from "js-yaml";
 import type { SimplifiedNode } from "~/extractors/types.js";
 import type { SerializableDesign } from "./serializable-design.js";
+import { dumpYaml } from "./yaml-dump.js";
 
 /**
  * Render the simplified design as a token-efficient indented tree.
@@ -42,15 +42,6 @@ export function serializeAsTree(design: SerializableDesign): string {
   sections.push(lines.join("\n"));
 
   return sections.join("\n");
-}
-
-function dumpYaml(value: unknown): string {
-  return yaml.dump(value, {
-    noRefs: true,
-    lineWidth: -1,
-    noCompatMode: true,
-    schema: yaml.JSON_SCHEMA,
-  });
 }
 
 function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -1,5 +1,6 @@
 import yaml from "js-yaml";
-import type { SimplifiedDesign, SimplifiedNode } from "~/extractors/types.js";
+import type { SimplifiedNode } from "~/extractors/types.js";
+import type { SerializableDesign } from "./serializable-design.js";
 
 /**
  * Render the simplified design as a token-efficient indented tree.
@@ -15,21 +16,23 @@ import type { SimplifiedDesign, SimplifiedNode } from "~/extractors/types.js";
  *
  * All SimplifiedNode fields are preserved; this is a serialization change only.
  */
-export function serializeAsTree(design: SimplifiedDesign): string {
+export function serializeAsTree(design: SerializableDesign): string {
   const sections: string[] = [];
 
-  sections.push(`NAME: ${design.name}`);
+  // Quote the design name — designers can use anything, including ":" or
+  // whitespace, which would otherwise produce a malformed `NAME: foo: bar` line.
+  sections.push(`NAME: ${quote(design.metadata.name)}`);
 
   if (Object.keys(design.globalVars.styles).length > 0) {
     sections.push(`\nGLOBAL_VARS:\n${dumpYaml(design.globalVars.styles)}`);
   }
 
-  if (Object.keys(design.components).length > 0) {
-    sections.push(`COMPONENTS:\n${dumpYaml(design.components)}`);
+  if (Object.keys(design.metadata.components).length > 0) {
+    sections.push(`COMPONENTS:\n${dumpYaml(design.metadata.components)}`);
   }
 
-  if (Object.keys(design.componentSets).length > 0) {
-    sections.push(`COMPONENT_SETS:\n${dumpYaml(design.componentSets)}`);
+  if (Object.keys(design.metadata.componentSets).length > 0) {
+    sections.push(`COMPONENT_SETS:\n${dumpYaml(design.metadata.componentSets)}`);
   }
 
   const lines: string[] = ["NODES:"];
@@ -103,12 +106,14 @@ function maybeQuote(s: string): string {
   return /[\s"]/.test(s) ? JSON.stringify(s) : s;
 }
 
-// Inline a Record as key:val pairs joined by commas. Values that contain commas
-// or colons (rare in component property names/values, but possible) are quoted.
+// Encode a record as compact JSON, escaping any whitespace inside keys/values
+// to `\uXXXX` so the result is a single whitespace-free token. Figma allows
+// free-form component property names like "On Sale" — without this, a literal
+// space inside the JSON breaks the space-delimited node-line parse contract.
+// The consumer round-trips by passing the value to `JSON.parse` directly.
 function encodeRecord(record: Record<string, string | boolean>): string {
-  const entries = Object.entries(record).map(([k, v]) => {
-    const val = typeof v === "string" && /[,:\s"]/.test(v) ? JSON.stringify(v) : String(v);
-    return `${k}:${val}`;
-  });
-  return entries.join(",");
+  return JSON.stringify(record).replace(
+    /\s/g,
+    (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
 }

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -1,0 +1,114 @@
+import yaml from "js-yaml";
+import type { SimplifiedDesign, SimplifiedNode } from "~/extractors/types.js";
+
+/**
+ * Render the simplified design as a token-efficient indented tree.
+ *
+ * Structural keys (id, name, type, children) are encoded positionally on each
+ * node line, eliminating the YAML/JSON overhead of repeating those keys for
+ * every node. Style values stay deduplicated in a globalVars block at the top,
+ * so identical styling across many nodes still pays once — the win over
+ * inline-only formats grows with how much style reuse the design has.
+ *
+ * Node line format:
+ *   [TYPE] "name" #id key=value key=value ...
+ *
+ * All SimplifiedNode fields are preserved; this is a serialization change only.
+ */
+export function serializeAsTree(design: SimplifiedDesign): string {
+  const sections: string[] = [];
+
+  sections.push(`NAME: ${design.name}`);
+
+  if (Object.keys(design.globalVars.styles).length > 0) {
+    sections.push(`\nGLOBAL_VARS:\n${dumpYaml(design.globalVars.styles)}`);
+  }
+
+  if (Object.keys(design.components).length > 0) {
+    sections.push(`COMPONENTS:\n${dumpYaml(design.components)}`);
+  }
+
+  if (Object.keys(design.componentSets).length > 0) {
+    sections.push(`COMPONENT_SETS:\n${dumpYaml(design.componentSets)}`);
+  }
+
+  const lines: string[] = ["NODES:"];
+  for (const node of design.nodes) {
+    renderNode(node, 0, lines);
+  }
+  sections.push(lines.join("\n"));
+
+  return sections.join("\n");
+}
+
+function dumpYaml(value: unknown): string {
+  return yaml.dump(value, {
+    noRefs: true,
+    lineWidth: -1,
+    noCompatMode: true,
+    schema: yaml.JSON_SCHEMA,
+  });
+}
+
+function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {
+  const indent = "  ".repeat(depth);
+  const parts: string[] = [];
+
+  parts.push(`[${node.type}]`);
+  parts.push(quote(node.name));
+  parts.push(`#${node.id}`);
+
+  // Order chosen to put high-signal properties first
+  if (node.layout !== undefined) parts.push(`layout=${node.layout}`);
+  if (node.fills !== undefined) parts.push(`fills=${maybeQuote(node.fills)}`);
+  if (node.strokes !== undefined) parts.push(`strokes=${maybeQuote(node.strokes)}`);
+  if (node.strokeWeight !== undefined) parts.push(`strokeWeight=${maybeQuote(node.strokeWeight)}`);
+  if (node.strokeWeights !== undefined) {
+    parts.push(`strokeWeights=${maybeQuote(node.strokeWeights)}`);
+  }
+  if (node.strokeDashes !== undefined) parts.push(`strokeDashes=${node.strokeDashes.join(",")}`);
+  if (node.effects !== undefined) parts.push(`effects=${maybeQuote(node.effects)}`);
+  if (node.opacity !== undefined) parts.push(`opacity=${node.opacity}`);
+  if (node.borderRadius !== undefined) parts.push(`borderRadius=${maybeQuote(node.borderRadius)}`);
+  if (node.styles !== undefined) parts.push(`styles=${maybeQuote(node.styles)}`);
+  if (node.componentId !== undefined) parts.push(`componentId=${node.componentId}`);
+  if (node.componentProperties !== undefined) {
+    parts.push(`componentProperties=${encodeRecord(node.componentProperties)}`);
+  }
+  if (node.componentPropertyReferences !== undefined) {
+    parts.push(`componentPropertyReferences=${encodeRecord(node.componentPropertyReferences)}`);
+  }
+  if (node.textStyle !== undefined) parts.push(`textStyle=${node.textStyle}`);
+  if (node.boldWeight !== undefined) parts.push(`boldWeight=${node.boldWeight}`);
+  if (node.text !== undefined) parts.push(`text=${quote(node.text)}`);
+
+  out.push(indent + parts.join(" "));
+
+  if (node.children) {
+    for (const child of node.children) {
+      renderNode(child, depth + 1, out);
+    }
+  }
+}
+
+// Always JSON-quote name and text so embedded whitespace, quotes, or newlines
+// can't break the line-per-node parse contract.
+function quote(s: string): string {
+  return JSON.stringify(s);
+}
+
+// Quote only when the value would otherwise break the space-separated
+// `key=value` parse — keeps short scalar refs (`layout_ABC`, `12px`) unquoted.
+function maybeQuote(s: string): string {
+  return /[\s"]/.test(s) ? JSON.stringify(s) : s;
+}
+
+// Inline a Record as key:val pairs joined by commas. Values that contain commas
+// or colons (rare in component property names/values, but possible) are quoted.
+function encodeRecord(record: Record<string, string | boolean>): string {
+  const entries = Object.entries(record).map(([k, v]) => {
+    const val = typeof v === "string" && /[,:\s"]/.test(v) ? JSON.stringify(v) : String(v);
+    return `${k}:${val}`;
+  });
+  return entries.join(",");
+}

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,6 +1,6 @@
-import yaml from "js-yaml";
 import { serializeAsTree } from "./serialize-tree.js";
 import type { SerializableDesign } from "./serializable-design.js";
+import { dumpYaml } from "./yaml-dump.js";
 
 export type OutputFormat = "yaml" | "json" | "tree";
 
@@ -15,19 +15,7 @@ export function isOutputFormat(value: string): value is OutputFormat {
 // shape and casts at its boundary. Production callers go through
 // `wrapForSerialization` which enforces the contract at compile time.
 export function serializeResult(result: unknown, format: OutputFormat): string {
-  if (format === "json") {
-    return JSON.stringify(result, null, 2);
-  }
-  if (format === "tree") {
-    return serializeAsTree(result as SerializableDesign);
-  }
-  // Output goes to LLMs, not human editors — optimize for speed over readability.
-  // noRefs skips O(n²) reference detection; lineWidth:-1 skips line-folding;
-  // JSON_SCHEMA reduces per-string implicit type checks.
-  return yaml.dump(result, {
-    noRefs: true,
-    lineWidth: -1,
-    noCompatMode: true,
-    schema: yaml.JSON_SCHEMA,
-  });
+  if (format === "json") return JSON.stringify(result, null, 2);
+  if (format === "tree") return serializeAsTree(result as SerializableDesign);
+  return dumpYaml(result);
 }

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,8 +1,15 @@
 import yaml from "js-yaml";
+import type { SimplifiedDesign } from "~/extractors/types.js";
+import { serializeAsTree } from "./serialize-tree.js";
 
-export function serializeResult(result: unknown, format: "yaml" | "json"): string {
+export type OutputFormat = "yaml" | "json" | "tree";
+
+export function serializeResult(result: unknown, format: OutputFormat): string {
   if (format === "json") {
     return JSON.stringify(result, null, 2);
+  }
+  if (format === "tree") {
+    return serializeAsTree(result as SimplifiedDesign);
   }
   // Output goes to LLMs, not human editors — optimize for speed over readability.
   // noRefs skips O(n²) reference detection; lineWidth:-1 skips line-folding;

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,15 +1,25 @@
 import yaml from "js-yaml";
-import type { SimplifiedDesign } from "~/extractors/types.js";
 import { serializeAsTree } from "./serialize-tree.js";
+import type { SerializableDesign } from "./serializable-design.js";
 
 export type OutputFormat = "yaml" | "json" | "tree";
 
+export const VALID_OUTPUT_FORMATS: readonly OutputFormat[] = ["yaml", "json", "tree"];
+
+export function isOutputFormat(value: string): value is OutputFormat {
+  return (VALID_OUTPUT_FORMATS as readonly string[]).includes(value);
+}
+
+// Accepts `unknown` so YAML/JSON callers can pass arbitrary structures (tests,
+// debug dumps, partial fixtures); the tree path requires the design wrapper
+// shape and casts at its boundary. Production callers go through
+// `wrapForSerialization` which enforces the contract at compile time.
 export function serializeResult(result: unknown, format: OutputFormat): string {
   if (format === "json") {
     return JSON.stringify(result, null, 2);
   }
   if (format === "tree") {
-    return serializeAsTree(result as SimplifiedDesign);
+    return serializeAsTree(result as SerializableDesign);
   }
   // Output goes to LLMs, not human editors — optimize for speed over readability.
   // noRefs skips O(n²) reference detection; lineWidth:-1 skips line-folding;

--- a/src/utils/yaml-dump.ts
+++ b/src/utils/yaml-dump.ts
@@ -1,0 +1,13 @@
+import yaml from "js-yaml";
+
+// Output goes to LLMs, not human editors — optimize for speed over readability.
+// noRefs skips O(n²) reference detection; lineWidth:-1 skips line-folding;
+// JSON_SCHEMA reduces per-string implicit type checks.
+export function dumpYaml(value: unknown): string {
+  return yaml.dump(value, {
+    noRefs: true,
+    lineWidth: -1,
+    noCompatMode: true,
+    schema: yaml.JSON_SCHEMA,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a third output format alongside YAML and JSON: a token-efficient indented tree format optimized for LLM consumption. Selectable via `--format=tree` flag or `OUTPUT_FORMAT=tree` env var. The existing `--json` flag becomes a back-compat alias for `--format=json`.

The tree format encodes structural keys (id, name, type, children) positionally on each node line, eliminating the YAML/JSON overhead of repeating those keys across thousands of nodes. Style values stay deduplicated in a `globalVars` block, so identical styling across many nodes still pays once. Net win over inline-only formats grows with how much style reuse a design has.

Node line format:
```
[TYPE] "name" #id key=value key=value ...
```

## What's in here

- **New format**: `src/utils/serialize-tree.ts` renders a `SerializableDesign` as the indented tree described above.
- **Plumbing**: `--format` flag on both `bin.ts` (server) and `commands/fetch.ts` (CLI), `OUTPUT_FORMAT` env var support in `getServerConfig`, and a shared `parseOutputFormat` that throws on invalid input so the CLI's `finally` (telemetry shutdown) still runs.
- **Type tightening**: replaces `"yaml" | "json"` literal unions across the call graph with a single `OutputFormat` type.
- **Helpers**: `scripts/compare-formats.ts` (byte-count comparison on a fixture) and `scripts/render-fixture.ts` (render a saved SimplifiedDesign in any format — used to feed pre-rendered data to sub-agents during benchmarks).
- **Refactor**: extracted `wrapForSerialization` so the wrapping shape lives in one place, and pulled `dumpYaml` into `src/utils/yaml-dump.ts` to avoid a circular import between the YAML and tree paths.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm test` — 160 passed, 1 pre-existing skip (includes 2 new tree-format tests covering the wrapping contract and quoting/escaping)
- [x] `pnpm lint` — only pre-existing warnings in `scripts/debug-fetch.ts`
- [x] Manual: `pnpm start --format=tree` and `pnpm fetch:cli --format=tree <fileKey>` against a real design and eyeball the output
- [x] Manual: confirm `--json` alias and `OUTPUT_FORMAT` env var still work
- [x] Manual: invalid `--format=foo` exits with a helpful message and doesn't strand the telemetry queue