### PR TITLE
fix: stop collapsing auto-layout frames to a single IMAGE-SVG

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -337,11 +337,11 @@ const COLLAPSIBLE_CONTAINER_TYPES = new Set(["FRAME", "GROUP", "INSTANCE", "BOOL
  * is a decorative pattern (dotted backgrounds, noise grids) where the payload cost of
  * preserving every leaf outweighs the structural value, and we collapse anyway.
  *
- * Pivot point chosen empirically: real charts and structural displays rarely exceed ~15
+ * Pivot point chosen empirically: real charts and structural displays rarely exceed ~10
  * primitives; decorative patterns typically have many dozens. Tune if real-world output
  * shows either category mis-classified.
  */
-const SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD = 15;
+const SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD = 10;
 
 /**
  * afterChildren callback that collapses SVG-heavy containers to IMAGE-SVG.

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -20,7 +20,7 @@ import {
   simplifyPropertyDefinitions,
   simplifyPropertyReferences,
 } from "~/transformers/component.js";
-import { hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
+import { hasAutoLayout, hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { generateVarId, isVisible, stableStringify } from "~/utils/common.js";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
 
@@ -311,9 +311,11 @@ export const layoutOnly = [layoutExtractor];
 
 /**
  * Node types that can be exported as SVG images.
- * When a FRAME, GROUP, INSTANCE, or BOOLEAN_OPERATION contains only these types, we can collapse
- * it to IMAGE-SVG. BOOLEAN_OPERATION is included because it's both a collapsible container AND
- * SVG-eligible as a child (boolean ops always produce vector output).
+ * When a collapsible container holds only these types, the container can be flattened to
+ * IMAGE-SVG. BOOLEAN_OPERATION is in both this set and the container set below because it's
+ * both collapsible AND SVG-eligible as a child (boolean ops always produce vector output).
+ *
+ * Tightly coupled to node-walker.ts, which renames VECTOR → IMAGE-SVG before this set is consulted.
  */
 export const SVG_ELIGIBLE_TYPES = new Set([
   "IMAGE-SVG", // VECTOR nodes are converted to IMAGE-SVG, or containers that were collapsed
@@ -325,11 +327,34 @@ export const SVG_ELIGIBLE_TYPES = new Set([
   "RECTANGLE",
 ]);
 
+/** Container node types eligible to collapse into a single IMAGE-SVG. */
+const COLLAPSIBLE_CONTAINER_TYPES = new Set(["FRAME", "GROUP", "INSTANCE", "BOOLEAN_OPERATION"]);
+
+/**
+ * Auto-layout signals authored structure — the spacing between children is intentional, so
+ * we normally preserve the container even when all its children are SVG-eligible (charts,
+ * toolbars, layout test frames). Above this many children, though, we assume the container
+ * is a decorative pattern (dotted backgrounds, noise grids) where the payload cost of
+ * preserving every leaf outweighs the structural value, and we collapse anyway.
+ *
+ * Pivot point chosen empirically: real charts and structural displays rarely exceed ~15
+ * primitives; decorative patterns typically have many dozens. Tune if real-world output
+ * shows either category mis-classified.
+ */
+const SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD = 15;
+
 /**
  * afterChildren callback that collapses SVG-heavy containers to IMAGE-SVG.
  *
- * If a FRAME, GROUP, INSTANCE, or BOOLEAN_OPERATION contains only SVG-eligible children, the parent
- * is marked as IMAGE-SVG and children are omitted, reducing payload size.
+ * Collapses when:
+ *   - container is a FRAME, GROUP, INSTANCE, or BOOLEAN_OPERATION
+ *   - all children are SVG-eligible types
+ *   - neither the node nor any direct child has an image fill
+ *   - container is NOT auto-layout, OR child count is past the decorative-pattern threshold
+ *
+ * The auto-layout carve-out preserves authored layouts (bar charts, button rows) that
+ * happen to bottom out in shape primitives. The count threshold reclaims payload for
+ * decorative patterns built with auto-layout grids.
  *
  * @param node - Original Figma node
  * @param result - SimplifiedNode being built
@@ -341,23 +366,16 @@ export function collapseSvgContainers(
   result: SimplifiedNode,
   children: SimplifiedNode[],
 ): SimplifiedNode[] {
-  const allChildrenAreSvgEligible = children.every((child) => SVG_ELIGIBLE_TYPES.has(child.type));
+  if (!COLLAPSIBLE_CONTAINER_TYPES.has(node.type)) return children;
+  if (!children.every((child) => SVG_ELIGIBLE_TYPES.has(child.type))) return children;
+  if (hasImageFillOnSelfOrDirectChildren(node)) return children;
 
-  if (
-    (node.type === "FRAME" ||
-      node.type === "GROUP" ||
-      node.type === "INSTANCE" ||
-      node.type === "BOOLEAN_OPERATION") &&
-    allChildrenAreSvgEligible &&
-    !hasImageFillInChildren(node)
-  ) {
-    // Collapse to IMAGE-SVG and omit children
-    result.type = "IMAGE-SVG";
-    return [];
+  if (hasAutoLayout(node) && children.length < SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD) {
+    return children;
   }
 
-  // Include all children normally
-  return children;
+  result.type = "IMAGE-SVG";
+  return [];
 }
 
 /**
@@ -367,7 +385,7 @@ export function collapseSvgContainers(
  * if a deeper descendant has image fills, its parent won't collapse (stays FRAME),
  * and FRAME isn't SVG-eligible, so the chain breaks naturally at each level.
  */
-function hasImageFillInChildren(node: FigmaDocumentNode): boolean {
+function hasImageFillOnSelfOrDirectChildren(node: FigmaDocumentNode): boolean {
   if (hasValue("fills", node) && node.fills.some((fill) => fill.type === "IMAGE")) {
     return true;
   }

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -20,7 +20,7 @@ import {
   simplifyPropertyDefinitions,
   simplifyPropertyReferences,
 } from "~/transformers/component.js";
-import { hasAutoLayout, hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
+import { hasFlexLayout, hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { generateVarId, isVisible, stableStringify } from "~/utils/common.js";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
 
@@ -331,8 +331,8 @@ export const SVG_ELIGIBLE_TYPES = new Set([
 const COLLAPSIBLE_CONTAINER_TYPES = new Set(["FRAME", "GROUP", "INSTANCE", "BOOLEAN_OPERATION"]);
 
 /**
- * Auto-layout signals authored structure — the spacing between children is intentional, so
- * we normally preserve the container even when all its children are SVG-eligible (charts,
+ * Flex auto-layout signals authored structure — the spacing between children is intentional,
+ * so we normally preserve the container even when all its children are SVG-eligible (charts,
  * toolbars, layout test frames). Above this many children, though, we assume the container
  * is a decorative pattern (dotted backgrounds, noise grids) where the payload cost of
  * preserving every leaf outweighs the structural value, and we collapse anyway.
@@ -340,8 +340,12 @@ const COLLAPSIBLE_CONTAINER_TYPES = new Set(["FRAME", "GROUP", "INSTANCE", "BOOL
  * Pivot point chosen empirically: real charts and structural displays rarely exceed ~10
  * primitives; decorative patterns typically have many dozens. Tune if real-world output
  * shows either category mis-classified.
+ *
+ * Note: this only carves out HORIZONTAL/VERTICAL flex layouts. GRID auto-layout is not yet
+ * handled here — when GRID support lands, this guard should likely apply to GRID containers
+ * too, since a grid of structural primitives (swatches, tiles) is also authored intent.
  */
-const SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD = 10;
+const SVG_COLLAPSE_FLEX_THRESHOLD = 10;
 
 /**
  * afterChildren callback that collapses SVG-heavy containers to IMAGE-SVG.
@@ -350,11 +354,11 @@ const SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD = 10;
  *   - container is a FRAME, GROUP, INSTANCE, or BOOLEAN_OPERATION
  *   - all children are SVG-eligible types
  *   - neither the node nor any direct child has an image fill
- *   - container is NOT auto-layout, OR child count is past the decorative-pattern threshold
+ *   - container is NOT flex auto-layout, OR child count is past the decorative-pattern threshold
  *
- * The auto-layout carve-out preserves authored layouts (bar charts, button rows) that
+ * The flex-auto-layout carve-out preserves authored layouts (bar charts, button rows) that
  * happen to bottom out in shape primitives. The count threshold reclaims payload for
- * decorative patterns built with auto-layout grids.
+ * decorative patterns built with flex auto-layout (e.g., grids of dots).
  *
  * @param node - Original Figma node
  * @param result - SimplifiedNode being built
@@ -370,7 +374,7 @@ export function collapseSvgContainers(
   if (!children.every((child) => SVG_ELIGIBLE_TYPES.has(child.type))) return children;
   if (hasImageFillOnSelfOrDirectChildren(node)) return children;
 
-  if (hasAutoLayout(node) && children.length < SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD) {
+  if (hasFlexLayout(node) && children.length < SVG_COLLAPSE_FLEX_THRESHOLD) {
     return children;
   }
 

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -243,6 +243,81 @@ describe("collapseSvgContainers", () => {
     expect(nodes[0].type).toBe("IMAGE-SVG");
     expect(nodes[0].children).toBeUndefined();
   });
+
+  // Auto-layout signals authored structure — the spacing between children is
+  // intentional, so we should preserve the container even when its children
+  // are all SVG-eligible (e.g., bar charts, button rows, layout test frames).
+  it("does not collapse an auto-layout frame whose children are all SVG-eligible", async () => {
+    const autoLayoutRow = makeNode({
+      id: "7:1",
+      name: "Bar Chart",
+      type: "FRAME",
+      clipsContent: false,
+      layoutMode: "HORIZONTAL",
+      itemSpacing: 8,
+      children: [
+        makeNode({ id: "7:2", name: "Bar 1", type: "RECTANGLE" }),
+        makeNode({ id: "7:3", name: "Bar 2", type: "RECTANGLE" }),
+        makeNode({ id: "7:4", name: "Bar 3", type: "RECTANGLE" }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([autoLayoutRow], allExtractors, {
+      afterChildren: collapseSvgContainers,
+    });
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("FRAME");
+    expect(nodes[0].children).toHaveLength(3);
+  });
+
+  // Escape hatch for decorative patterns: enough leaf primitives that the
+  // payload cost outweighs the structural value (e.g., dotted backgrounds
+  // built from grids of ellipses).
+  it("collapses an auto-layout frame with many SVG-eligible children", async () => {
+    const dotRow = makeNode({
+      id: "8:1",
+      name: "Dot Row",
+      type: "FRAME",
+      clipsContent: false,
+      layoutMode: "HORIZONTAL",
+      itemSpacing: 4,
+      children: Array.from({ length: 20 }, (_, i) =>
+        makeNode({ id: `8:${i + 2}`, name: `Dot ${i}`, type: "ELLIPSE" }),
+      ),
+    });
+
+    const { nodes } = await extractFromDesign([dotRow], allExtractors, {
+      afterChildren: collapseSvgContainers,
+    });
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("IMAGE-SVG");
+    expect(nodes[0].children).toBeUndefined();
+  });
+
+  // Non-auto-layout container with shape children is the original target case:
+  // hand-drawn icons made of vector primitives. Must keep collapsing.
+  it("still collapses a non-auto-layout frame whose children are all SVG-eligible", async () => {
+    const iconFrame = makeNode({
+      id: "9:1",
+      name: "Icon",
+      type: "FRAME",
+      clipsContent: false,
+      children: [
+        makeNode({ id: "9:2", name: "Circle", type: "ELLIPSE" }),
+        makeNode({ id: "9:3", name: "Rect", type: "RECTANGLE" }),
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([iconFrame], allExtractors, {
+      afterChildren: collapseSvgContainers,
+    });
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("IMAGE-SVG");
+    expect(nodes[0].children).toBeUndefined();
+  });
 });
 
 describe("component property support", () => {

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -1,4 +1,10 @@
-import { isInAutoLayoutFlow, isFrame, isLayout, isRectangle } from "~/utils/identity.js";
+import {
+  hasAutoLayout,
+  isInAutoLayoutFlow,
+  isFrame,
+  isLayout,
+  isRectangle,
+} from "~/utils/identity.js";
 import type {
   Node as FigmaDocumentNode,
   HasFramePropertiesTrait,
@@ -141,12 +147,7 @@ function buildSimplifiedFrameValues(n: FigmaDocumentNode): SimplifiedLayout | { 
   }
 
   const frameValues: SimplifiedLayout = {
-    mode:
-      !n.layoutMode || n.layoutMode === "NONE"
-        ? "none"
-        : n.layoutMode === "HORIZONTAL"
-          ? "row"
-          : "column",
+    mode: !hasAutoLayout(n) ? "none" : n.layoutMode === "HORIZONTAL" ? "row" : "column",
   };
 
   const overflowScroll: SimplifiedLayout["overflowScroll"] = [];

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -1,5 +1,5 @@
 import {
-  hasAutoLayout,
+  hasFlexLayout,
   isInAutoLayoutFlow,
   isFrame,
   isLayout,
@@ -147,7 +147,7 @@ function buildSimplifiedFrameValues(n: FigmaDocumentNode): SimplifiedLayout | { 
   }
 
   const frameValues: SimplifiedLayout = {
-    mode: !hasAutoLayout(n) ? "none" : n.layoutMode === "HORIZONTAL" ? "row" : "column",
+    mode: !hasFlexLayout(n) ? "none" : n.layoutMode === "HORIZONTAL" ? "row" : "column",
   };
 
   const overflowScroll: SimplifiedLayout["overflowScroll"] = [];

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -47,6 +47,14 @@ export function isLayout(val: unknown): val is HasLayoutTrait {
 }
 
 /**
+ * Whether a node uses auto-layout (HORIZONTAL or VERTICAL layoutMode).
+ * Non-frame nodes return false. Frames without layoutMode (or with "NONE") return false.
+ */
+export function hasAutoLayout(val: unknown): boolean {
+  return isFrame(val) && (val.layoutMode === "HORIZONTAL" || val.layoutMode === "VERTICAL");
+}
+
+/**
  * Checks if:
  * 1. A node is a child to an auto layout frame
  * 2. The child adheres to the auto layout rules—i.e. it's not absolutely positioned
@@ -56,13 +64,7 @@ export function isLayout(val: unknown): val is HasLayoutTrait {
  * @returns True if the node is a child of an auto layout frame, false otherwise.
  */
 export function isInAutoLayoutFlow(node: unknown, parent: unknown): boolean {
-  const autoLayoutModes = ["HORIZONTAL", "VERTICAL"];
-  return (
-    isFrame(parent) &&
-    autoLayoutModes.includes(parent.layoutMode ?? "NONE") &&
-    isLayout(node) &&
-    node.layoutPositioning !== "ABSOLUTE"
-  );
+  return hasAutoLayout(parent) && isLayout(node) && node.layoutPositioning !== "ABSOLUTE";
 }
 
 export function isStrokeWeights(val: unknown): val is StrokeWeights {

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -47,24 +47,30 @@ export function isLayout(val: unknown): val is HasLayoutTrait {
 }
 
 /**
- * Whether a node uses auto-layout (HORIZONTAL or VERTICAL layoutMode).
- * Non-frame nodes return false. Frames without layoutMode (or with "NONE") return false.
+ * Whether a node uses flex-style auto-layout (HORIZONTAL or VERTICAL layoutMode).
+ *
+ * Deliberately narrower than Figma's general "auto-layout" concept, which also includes
+ * `layoutMode: "GRID"`. GRID has a different positioning model (gridRowAnchorIndex etc.)
+ * and callers that care about row/column flex semantics specifically should use this;
+ * callers that want "any non-NONE auto-layout" need a separate, broader predicate.
  */
-export function hasAutoLayout(val: unknown): boolean {
+export function hasFlexLayout(val: unknown): boolean {
   return isFrame(val) && (val.layoutMode === "HORIZONTAL" || val.layoutMode === "VERTICAL");
 }
 
 /**
  * Checks if:
- * 1. A node is a child to an auto layout frame
+ * 1. A node is a child to a flex auto-layout frame
  * 2. The child adheres to the auto layout rules—i.e. it's not absolutely positioned
+ *
+ * Does NOT cover GRID auto-layout — see `hasFlexLayout` for why.
  *
  * @param node - The node to check.
  * @param parent - The parent node.
- * @returns True if the node is a child of an auto layout frame, false otherwise.
+ * @returns True if the node is a child of a flex auto-layout frame, false otherwise.
  */
 export function isInAutoLayoutFlow(node: unknown, parent: unknown): boolean {
-  return hasAutoLayout(parent) && isLayout(node) && node.layoutPositioning !== "ABSOLUTE";
+  return hasFlexLayout(parent) && isLayout(node) && node.layoutPositioning !== "ABSOLUTE";
 }
 
 export function isStrokeWeights(val: unknown): val is StrokeWeights {


### PR DESCRIPTION
## What changed

Auto-layout containers whose children all happen to be shape primitives (rectangles, ellipses, etc.) are no longer flattened into a single `IMAGE-SVG` node. The authored structure — the row of bars in a chart, the toolbar of icon buttons, a layout-test frame of rectangles — now survives extraction.

## Why

The previous rule was "all children SVG-eligible → collapse the container." That's the right call for hand-drawn icons made of vector parts, but it was also discarding meaningful structure any time a designer used auto-layout to arrange shape primitives: bar charts collapsed to one opaque blob, button rows lost their spacing, and the test fixture I was using to validate auto-layout positions returned a single `IMAGE-SVG` with no children.

## How the rule changed

A container collapses to `IMAGE-SVG` when:
- It's a FRAME, GROUP, INSTANCE, or BOOLEAN_OPERATION
- All children are SVG-eligible primitives
- Neither it nor its direct children have image fills
- **AND** it doesn't have auto-layout **OR** child count ≥ 10

The auto-layout carve-out preserves authored intent. The count threshold (10) is the escape hatch for decorative patterns — dotted/noise backgrounds built from grids of ellipses, where the per-leaf payload cost dwarfs the structural value.

## Test plan

- [x] New unit tests: auto-layout frame of 3 rectangles preserves structure; auto-layout frame of 20 ellipses collapses; non-auto-layout frame of shapes still collapses (regression guard)
- [x] Existing `collapseSvgContainers` tests still pass (BOOLEAN_OPERATION cases)
- [x] Full test suite: 165 passing
- [x] `pnpm type-check` and `pnpm lint` clean
- [x] Manual verification on the "Layouts 3" Figma fixture that triggered the report