### PR TITLE
fix: guide LLMs to fix bad node-id errors (proto/branch/figjam URLs)

### DIFF
--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -57,9 +57,13 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
     if (nodeData === null) {
       tagError(
         new Error(
-          `Node ${nodeId} was not found in the Figma file. ` +
-            `It may have been deleted or the link may be outdated. ` +
-            `Try copying a fresh link from the Figma file.`,
+          `Node ${nodeId} was not found in the Figma file. Likely causes: ` +
+            `(1) The source URL was a /proto/, /figjam/, /slides/, /board/, or /deck/ link — ` +
+            `only /design/ and /file/ URLs are supported by the Figma REST API. ` +
+            `(2) The node is inside a Figma branch — branches have their own fileKey ` +
+            `(the value after /branch/ in the URL), use that instead of the parent file's key. ` +
+            `(3) The link is stale or the node was deleted. ` +
+            `Ask the user for a fresh /design/ URL pointing to the specific frame.`,
         ),
         { category: "not_found" },
       );


### PR DESCRIPTION
## Summary

When a node lookup returns null from Figma's REST API, the error previously said *"It may have been deleted or the link may be outdated. Try copying a fresh link from the Figma file."* That hint is wrong for the most common case: the source URL was a `/proto/`, `/figjam/`, `/slides/`, `/board/`, `/deck/`, or branch URL, and re-copying the same kind of URL produces the same null. The REST API simply doesn't serve nodes from those surfaces.

This shows up often in `not_found` telemetry, and the misleading hint kept LLMs (and the people using them) stuck in a retry loop instead of fixing the input.

The new message names the three real causes so the LLM can self-correct or ask the user for the right URL:

1. Unsupported URL type — only `/design/` and `/file/` URLs work
2. Branch URL — the branch has its own `fileKey` after `/branch/`, use that instead
3. Genuinely stale or deleted node

Relates to #201 (original `/proto/` crash report). The crash itself was fixed in #344; this addresses the leftover "tried a prototype URL, got nothing useful" experience.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (158/158)
- [ ] Trigger in a live MCP client and confirm the new message reads well