### PR TITLE
fix(layout): include positions for children of SECTION nodes

### DIFF
--- a/src/tests/layout-alignment.test.ts
+++ b/src/tests/layout-alignment.test.ts
@@ -264,4 +264,58 @@ describe("layout alignment", () => {
       expect(buildSimplifiedLayout(child, parent).dimensions).toEqual({ height: 78 });
     });
   });
+
+  describe("locationRelativeToParent", () => {
+    // SECTION holds children but has no frame properties (no clipsContent, no
+    // layoutMode), so it can never auto-layout — children are always positioned
+    // absolutely within it. Regression guard: a stricter `isFrame(parent)` gate
+    // previously dropped positions for SECTION children entirely.
+    test("emits position for children of a SECTION parent", () => {
+      const section = {
+        type: "SECTION",
+        absoluteBoundingBox: { x: 100, y: 200, width: 708, height: 245 },
+      } as unknown as FigmaDocumentNode;
+      const child = makeFrame({
+        layoutMode: "NONE",
+        absoluteBoundingBox: { x: 120, y: 210, width: 50, height: 50 },
+      });
+
+      expect(buildSimplifiedLayout(child, section).locationRelativeToParent).toEqual({
+        x: 20,
+        y: 10,
+      });
+    });
+
+    test("omits position for top-level nodes (no parent)", () => {
+      const node = makeFrame({
+        absoluteBoundingBox: { x: 100, y: 200, width: 50, height: 50 },
+      });
+      expect(buildSimplifiedLayout(node).locationRelativeToParent).toBeUndefined();
+    });
+
+    test("omits position for in-flow children of an auto-layout parent", () => {
+      const parent = makeFrame({
+        layoutMode: "HORIZONTAL",
+        absoluteBoundingBox: { x: 0, y: 0, width: 200, height: 100 },
+      });
+      const child = makeFrame({
+        absoluteBoundingBox: { x: 10, y: 10, width: 50, height: 50 },
+      });
+      expect(buildSimplifiedLayout(child, parent).locationRelativeToParent).toBeUndefined();
+    });
+
+    test("emits position for ABSOLUTE children inside an auto-layout parent", () => {
+      const parent = makeFrame({
+        layoutMode: "HORIZONTAL",
+        absoluteBoundingBox: { x: 0, y: 0, width: 200, height: 100 },
+      });
+      const child = makeFrame({
+        layoutPositioning: "ABSOLUTE",
+        absoluteBoundingBox: { x: 30, y: 40, width: 50, height: 50 },
+      });
+      const result = buildSimplifiedLayout(child, parent);
+      expect(result.position).toBe("absolute");
+      expect(result.locationRelativeToParent).toEqual({ x: 30, y: 40 });
+    });
+  });
 });

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -204,12 +204,11 @@ function buildSimplifiedLayoutValues(
     vertical: convertSizing(n.layoutSizingVertical),
   };
 
-  // Only include positioning-related properties if parent layout isn't flex or if the node is absolute
-  if (
-    // If parent is a frame but not an AutoLayout, or if the node is absolute, include positioning-related properties
-    isFrame(parent) &&
-    !isInAutoLayoutFlow(n, parent)
-  ) {
+  // Emit positioning relative to parent unless the parent's auto-layout already
+  // places this child. `isLayout(parent)` also screens out top-level nodes
+  // (no parent) and parents without bounding boxes (e.g. CANVAS), where
+  // coordinates would be meaningless.
+  if (isLayout(parent) && !isInAutoLayoutFlow(n, parent)) {
     if (n.layoutPositioning === "ABSOLUTE") {
       layoutValues.position = "absolute";
     }

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -20,9 +20,12 @@ export function hasValue<K extends PropertyKey, T>(
   return typeGuard ? typeGuard(val) : val !== undefined;
 }
 
-// Checks for frame *traits*, not node type. Many node types (FRAME, COMPONENT,
-// INSTANCE, SECTION, etc.) carry frame properties. Structural checking via
-// `clipsContent` covers all of them without maintaining a type-string list.
+// Checks for `HasFramePropertiesTrait`, not node type. This is the FRAME family
+// — FRAME, GROUP, COMPONENT, COMPONENT_SET, INSTANCE — i.e. the nodes that can
+// carry auto-layout properties like `layoutMode`, `paddingTop`, etc. NOT a
+// general "is container" check: SECTION, BOOLEAN_OPERATION, and TABLE all hold
+// children but do not have frame properties. Structural checking via
+// `clipsContent` covers the FRAME family without maintaining a type-string list.
 export function isFrame(val: unknown): val is HasFramePropertiesTrait {
   return (
     typeof val === "object" &&


### PR DESCRIPTION
## What

When fetching a Figma node that lives inside a SECTION, the MCP output now includes `locationRelativeToParent` for each direct child of the SECTION. Previously these coordinates were silently dropped, so downstream LLMs had no way to position children within a section-rooted design — they'd see four frames with no x/y and stack them arbitrarily.

## Why

Sections can't auto-layout, so children output without positioning data have to be guessed at.

Root cause: the positioning gate in `buildSimplifiedLayoutValues` required `isFrame(parent)`, which is a structural `clipsContent` check. SECTION carries `HasLayoutTrait` + `HasChildrenTrait` but not `HasFramePropertiesTrait`, so the gate excluded it.

## Fix

Switched the gate to `isLayout(parent)`, which is what the block actually needs (we use `parent.absoluteBoundingBox` to compute relative coordinates). It also naturally returns false for top-level extracted nodes (no parent in traversal context) and parents without bounding boxes (e.g. CANVAS), so the existing behavior for those cases is preserved.

Also fixed a comment on `isFrame` that incorrectly claimed SECTION carries frame properties — per `@figma/rest-api-spec`, it doesn't.

## Tests

Added four cases under `locationRelativeToParent`:
- SECTION-rooted child gets positions (the regression guard)
- Top-level node emits nothing
- In-flow child of an auto-layout parent emits nothing (no change)
- ABSOLUTE-positioned child of an auto-layout parent gets both `position: "absolute"` and coordinates (no change)