### PR TITLE
fix(layout): respect parent axis for dimensions

### DIFF
--- a/src/tests/layout-alignment.test.ts
+++ b/src/tests/layout-alignment.test.ts
@@ -245,4 +245,23 @@ describe("layout alignment", () => {
       expect(buildSimplifiedLayout(node).alignItems).toBe("center");
     });
   });
+
+  describe("dimensions in parent auto layout", () => {
+    test("keeps fixed height when a row child stretches across a column parent", () => {
+      const parent = makeFrame({
+        layoutMode: "VERTICAL",
+        absoluteBoundingBox: { x: 0, y: 0, width: 536, height: 158 },
+      });
+      const child = makeFrame({
+        layoutMode: "HORIZONTAL",
+        absoluteBoundingBox: { x: 0, y: 80, width: 536, height: 78 },
+        layoutAlign: "STRETCH",
+        layoutGrow: 0,
+        layoutSizingHorizontal: "FILL",
+        layoutSizingVertical: "FIXED",
+      });
+
+      expect(buildSimplifiedLayout(child, parent).dimensions).toEqual({ height: 78 });
+    });
+  });
 });

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -183,6 +183,13 @@ function buildSimplifiedFrameValues(n: FigmaDocumentNode): SimplifiedLayout | { 
   return frameValues;
 }
 
+function getParentAutoLayoutMode(parent?: FigmaDocumentNode): "row" | "column" | undefined {
+  if (!isFrame(parent)) return undefined;
+  if (parent.layoutMode === "HORIZONTAL") return "row";
+  if (parent.layoutMode === "VERTICAL") return "column";
+  return undefined;
+}
+
 function buildSimplifiedLayoutValues(
   n: FigmaDocumentNode,
   parent: FigmaDocumentNode | undefined,
@@ -217,15 +224,18 @@ function buildSimplifiedLayoutValues(
   // Handle dimensions based on layout growth and alignment
   if (isRectangle("absoluteBoundingBox", n)) {
     const dimensions: { width?: number; height?: number; aspectRatio?: number } = {};
+    const sizingMode = isInAutoLayoutFlow(n, parent)
+      ? (getParentAutoLayoutMode(parent) ?? mode)
+      : mode;
 
     // Only include dimensions that aren't meant to stretch
-    if (mode === "row") {
+    if (sizingMode === "row") {
       // AutoLayout row, only include dimensions if the node is not growing
       if (!n.layoutGrow && n.layoutSizingHorizontal == "FIXED")
         dimensions.width = n.absoluteBoundingBox.width;
       if (n.layoutAlign !== "STRETCH" && n.layoutSizingVertical == "FIXED")
         dimensions.height = n.absoluteBoundingBox.height;
-    } else if (mode === "column") {
+    } else if (sizingMode === "column") {
       // AutoLayout column, only include dimensions if the node is not growing
       if (n.layoutAlign !== "STRETCH" && n.layoutSizingHorizontal == "FIXED")
         dimensions.width = n.absoluteBoundingBox.width;


### PR DESCRIPTION
## Summary
Fix simplified layout dimensions for Auto Layout children whose own layout direction differs from their parent.

## Background
A Figma node can be an Auto Layout container itself while also being a child inside another Auto Layout parent. For example, a button may define its own horizontal Auto Layout for internal text/icon alignment, while the button itself is placed inside a vertical parent stack.

In that situation, the child can have `layoutMode = HORIZONTAL`, parent `layoutMode = VERTICAL`, `layoutAlign = STRETCH`, `layoutSizingHorizontal = FILL`, `layoutSizingVertical = FIXED`, and a concrete `absoluteBoundingBox.height`.

The previous dimension filtering used the child node's own `layoutMode` to decide which axis `layoutAlign: STRETCH` applies to. That incorrectly treated vertical size as stretch-controlled and omitted the fixed height from simplified output, even though `STRETCH` applies to the parent's cross axis, which is horizontal for a vertical parent.

## Minimal Reproduction

### Raw Figma Input

```json
{
  "id": "parent",
  "type": "FRAME",
  "layoutMode": "VERTICAL",
  "absoluteBoundingBox": {
    "x": 0,
    "y": 0,
    "width": 536,
    "height": 158
  },
  "children": [
    {
      "id": "child",
      "type": "FRAME",
      "layoutMode": "HORIZONTAL",
      "layoutAlign": "STRETCH",
      "layoutGrow": 0,
      "layoutSizingHorizontal": "FILL",
      "layoutSizingVertical": "FIXED",
      "absoluteBoundingBox": {
        "x": 0,
        "y": 80,
        "width": 536,
        "height": 78
      },
      "children": []
    }
  ]
}
```

### Previous Simplified Output

```yaml
layout:
  mode: row
  alignSelf: stretch
  sizing:
    horizontal: fill
    vertical: fixed
```

`dimensions.height` was missing, even though the child has fixed vertical sizing and a concrete `absoluteBoundingBox.height`.

### Expected Simplified Output

```yaml
layout:
  mode: row
  alignSelf: stretch
  sizing:
    horizontal: fill
    vertical: fixed
  dimensions:
    height: 78
```

## Fix
When a node participates in its parent Auto Layout flow, dimension filtering now derives the sizing axis from the parent `layoutMode` instead of the child node's own `layoutMode`.

This preserves fixed dimensions on the unaffected axis while keeping the existing behavior for dimensions controlled by stretch or grow.

## Test Plan
- [x] `pnpm test -- src/tests/layout-alignment.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm lint`