### PR TITLE
feat: support request bearer oauth tokens over HTTP

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -141,14 +141,15 @@ export async function startHttpServer(
   const handlePost = async (req: Request, res: Response) => {
     Logger.log("Received StreamableHTTP request");
     const requestKey = getRequestApiKey(req);
-    const auth = resolveRequestAuth(baseAuth, requestKey);
+    const requestBearerToken = getRequestBearerToken(req);
+    const auth = resolveRequestAuth(baseAuth, requestKey, requestBearerToken);
+    const requestSecrets = [requestKey, requestBearerToken].filter(
+      (secret): secret is string => !!secret,
+    );
 
-    // Per-request X-Figma-Token isn't known to telemetry's init-time redaction
-    // list. Wrapping the handler in `withRequestSecrets` makes the key
-    // available to `redactErrorMessage` via AsyncLocalStorage, so any error
-    // captured during this request gets the per-request token scrubbed before
-    // it ships to PostHog.
-    await telemetry.withRequestSecrets(requestKey ? [requestKey] : [], async () => {
+    // Request-level credentials are not known to telemetry's init-time
+    // redaction list, so make them available only for this request scope.
+    await telemetry.withRequestSecrets(requestSecrets, async () => {
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
       const mcpServer = createServer(auth, { ...serverOptions, transport: "http" });
       const conn: ActiveConnection = { transport, server: mcpServer };
@@ -210,19 +211,38 @@ export async function startHttpServer(
 function resolveRequestAuth(
   baseAuth: FigmaAuthOptions,
   requestKey: string | undefined,
+  requestBearerToken: string | undefined,
 ): FigmaAuthOptions {
-  if (!requestKey) return baseAuth;
-  return {
-    figmaApiKey: requestKey,
-    figmaOAuthToken: "",
-    useOAuth: false,
-  };
+  if (requestKey) {
+    return {
+      figmaApiKey: requestKey,
+      figmaOAuthToken: "",
+      useOAuth: false,
+    };
+  }
+
+  if (requestBearerToken) {
+    return {
+      figmaApiKey: "",
+      figmaOAuthToken: requestBearerToken,
+      useOAuth: true,
+    };
+  }
+
+  return baseAuth;
 }
 
 function getRequestApiKey(req: Request): string | undefined {
   const value = req.headers["x-figma-token"];
   if (Array.isArray(value)) return value[0]?.trim() || undefined;
   return value?.trim() || undefined;
+}
+
+function getRequestBearerToken(req: Request): string | undefined {
+  const value = req.headers.authorization;
+  const header = Array.isArray(value) ? value[0] : value;
+  const match = header?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || undefined;
 }
 
 export async function stopHttpServer(): Promise<void> {

--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -43,7 +43,7 @@ export class FigmaService {
 
     if (!this.apiKey) {
       throw new Error(
-        "Figma API authentication is required. Configure FIGMA_API_KEY or FIGMA_OAUTH_TOKEN on the server, or send X-Figma-Token on the HTTP request.",
+        "Figma API authentication is required. Configure FIGMA_API_KEY or FIGMA_OAUTH_TOKEN on the server, or send X-Figma-Token / Authorization: Bearer on the HTTP request.",
       );
     }
 

--- a/src/tests/http-header-auth.test.ts
+++ b/src/tests/http-header-auth.test.ts
@@ -129,6 +129,49 @@ describe("HTTP header Figma API key authentication", () => {
     expect(firstFigmaRequestHeaders()).toMatchObject({ "X-Figma-Token": "request-key" });
   });
 
+  it("uses Authorization bearer tokens from the HTTP request for get_figma_data", async () => {
+    await connectClient({ Authorization: "Bearer request-oauth-token" });
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "get_figma_data",
+          arguments: { fileKey: "abc123" },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(firstFigmaRequestHeaders()).toMatchObject({
+      Authorization: "Bearer request-oauth-token",
+    });
+  });
+
+  it("uses HTTP Authorization bearer tokens instead of the server API key", async () => {
+    await connectClient(
+      { Authorization: "Bearer request-oauth-token" },
+      { figmaApiKey: "server-key", figmaOAuthToken: "", useOAuth: false },
+    );
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "get_figma_data",
+          arguments: { fileKey: "abc123" },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(firstFigmaRequestHeaders()).toMatchObject({
+      Authorization: "Bearer request-oauth-token",
+    });
+  });
+
   it("returns a tool error when no server or request credentials are available", async () => {
     await connectClient();
 
@@ -146,7 +189,9 @@ describe("HTTP header Figma API key authentication", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe("text");
     if (result.content[0].type === "text") {
-      expect(result.content[0].text).toContain("send X-Figma-Token on the HTTP request");
+      expect(result.content[0].text).toContain(
+        "send X-Figma-Token / Authorization: Bearer on the HTTP request",
+      );
     }
     expect(figmaRequestCount()).toBe(0);
   });


### PR DESCRIPTION
## Summary

Related to #337.

- Accepts request-level `Authorization: Bearer TOKEN` on the Streamable HTTP endpoints
- Uses that bearer value as a request-scoped Figma OAuth token, matching the existing `FIGMA_OAUTH_TOKEN` forwarding path
- Includes the request bearer token in request-scoped telemetry redaction
- Updates the missing-credentials error text to mention both `X-Figma-Token` and `Authorization: Bearer`

This intentionally does not implement the full MCP OAuth discovery / authorization-code flow from #337. It keeps the change focused on the bearer-token request path that MCP HTTP clients already know how to send.

## Test plan

- [x] `pnpm exec vitest run src/tests/http-header-auth.test.ts`
- [x] `pnpm exec vitest run src/tests/http-header-auth.test.ts src/tests/telemetry-redaction.test.ts`
- [x] `src/tests/server.test.ts` filtered to the StreamableHTTP, method-not-allowed, multi-client, and lifecycle cases
- [x] `pnpm type-check`
- [x] `pnpm lint`

## Note

I did not use full `pnpm test` for the final local check on Windows because the existing process-level server test spawns `tsx` directly and fails locally with `spawn tsx ENOENT`. The related HTTP/auth/server subsets above passed.