### PR TITLE
feat(strokes): include strokeAlign in simplified stroke output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,12 @@ From CONTRIBUTING.md — important context for development:
 2. **Focused Scope** — The server only handles "ingesting designs for AI consumption." Out of scope: image manipulation, CMS syncing, code generation, third-party integrations.
 3. **Project-level Config** — Options unlikely to change between requests should be CLI arguments, not tool parameters.
 
+## Token Efficiency
+
+The simplified output is consumed by LLMs, so every field costs context budget. Keep it lean:
+
+- Omit default values where LLMs can reliably infer the expectation without explicit data — emit only deviations. (e.g. `strokeAlign: INSIDE` matches the default CSS `border` an LLM already produces, so it is dropped; only `OUTSIDE`/`CENTER` are emitted.)
+
 ## Quality
 
 This codebase will outlive you. Every shortcut becomes someone else's burden. Every hack compounds into technical debt that slows the whole team down.

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -172,6 +172,7 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
     if (strokes.strokeWeight) result.strokeWeight = strokes.strokeWeight;
     if (strokes.strokeDashes) result.strokeDashes = strokes.strokeDashes;
     if (strokes.strokeWeights) result.strokeWeights = strokes.strokeWeights;
+    if (strokes.strokeAlign) result.strokeAlign = strokes.strokeAlign;
   }
 
   // effects

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -123,6 +123,7 @@ export interface SimplifiedNode {
   strokeWeight?: string;
   strokeDashes?: number[];
   strokeWeights?: string;
+  strokeAlign?: "INSIDE" | "OUTSIDE" | "CENTER";
   effects?: string;
   opacity?: number;
   borderRadius?: string;

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -150,7 +150,7 @@ describe("extractFromDesign", () => {
     expect(colorEntries[0][0]).toMatch(/^fill_/);
   });
 
-  it("preserves stroke alignment on the simplified node", async () => {
+  it("preserves non-default stroke alignment on the simplified node", async () => {
     const node = makeNode({
       id: "9:1",
       name: "Card",
@@ -163,6 +163,22 @@ describe("extractFromDesign", () => {
     const { nodes } = await extractFromDesign([node], allExtractors);
 
     expect(nodes[0].strokeAlign).toBe("OUTSIDE");
+    expect(nodes[0].strokeWeight).toBe("2px");
+  });
+
+  it("omits INSIDE stroke alignment, the CSS-border default consumers assume", async () => {
+    const node = makeNode({
+      id: "9:2",
+      name: "Card",
+      type: "FRAME",
+      strokes: [{ type: "SOLID", color: { r: 0.89, g: 0.9, b: 0.9, a: 1 }, visible: true }],
+      strokeWeight: 2,
+      strokeAlign: "INSIDE",
+    });
+
+    const { nodes } = await extractFromDesign([node], allExtractors);
+
+    expect(nodes[0].strokeAlign).toBeUndefined();
     expect(nodes[0].strokeWeight).toBe("2px");
   });
 

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -150,6 +150,22 @@ describe("extractFromDesign", () => {
     expect(colorEntries[0][0]).toMatch(/^fill_/);
   });
 
+  it("preserves stroke alignment on the simplified node", async () => {
+    const node = makeNode({
+      id: "9:1",
+      name: "Card",
+      type: "FRAME",
+      strokes: [{ type: "SOLID", color: { r: 0.89, g: 0.9, b: 0.9, a: 1 }, visible: true }],
+      strokeWeight: 2,
+      strokeAlign: "OUTSIDE",
+    });
+
+    const { nodes } = await extractFromDesign([node], allExtractors);
+
+    expect(nodes[0].strokeAlign).toBe("OUTSIDE");
+    expect(nodes[0].strokeWeight).toBe("2px");
+  });
+
   it("disambiguates named styles when style names collide", async () => {
     const nodeA = makeNode({
       id: "7:1",

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -258,10 +258,7 @@ export function buildSimplifiedStrokes(
     strokes.strokeDashes = n.strokeDashes;
   }
 
-  if (
-    hasValue("strokeAlign", n) &&
-    (n.strokeAlign === "INSIDE" || n.strokeAlign === "OUTSIDE" || n.strokeAlign === "CENTER")
-  ) {
+  if (hasValue("strokeAlign", n) && (n.strokeAlign === "OUTSIDE" || n.strokeAlign === "CENTER")) {
     strokes.strokeAlign = n.strokeAlign;
   }
 

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -118,6 +118,7 @@ export type SimplifiedStroke = {
   strokeWeight?: string;
   strokeDashes?: number[];
   strokeWeights?: string;
+  strokeAlign?: "INSIDE" | "OUTSIDE" | "CENTER";
 };
 
 /**
@@ -255,6 +256,13 @@ export function buildSimplifiedStrokes(
 
   if (hasValue("strokeDashes", n) && Array.isArray(n.strokeDashes) && n.strokeDashes.length) {
     strokes.strokeDashes = n.strokeDashes;
+  }
+
+  if (
+    hasValue("strokeAlign", n) &&
+    (n.strokeAlign === "INSIDE" || n.strokeAlign === "OUTSIDE" || n.strokeAlign === "CENTER")
+  ) {
+    strokes.strokeAlign = n.strokeAlign;
   }
 
   if (hasValue("individualStrokeWeights", n, isStrokeWeights)) {


### PR DESCRIPTION
Stroke alignment was dropped during simplification, so consumers see only the color + weight and can't tell an inset border from an outset one. That's a material CSS difference — an `OUTSIDE` stroke is an outline / box-shadow ring, not an inset `border`. We hit this in practice: a code-gen agent rendered a Figma `OUTSIDE` hover border as an inset border on the wrong element, purely because the alignment wasn't in the data.

## Changes

- `buildSimplifiedStrokes` reads `strokeAlign` and includes it in `SimplifiedStroke`.
- Carried onto the simplified node in the built-in extractor.
- Added to the node type + a unit test in `tree-walker.test.ts`.
