### PR TITLE
feat(extractors): deduplicate repeated styles and subtrees to shrink output

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -21,7 +21,8 @@ import {
   simplifyPropertyReferences,
 } from "~/transformers/component.js";
 import { hasAutoLayout, hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
-import { generateVarId, isVisible, stableStringify } from "~/utils/common.js";
+import { isVisible, stableStringify } from "~/utils/common.js";
+import { createHash } from "node:crypto";
 import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
 
 // Reverse lookup cache: serialized style value → varId.
@@ -64,7 +65,12 @@ function findOrCreateVar(globalVars: GlobalVars, value: StyleTypes, prefix: stri
   const existing = cache.get(key);
   if (existing) return existing;
 
-  const varId = generateVarId(prefix);
+  // Content-addressed id: identical values collapse to one entry (same as a
+  // random id would, via the cache) AND the output is byte-stable across runs.
+  // Determinism matters here beyond reproducibility — element-template hashes
+  // embed these ids, so a stable id is what lets two identical subtrees hash to
+  // the same template. Mirrors FrameLink's sha1-based style names.
+  const varId = `${prefix}_${createHash("sha1").update(key).digest("hex").slice(0, 8)}`;
   globalVars.styles[varId] = value;
   cache.set(key, varId);
   return varId;
@@ -85,6 +91,9 @@ function registerStyle(
   if (styleMatch) {
     const styleKey = resolveStyleKey(context, styleMatch, value);
     context.globalVars.styles[styleKey] = value;
+    // Mark as a named style so the finalize pass keeps it hoisted even if only
+    // one node uses it — a named Figma style is design-system intent, not noise.
+    context.traversalState.namedStyleKeys.add(styleKey);
     return styleKey;
   }
   return findOrCreateVar(context.globalVars, value, prefix);
@@ -377,7 +386,10 @@ export function collapseSvgContainers(
   children: SimplifiedNode[],
 ): SimplifiedNode[] {
   if (!COLLAPSIBLE_CONTAINER_TYPES.has(node.type)) return children;
-  if (!children.every((child) => SVG_ELIGIBLE_TYPES.has(child.type))) return children;
+  // `type` is optional on SimplifiedNode only because post-walk template refs
+  // drop it; at afterChildren time (mid-walk) every child still has a type, so
+  // the `?? ""` is a type-level concession that never matches at runtime.
+  if (!children.every((child) => SVG_ELIGIBLE_TYPES.has(child.type ?? ""))) return children;
   if (hasImageFillOnSelfOrDirectChildren(node)) return children;
 
   if (hasAutoLayout(node) && children.length < SVG_COLLAPSE_AUTOLAYOUT_THRESHOLD) {

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -65,11 +65,8 @@ function findOrCreateVar(globalVars: GlobalVars, value: StyleTypes, prefix: stri
   const existing = cache.get(key);
   if (existing) return existing;
 
-  // Content-addressed id: identical values collapse to one entry (same as a
-  // random id would, via the cache) AND the output is byte-stable across runs.
-  // Determinism matters here beyond reproducibility — element-template hashes
-  // embed these ids, so a stable id is what lets two identical subtrees hash to
-  // the same template. Mirrors FrameLink's sha1-based style names.
+  // Content-addressed id so the same value yields the same id across runs, making
+  // output byte-stable (the value→id cache already dedups within a single run).
   const varId = `${prefix}_${createHash("sha1").update(key).digest("hex").slice(0, 8)}`;
   globalVars.styles[varId] = value;
   cache.set(key, varId);

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -67,7 +67,21 @@ function findOrCreateVar(globalVars: GlobalVars, value: StyleTypes, prefix: stri
 
   // Content-addressed id so the same value yields the same id across runs, making
   // output byte-stable (the value→id cache already dedups within a single run).
-  const varId = `${prefix}_${createHash("sha1").update(key).digest("hex").slice(0, 8)}`;
+  const fullHash = createHash("sha1").update(key).digest("hex");
+
+  // Truncated-hash collision guard. The 8-hex slice (32 bits) keeps refs short but
+  // can alias two different style values. We reached here on a cache miss, so a
+  // taken slot means a genuine collision — reusing the id would overwrite the
+  // other value and every node referencing it would silently resolve to the wrong
+  // style. Lengthen this value's id until the slot is free. Deterministic because
+  // the walk order is stable, so the same file reproduces the same ids.
+  let length = 8;
+  let varId = `${prefix}_${fullHash.slice(0, length)}`;
+  while (globalVars.styles[varId] !== undefined && length < fullHash.length) {
+    length += 4;
+    varId = `${prefix}_${fullHash.slice(0, length)}`;
+  }
+
   globalVars.styles[varId] = value;
   cache.set(key, varId);
   return varId;

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -10,6 +10,7 @@ import { simplifyComponents, simplifyComponentSets } from "~/transformers/compon
 import { tagError } from "~/utils/error-meta.js";
 import type { ExtractorFn, TraversalOptions, SimplifiedDesign } from "./types.js";
 import { extractFromDesign } from "./node-walker.js";
+import { finalizeDesign } from "./finalize.js";
 
 /**
  * Extract a complete SimplifiedDesign from raw Figma API response using extractors.
@@ -26,20 +27,29 @@ export async function simplifyRawFigmaObject(
   // Process nodes using the flexible extractor system
   const {
     nodes: extractedNodes,
-    globalVars: finalGlobalVars,
+    globalVars: walkedGlobalVars,
     traversalState,
   } = await extractFromDesign(rawNodes, nodeExtractors, options, { styles: {} }, extraStyles);
 
+  // Finalize pass: count-gate style hoisting (and, later, element dedup). Runs
+  // here, after the full walk, because it needs whole-tree usage counts the
+  // single-pass extractors can't see. See finalize.ts.
+  const { nodes, globalVars, elements } = finalizeDesign(
+    extractedNodes,
+    walkedGlobalVars,
+    traversalState.namedStyleKeys,
+  );
+
   return {
     ...metadata,
-    nodes: extractedNodes,
+    nodes,
     components: simplifyComponents(components, traversalState.componentPropertyDefinitions),
     componentSets: simplifyComponentSets(
       componentSets,
       traversalState.componentPropertyDefinitions,
     ),
-    globalVars: { styles: finalGlobalVars.styles },
-    elements: {},
+    globalVars,
+    elements,
   };
 }
 

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -39,6 +39,7 @@ export async function simplifyRawFigmaObject(
       traversalState.componentPropertyDefinitions,
     ),
     globalVars: { styles: finalGlobalVars.styles },
+    elements: {},
   };
 }
 

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "~/utils/common.js";
-import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
+import type { ElementBody, GlobalVars, SimplifiedNode } from "./types.js";
 
 /**
  * Post-walk deduplication pass.
@@ -27,7 +27,7 @@ import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
  * side. Either way the post-gating bodies match. Hash before gating and the two
  * sides could differ on which refs remained, breaking dedup.
  *
- * A final step (expandExclusiveStyles) collapses the double indirection that
+ * A final step (inlineExclusiveStyles) collapses the double indirection that
  * arises when a surviving style turns out to be used only by the instances of a
  * single deduplicated element — see below.
  */
@@ -38,7 +38,7 @@ export function finalizeDesign(
 ): {
   nodes: SimplifiedNode[];
   globalVars: GlobalVars;
-  elements: Record<string, ElementDefinition>;
+  elements: Record<string, ElementBody>;
 } {
   // Per-style usage counts, taken before dedup while every node still carries
   // its own style fields. Reused by both the inlining and expansion steps.
@@ -46,7 +46,7 @@ export function finalizeDesign(
 
   const styles = inlineSingleUseStyles(nodes, globalVars.styles, namedStyleKeys, styleCounts);
   const { elements, instanceCounts } = deduplicateElements(nodes);
-  expandExclusiveStyles(elements, instanceCounts, styles, styleCounts, namedStyleKeys);
+  inlineExclusiveStyles(elements, instanceCounts, styles, styleCounts, namedStyleKeys);
 
   return { nodes, globalVars: { styles }, elements };
 }
@@ -125,16 +125,16 @@ function countStyleRefs(nodes: SimplifiedNode[]): Map<string, number> {
  * count. Mutates nodes in place.
  */
 function deduplicateElements(nodes: SimplifiedNode[]): {
-  elements: Record<string, ElementDefinition>;
+  elements: Record<string, ElementBody>;
   instanceCounts: Map<string, number>;
 } {
-  const seen = new Map<string, { body: ElementDefinition; count: number }>();
+  const bodiesByHash = new Map<string, { body: ElementBody; count: number }>();
   const hashByNode = new Map<SimplifiedNode, string>();
-  collectElements(nodes, seen, hashByNode);
+  collectElements(nodes, bodiesByHash, hashByNode);
 
-  const elements: Record<string, ElementDefinition> = {};
+  const elements: Record<string, ElementBody> = {};
   const instanceCounts = new Map<string, number>();
-  for (const [hash, { body, count }] of seen) {
+  for (const [hash, { body, count }] of bodiesByHash) {
     if (count >= 2) {
       elements[hash] = body;
       instanceCounts.set(hash, count);
@@ -158,8 +158,8 @@ function deduplicateElements(nodes: SimplifiedNode[]): {
  * indirection. A style appearing on two fields of the same body (count = 2×
  * instances) simply won't match and stays hoisted; safe, if not optimal.
  */
-function expandExclusiveStyles(
-  elements: Record<string, ElementDefinition>,
+function inlineExclusiveStyles(
+  elements: Record<string, ElementBody>,
   instanceCounts: Map<string, number>,
   styles: GlobalVars["styles"],
   counts: Map<string, number>,
@@ -186,18 +186,18 @@ function expandExclusiveStyles(
 // styling) is intrinsic to the element and gets shared across instances.
 const ELEMENT_OMIT_KEYS = new Set(["id", "name", "children"]);
 
-function bodyOf(node: SimplifiedNode): ElementDefinition {
+function bodyOf(node: SimplifiedNode): ElementBody {
   const source = node as unknown as Record<string, unknown>;
   const body: Record<string, unknown> = {};
   for (const key of Object.keys(source)) {
     if (!ELEMENT_OMIT_KEYS.has(key)) body[key] = source[key];
   }
-  return body as ElementDefinition;
+  return body as ElementBody;
 }
 
 function collectElements(
   nodes: SimplifiedNode[],
-  seen: Map<string, { body: ElementDefinition; count: number }>,
+  bodiesByHash: Map<string, { body: ElementBody; count: number }>,
   hashByNode: Map<SimplifiedNode, string>,
 ): void {
   for (const node of nodes) {
@@ -208,23 +208,23 @@ function collectElements(
     // pay for themselves at 2+ uses and scale with repetition.
     if (Object.keys(body).length > 1) {
       const hash = hashBody(body);
-      const entry = seen.get(hash);
+      const entry = bodiesByHash.get(hash);
       if (entry) entry.count += 1;
-      else seen.set(hash, { body, count: 1 });
+      else bodiesByHash.set(hash, { body, count: 1 });
       hashByNode.set(node, hash);
     }
-    if (node.children) collectElements(node.children, seen, hashByNode);
+    if (node.children) collectElements(node.children, bodiesByHash, hashByNode);
   }
 }
 
-function hashBody(body: ElementDefinition): string {
+function hashBody(body: ElementBody): string {
   return `EL-${createHash("sha1").update(stableStringify(body)).digest("hex").slice(0, 8)}`;
 }
 
 function applyTemplateRefs(
   nodes: SimplifiedNode[],
   hashByNode: Map<SimplifiedNode, string>,
-  elements: Record<string, ElementDefinition>,
+  elements: Record<string, ElementBody>,
 ): void {
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -11,7 +11,7 @@ import type { ElementBody, GlobalVars, SimplifiedNode } from "./types.js";
  * composable-extractor model, we run this as a finalize pass over the
  * already-built design, after the walk completes.
  *
- * Two transformations, in this order (the order is load-bearing — see below):
+ * Two transformations, in this order:
  *   1. Count-gated style hoisting — a style stays in globalVars only when 2+
  *      nodes reference it (or it's a named Figma style); single-use styles are
  *      inlined back onto their node, dropping the indirection tax.
@@ -19,13 +19,14 @@ import type { ElementBody, GlobalVars, SimplifiedNode } from "./types.js";
  *      appear 2+ times are emitted once into `elements` and each occurrence is
  *      replaced by a compact `{ id, name, template, children? }` reference.
  *
- * Style gating MUST run before element hashing: gating rewrites single-use refs
- * to inline values, so two structurally-identical subtrees only hash to the same
- * template once their bodies are byte-identical. Any style shared between the two
- * subtrees necessarily has count >= 2, so it stays a (shared) ref in both —
- * identical on each side. Any single-use style is inlined identically on each
- * side. Either way the post-gating bodies match. Hash before gating and the two
- * sides could differ on which refs remained, breaking dedup.
+ * The order is for simplicity (hash bodies that are already gated), NOT a
+ * correctness requirement. Style ids are content-addressed (see findOrCreateVar),
+ * so two structurally-identical subtrees already carry byte-identical refs before
+ * gating — they hash to the same template with or without it. And gating only
+ * rewrites single-use styles, whose lone reference necessarily sits on a unique,
+ * non-repeated body (any repeated body would push the style's count to >= 2), so
+ * gating never touches a node that participates in templating. Hashing before or
+ * after gating yields the same templates either way.
  *
  * A final step (inlineExclusiveStyles) collapses the double indirection that
  * arises when a surviving style turns out to be used only by the instances of a
@@ -128,7 +129,7 @@ function deduplicateElements(nodes: SimplifiedNode[]): {
   elements: Record<string, ElementBody>;
   instanceCounts: Map<string, number>;
 } {
-  const bodiesByHash = new Map<string, { body: ElementBody; count: number }>();
+  const bodiesByHash = new Map<string, { body: ElementBody; str: string; count: number }>();
   const hashByNode = new Map<SimplifiedNode, string>();
   collectElements(nodes, bodiesByHash, hashByNode);
 
@@ -197,7 +198,7 @@ function bodyOf(node: SimplifiedNode): ElementBody {
 
 function collectElements(
   nodes: SimplifiedNode[],
-  bodiesByHash: Map<string, { body: ElementBody; count: number }>,
+  bodiesByHash: Map<string, { body: ElementBody; str: string; count: number }>,
   hashByNode: Map<SimplifiedNode, string>,
 ): void {
   for (const node of nodes) {
@@ -207,18 +208,35 @@ function collectElements(
     // replaces. Dedup must never grow the payload; bodies with any real styling
     // pay for themselves at 2+ uses and scale with repetition.
     if (Object.keys(body).length > 1) {
-      const hash = hashBody(body);
-      const entry = bodiesByHash.get(hash);
+      const str = stableStringify(body);
+      const id = elementId(str, bodiesByHash);
+      const entry = bodiesByHash.get(id);
       if (entry) entry.count += 1;
-      else bodiesByHash.set(hash, { body, count: 1 });
-      hashByNode.set(node, hash);
+      else bodiesByHash.set(id, { body, str, count: 1 });
+      hashByNode.set(node, id);
     }
     if (node.children) collectElements(node.children, bodiesByHash, hashByNode);
   }
 }
 
-function hashBody(body: ElementBody): string {
-  return `EL-${createHash("sha1").update(stableStringify(body)).digest("hex").slice(0, 8)}`;
+/**
+ * Content-addressed element id, with a truncated-hash collision guard. The 8-hex
+ * slice (32 bits) keeps template refs short but can alias two distinct bodies;
+ * letting them share an id would make applyTemplateRefs merge two different
+ * elements into one. On a clash we lengthen this body's id until the slot is free
+ * or already holds the same body. Deterministic because the walk order is stable.
+ */
+function elementId(
+  str: string,
+  bodiesByHash: Map<string, { body: ElementBody; str: string; count: number }>,
+): string {
+  const fullHash = createHash("sha1").update(str).digest("hex");
+  for (let length = 8; length < fullHash.length; length += 4) {
+    const id = `EL-${fullHash.slice(0, length)}`;
+    const entry = bodiesByHash.get(id);
+    if (!entry || entry.str === str) return id;
+  }
+  return `EL-${fullHash}`;
 }
 
 function applyTemplateRefs(

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -1,18 +1,32 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "~/utils/common.js";
 import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
 
 /**
  * Post-walk deduplication pass.
  *
- * Count-gated style hoisting needs GLOBAL knowledge the single-pass extractor
- * walk can't have: you can't tell whether a style is used once or a hundred
- * times until the whole tree is built. So rather than fight the
+ * Both features here need GLOBAL knowledge that the single-pass extractor walk
+ * can't have: you can't tell whether a style or a subtree is used once or a
+ * hundred times until the whole tree is built. So rather than fight the
  * composable-extractor model, we run this as a finalize pass over the
  * already-built design — mirroring FrameLink's "resolve after the full walk"
  * ordering.
  *
- * A style stays in globalVars only when 2+ nodes reference it (or it's a named
- * Figma style); single-use styles are inlined back onto their node, dropping the
- * indirection tax (a sidecar entry plus a ref) that buys nothing at one use.
+ * Two transformations, in this order (the order is load-bearing — see below):
+ *   1. Count-gated style hoisting — a style stays in globalVars only when 2+
+ *      nodes reference it (or it's a named Figma style); single-use styles are
+ *      inlined back onto their node, dropping the indirection tax.
+ *   2. Element templates — node bodies (everything except id/name/children) that
+ *      appear 2+ times are emitted once into `elements` and each occurrence is
+ *      replaced by a compact `{ id, name, template, children? }` reference.
+ *
+ * Style gating MUST run before element hashing: gating rewrites single-use refs
+ * to inline values, so two structurally-identical subtrees only hash to the same
+ * template once their bodies are byte-identical. Any style shared between the two
+ * subtrees necessarily has count >= 2, so it stays a (shared) ref in both —
+ * identical on each side. Any single-use style is inlined identically on each
+ * side. Either way the post-gating bodies match. Hash before gating and the two
+ * sides could differ on which refs remained, breaking dedup.
  */
 export function finalizeDesign(
   nodes: SimplifiedNode[],
@@ -24,7 +38,8 @@ export function finalizeDesign(
   elements: Record<string, ElementDefinition>;
 } {
   const styles = gateStyles(nodes, globalVars, namedStyleKeys);
-  return { nodes, globalVars: { styles }, elements: {} };
+  const elements = deduplicateElements(nodes);
+  return { nodes, globalVars: { styles }, elements };
 }
 
 // Node fields that carry a style reference (a globalVars key) and, after gating,
@@ -39,10 +54,10 @@ const STYLE_REF_FIELDS = ["layout", "fills", "strokes", "effects", "textStyle"] 
 const INLINE_TEXT_STYLE_KEY = /^ts\d+$/;
 
 /**
- * Inline single-use styles, returning the surviving globalVars.styles. Mutates
- * the passed nodes in place (they're owned by this call). A single-use value is
- * referenced by exactly one node, so assigning the shared value object onto that
- * node creates no aliasing.
+ * Feature 1: inline single-use styles, returning the surviving globalVars.styles.
+ * Mutates the passed nodes in place (they're owned by this call). A single-use
+ * value is referenced by exactly one node, so assigning the shared value object
+ * onto that node creates no aliasing.
  */
 function gateStyles(
   nodes: SimplifiedNode[],
@@ -94,5 +109,81 @@ function inlineStyleRefs(
       }
     }
     if (node.children) inlineStyleRefs(node.children, styles, inlineKeys);
+  }
+}
+
+/**
+ * Feature 2: hash each node body and replace bodies that repeat 2+ times with a
+ * template reference, returning the element table. Mutates nodes in place.
+ */
+function deduplicateElements(nodes: SimplifiedNode[]): Record<string, ElementDefinition> {
+  const seen = new Map<string, { body: ElementDefinition; count: number }>();
+  const hashByNode = new Map<SimplifiedNode, string>();
+  collectElements(nodes, seen, hashByNode);
+
+  const elements: Record<string, ElementDefinition> = {};
+  for (const [hash, { body, count }] of seen) {
+    if (count >= 2) elements[hash] = body;
+  }
+
+  applyTemplateRefs(nodes, hashByNode, elements);
+  return elements;
+}
+
+// Per-instance keys excluded from the hashed body. Everything else (type and all
+// styling) is intrinsic to the element and gets shared across instances.
+const ELEMENT_OMIT_KEYS = new Set(["id", "name", "children"]);
+
+function bodyOf(node: SimplifiedNode): ElementDefinition {
+  const source = node as unknown as Record<string, unknown>;
+  const body: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    if (!ELEMENT_OMIT_KEYS.has(key)) body[key] = source[key];
+  }
+  return body as ElementDefinition;
+}
+
+function collectElements(
+  nodes: SimplifiedNode[],
+  seen: Map<string, { body: ElementDefinition; count: number }>,
+  hashByNode: Map<SimplifiedNode, string>,
+): void {
+  for (const node of nodes) {
+    const body = bodyOf(node);
+    // Skip type-only bodies. A `{type}` element would cost more than it saves —
+    // a `template=EL-xxxx` ref plus a global entry, versus the bare `[TYPE]` it
+    // replaces. This deviates from FrameLink (which dedupes unconditionally) on
+    // purpose: dedup must never grow the payload. Bodies with any real styling
+    // pay for themselves at 2+ uses and scale with repetition.
+    if (Object.keys(body).length > 1) {
+      const hash = hashBody(body);
+      const entry = seen.get(hash);
+      if (entry) entry.count += 1;
+      else seen.set(hash, { body, count: 1 });
+      hashByNode.set(node, hash);
+    }
+    if (node.children) collectElements(node.children, seen, hashByNode);
+  }
+}
+
+function hashBody(body: ElementDefinition): string {
+  return `EL-${createHash("sha1").update(stableStringify(body)).digest("hex").slice(0, 8)}`;
+}
+
+function applyTemplateRefs(
+  nodes: SimplifiedNode[],
+  hashByNode: Map<SimplifiedNode, string>,
+  elements: Record<string, ElementDefinition>,
+): void {
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (node.children) applyTemplateRefs(node.children, hashByNode, elements);
+
+    const hash = hashByNode.get(node);
+    if (hash && elements[hash]) {
+      const ref: SimplifiedNode = { id: node.id, name: node.name, template: hash };
+      if (node.children && node.children.length > 0) ref.children = node.children;
+      nodes[i] = ref;
+    }
   }
 }

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -1,0 +1,98 @@
+import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
+
+/**
+ * Post-walk deduplication pass.
+ *
+ * Count-gated style hoisting needs GLOBAL knowledge the single-pass extractor
+ * walk can't have: you can't tell whether a style is used once or a hundred
+ * times until the whole tree is built. So rather than fight the
+ * composable-extractor model, we run this as a finalize pass over the
+ * already-built design — mirroring FrameLink's "resolve after the full walk"
+ * ordering.
+ *
+ * A style stays in globalVars only when 2+ nodes reference it (or it's a named
+ * Figma style); single-use styles are inlined back onto their node, dropping the
+ * indirection tax (a sidecar entry plus a ref) that buys nothing at one use.
+ */
+export function finalizeDesign(
+  nodes: SimplifiedNode[],
+  globalVars: GlobalVars,
+  namedStyleKeys: Set<string>,
+): {
+  nodes: SimplifiedNode[];
+  globalVars: GlobalVars;
+  elements: Record<string, ElementDefinition>;
+} {
+  const styles = gateStyles(nodes, globalVars, namedStyleKeys);
+  return { nodes, globalVars: { styles }, elements: {} };
+}
+
+// Node fields that carry a style reference (a globalVars key) and, after gating,
+// may instead carry the inline style value. These are the only fields counted
+// and inlined. `styles` is intentionally excluded — it's never populated.
+const STYLE_REF_FIELDS = ["layout", "fills", "strokes", "effects", "textStyle"] as const;
+
+// Inline text-style deltas live under `ts1`, `ts2`, ... and are referenced from
+// inside `text` strings (`{ts1}…{/ts1}`), not from node style fields. They are
+// their own indirection mechanism with no node-field reference to count, so the
+// gate must leave them alone — never inline or drop them.
+const INLINE_TEXT_STYLE_KEY = /^ts\d+$/;
+
+/**
+ * Inline single-use styles, returning the surviving globalVars.styles. Mutates
+ * the passed nodes in place (they're owned by this call). A single-use value is
+ * referenced by exactly one node, so assigning the shared value object onto that
+ * node creates no aliasing.
+ */
+function gateStyles(
+  nodes: SimplifiedNode[],
+  globalVars: GlobalVars,
+  namedStyleKeys: Set<string>,
+): GlobalVars["styles"] {
+  const counts = new Map<string, number>();
+  countStyleRefs(nodes, counts);
+
+  const inlineKeys = new Set<string>();
+  for (const key of Object.keys(globalVars.styles)) {
+    if (INLINE_TEXT_STYLE_KEY.test(key)) continue; // referenced from text, not gated
+    if (namedStyleKeys.has(key)) continue; // design-system intent, keep hoisted
+    if ((counts.get(key) ?? 0) >= 2) continue; // shared, keep hoisted
+    inlineKeys.add(key);
+  }
+
+  inlineStyleRefs(nodes, globalVars.styles, inlineKeys);
+
+  const surviving: GlobalVars["styles"] = {};
+  for (const [key, value] of Object.entries(globalVars.styles)) {
+    if (!inlineKeys.has(key)) surviving[key] = value;
+  }
+  return surviving;
+}
+
+function countStyleRefs(nodes: SimplifiedNode[], counts: Map<string, number>): void {
+  for (const node of nodes) {
+    for (const field of STYLE_REF_FIELDS) {
+      const value = node[field];
+      if (typeof value === "string") counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    if (node.children) countStyleRefs(node.children, counts);
+  }
+}
+
+function inlineStyleRefs(
+  nodes: SimplifiedNode[],
+  styles: GlobalVars["styles"],
+  inlineKeys: Set<string>,
+): void {
+  for (const node of nodes) {
+    for (const field of STYLE_REF_FIELDS) {
+      const value = node[field];
+      if (typeof value === "string" && inlineKeys.has(value)) {
+        // Assigning the looked-up value; widened SimplifiedNode field types make
+        // this assignment legal, but TS can't narrow per-field here.
+        (node as unknown as Record<string, unknown>)[field] = styles[value];
+      }
+    }
+    if (node.children) inlineStyleRefs(node.children, styles, inlineKeys);
+  }
+}

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -27,6 +27,10 @@ import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
  * identical on each side. Any single-use style is inlined identically on each
  * side. Either way the post-gating bodies match. Hash before gating and the two
  * sides could differ on which refs remained, breaking dedup.
+ *
+ * A final step (expandExclusiveStyles) collapses the double indirection that
+ * arises when a surviving style turns out to be used only by the instances of a
+ * single deduplicated element — see below.
  */
 export function finalizeDesign(
   nodes: SimplifiedNode[],
@@ -37,8 +41,15 @@ export function finalizeDesign(
   globalVars: GlobalVars;
   elements: Record<string, ElementDefinition>;
 } {
-  const styles = gateStyles(nodes, globalVars, namedStyleKeys);
-  const elements = deduplicateElements(nodes);
+  // Per-style usage counts, taken before dedup while every node still carries
+  // its own style fields. Reused by both gating and exclusive-style expansion.
+  const counts = new Map<string, number>();
+  countStyleRefs(nodes, counts);
+
+  const styles = gateStyles(nodes, globalVars, namedStyleKeys, counts);
+  const { elements, instanceCounts } = deduplicateElements(nodes);
+  expandExclusiveStyles(elements, instanceCounts, styles, counts, namedStyleKeys);
+
   return { nodes, globalVars: { styles }, elements };
 }
 
@@ -63,10 +74,8 @@ function gateStyles(
   nodes: SimplifiedNode[],
   globalVars: GlobalVars,
   namedStyleKeys: Set<string>,
+  counts: Map<string, number>,
 ): GlobalVars["styles"] {
-  const counts = new Map<string, number>();
-  countStyleRefs(nodes, counts);
-
   const inlineKeys = new Set<string>();
   for (const key of Object.keys(globalVars.styles)) {
     if (INLINE_TEXT_STYLE_KEY.test(key)) continue; // referenced from text, not gated
@@ -114,20 +123,65 @@ function inlineStyleRefs(
 
 /**
  * Feature 2: hash each node body and replace bodies that repeat 2+ times with a
- * template reference, returning the element table. Mutates nodes in place.
+ * template reference, returning the element table and each element's instance
+ * count. Mutates nodes in place.
  */
-function deduplicateElements(nodes: SimplifiedNode[]): Record<string, ElementDefinition> {
+function deduplicateElements(nodes: SimplifiedNode[]): {
+  elements: Record<string, ElementDefinition>;
+  instanceCounts: Map<string, number>;
+} {
   const seen = new Map<string, { body: ElementDefinition; count: number }>();
   const hashByNode = new Map<SimplifiedNode, string>();
   collectElements(nodes, seen, hashByNode);
 
   const elements: Record<string, ElementDefinition> = {};
+  const instanceCounts = new Map<string, number>();
   for (const [hash, { body, count }] of seen) {
-    if (count >= 2) elements[hash] = body;
+    if (count >= 2) {
+      elements[hash] = body;
+      instanceCounts.set(hash, count);
+    }
   }
 
   applyTemplateRefs(nodes, hashByNode, elements);
-  return elements;
+  return { elements, instanceCounts };
+}
+
+/**
+ * Stretch optimization: collapse double indirection. When a surviving style is
+ * referenced only by the instances of a single deduplicated element, the output
+ * pays twice — `template → style ref → value`. Inline the value into the element
+ * body and drop the global entry so it's just `template → value`.
+ *
+ * The test is FrameLink's: a style whose total pre-dedup reference count equals
+ * an element's instance count, and which appears in that element's body, can only
+ * have come from that element's instances (any other use would push the count
+ * higher). Named styles are left hoisted — surfacing design-system intent is
+ * worth the indirection. A style appearing on two fields of the same body (count
+ * = 2× instances) simply won't match and stays hoisted; safe, if not optimal.
+ */
+function expandExclusiveStyles(
+  elements: Record<string, ElementDefinition>,
+  instanceCounts: Map<string, number>,
+  styles: GlobalVars["styles"],
+  counts: Map<string, number>,
+  namedStyleKeys: Set<string>,
+): void {
+  for (const [hash, body] of Object.entries(elements)) {
+    const instanceCount = instanceCounts.get(hash);
+    if (instanceCount === undefined) continue;
+    const writable = body as Record<string, unknown>;
+    for (const field of STYLE_REF_FIELDS) {
+      const ref = writable[field];
+      if (typeof ref !== "string") continue;
+      if (namedStyleKeys.has(ref) || INLINE_TEXT_STYLE_KEY.test(ref)) continue;
+      if (!(ref in styles)) continue;
+      if (counts.get(ref) === instanceCount) {
+        writable[field] = styles[ref];
+        delete styles[ref];
+      }
+    }
+  }
 }
 
 // Per-instance keys excluded from the hashed body. Everything else (type and all

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -9,8 +9,7 @@ import type { ElementDefinition, GlobalVars, SimplifiedNode } from "./types.js";
  * can't have: you can't tell whether a style or a subtree is used once or a
  * hundred times until the whole tree is built. So rather than fight the
  * composable-extractor model, we run this as a finalize pass over the
- * already-built design — mirroring FrameLink's "resolve after the full walk"
- * ordering.
+ * already-built design, after the walk completes.
  *
  * Two transformations, in this order (the order is load-bearing — see below):
  *   1. Count-gated style hoisting — a style stays in globalVars only when 2+
@@ -42,13 +41,12 @@ export function finalizeDesign(
   elements: Record<string, ElementDefinition>;
 } {
   // Per-style usage counts, taken before dedup while every node still carries
-  // its own style fields. Reused by both gating and exclusive-style expansion.
-  const counts = new Map<string, number>();
-  countStyleRefs(nodes, counts);
+  // its own style fields. Reused by both the inlining and expansion steps.
+  const styleCounts = countStyleRefs(nodes);
 
-  const styles = gateStyles(nodes, globalVars, namedStyleKeys, counts);
+  const styles = inlineSingleUseStyles(nodes, globalVars.styles, namedStyleKeys, styleCounts);
   const { elements, instanceCounts } = deduplicateElements(nodes);
-  expandExclusiveStyles(elements, instanceCounts, styles, counts, namedStyleKeys);
+  expandExclusiveStyles(elements, instanceCounts, styles, styleCounts, namedStyleKeys);
 
   return { nodes, globalVars: { styles }, elements };
 }
@@ -65,60 +63,60 @@ const STYLE_REF_FIELDS = ["layout", "fills", "strokes", "effects", "textStyle"] 
 const INLINE_TEXT_STYLE_KEY = /^ts\d+$/;
 
 /**
- * Feature 1: inline single-use styles, returning the surviving globalVars.styles.
+ * Feature 1: replace single-use style refs with their inline value, returning the
+ * styles that stay hoisted in globalVars (used by 2+ nodes, or named styles).
  * Mutates the passed nodes in place (they're owned by this call). A single-use
- * value is referenced by exactly one node, so assigning the shared value object
- * onto that node creates no aliasing.
+ * value is referenced by exactly one node, so sharing the value object on inline
+ * creates no aliasing.
  */
-function gateStyles(
+function inlineSingleUseStyles(
   nodes: SimplifiedNode[],
-  globalVars: GlobalVars,
+  styles: GlobalVars["styles"],
   namedStyleKeys: Set<string>,
   counts: Map<string, number>,
 ): GlobalVars["styles"] {
   const inlineKeys = new Set<string>();
-  for (const key of Object.keys(globalVars.styles)) {
-    if (INLINE_TEXT_STYLE_KEY.test(key)) continue; // referenced from text, not gated
+  for (const key of Object.keys(styles)) {
+    if (INLINE_TEXT_STYLE_KEY.test(key)) continue; // referenced from text, leave hoisted
     if (namedStyleKeys.has(key)) continue; // design-system intent, keep hoisted
     if ((counts.get(key) ?? 0) >= 2) continue; // shared, keep hoisted
     inlineKeys.add(key);
   }
 
-  inlineStyleRefs(nodes, globalVars.styles, inlineKeys);
+  const walk = (ns: SimplifiedNode[]): void => {
+    for (const node of ns) {
+      for (const field of STYLE_REF_FIELDS) {
+        const value = node[field];
+        if (typeof value === "string" && inlineKeys.has(value)) {
+          // Widened SimplifiedNode field types make this legal; TS can't narrow per-field.
+          (node as unknown as Record<string, unknown>)[field] = styles[value];
+        }
+      }
+      if (node.children) walk(node.children);
+    }
+  };
+  walk(nodes);
 
   const surviving: GlobalVars["styles"] = {};
-  for (const [key, value] of Object.entries(globalVars.styles)) {
+  for (const [key, value] of Object.entries(styles)) {
     if (!inlineKeys.has(key)) surviving[key] = value;
   }
   return surviving;
 }
 
-function countStyleRefs(nodes: SimplifiedNode[], counts: Map<string, number>): void {
-  for (const node of nodes) {
-    for (const field of STYLE_REF_FIELDS) {
-      const value = node[field];
-      if (typeof value === "string") counts.set(value, (counts.get(value) ?? 0) + 1);
-    }
-    if (node.children) countStyleRefs(node.children, counts);
-  }
-}
-
-function inlineStyleRefs(
-  nodes: SimplifiedNode[],
-  styles: GlobalVars["styles"],
-  inlineKeys: Set<string>,
-): void {
-  for (const node of nodes) {
-    for (const field of STYLE_REF_FIELDS) {
-      const value = node[field];
-      if (typeof value === "string" && inlineKeys.has(value)) {
-        // Assigning the looked-up value; widened SimplifiedNode field types make
-        // this assignment legal, but TS can't narrow per-field here.
-        (node as unknown as Record<string, unknown>)[field] = styles[value];
+function countStyleRefs(nodes: SimplifiedNode[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const walk = (ns: SimplifiedNode[]): void => {
+    for (const node of ns) {
+      for (const field of STYLE_REF_FIELDS) {
+        const value = node[field];
+        if (typeof value === "string") counts.set(value, (counts.get(value) ?? 0) + 1);
       }
+      if (node.children) walk(node.children);
     }
-    if (node.children) inlineStyleRefs(node.children, styles, inlineKeys);
-  }
+  };
+  walk(nodes);
+  return counts;
 }
 
 /**
@@ -153,12 +151,12 @@ function deduplicateElements(nodes: SimplifiedNode[]): {
  * pays twice — `template → style ref → value`. Inline the value into the element
  * body and drop the global entry so it's just `template → value`.
  *
- * The test is FrameLink's: a style whose total pre-dedup reference count equals
- * an element's instance count, and which appears in that element's body, can only
- * have come from that element's instances (any other use would push the count
- * higher). Named styles are left hoisted — surfacing design-system intent is
- * worth the indirection. A style appearing on two fields of the same body (count
- * = 2× instances) simply won't match and stays hoisted; safe, if not optimal.
+ * The test: a style whose total pre-dedup reference count equals an element's
+ * instance count, and which appears in that element's body, can only have come
+ * from that element's instances (any other use would push the count higher).
+ * Named styles are left hoisted — surfacing design-system intent is worth the
+ * indirection. A style appearing on two fields of the same body (count = 2×
+ * instances) simply won't match and stays hoisted; safe, if not optimal.
  */
 function expandExclusiveStyles(
   elements: Record<string, ElementDefinition>,
@@ -206,8 +204,7 @@ function collectElements(
     const body = bodyOf(node);
     // Skip type-only bodies. A `{type}` element would cost more than it saves —
     // a `template=EL-xxxx` ref plus a global entry, versus the bare `[TYPE]` it
-    // replaces. This deviates from FrameLink (which dedupes unconditionally) on
-    // purpose: dedup must never grow the payload. Bodies with any real styling
+    // replaces. Dedup must never grow the payload; bodies with any real styling
     // pay for themselves at 2+ uses and scale with repetition.
     if (Object.keys(body).length > 1) {
       const hash = hashBody(body);

--- a/src/extractors/finalize.ts
+++ b/src/extractors/finalize.ts
@@ -77,9 +77,20 @@ function inlineSingleUseStyles(
   counts: Map<string, number>,
 ): GlobalVars["styles"] {
   const inlineKeys = new Set<string>();
+  const dropKeys = new Set<string>();
   for (const key of Object.keys(styles)) {
     if (INLINE_TEXT_STYLE_KEY.test(key)) continue; // referenced from text, leave hoisted
-    if (namedStyleKeys.has(key)) continue; // design-system intent, keep hoisted
+    if (namedStyleKeys.has(key)) {
+      // Named styles are design-system intent, normally kept hoisted — but only
+      // while something still references them. A named style can reach zero
+      // references when its only node is dropped after registration (e.g.
+      // collapseSvgContainers registers a vector child's style, then folds the
+      // child away). A hoisted entry nothing points to is orphan noise, so drop
+      // it. (Non-named zero-count styles fall through to inlineKeys below and are
+      // likewise dropped — nothing references them, so nothing gets inlined.)
+      if ((counts.get(key) ?? 0) === 0) dropKeys.add(key);
+      continue;
+    }
     if ((counts.get(key) ?? 0) >= 2) continue; // shared, keep hoisted
     inlineKeys.add(key);
   }
@@ -100,7 +111,7 @@ function inlineSingleUseStyles(
 
   const surviving: GlobalVars["styles"] = {};
   for (const [key, value] of Object.entries(styles)) {
-    if (!inlineKeys.has(key)) surviving[key] = value;
+    if (!inlineKeys.has(key) && !dropKeys.has(key)) surviving[key] = value;
   }
   return surviving;
 }

--- a/src/extractors/node-walker.ts
+++ b/src/extractors/node-walker.ts
@@ -48,7 +48,7 @@ export async function extractFromDesign(
     globalVars,
     extraStyles,
     currentDepth: 0,
-    traversalState: { componentPropertyDefinitions: {}, tsCounter: 0 },
+    traversalState: { componentPropertyDefinitions: {}, tsCounter: 0, namedStyleKeys: new Set() },
     nodeCounter: options.nodeCounter ?? { count: 0 },
   };
 

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -53,6 +53,14 @@ export interface TraversalState {
    * content with short, readable identifiers.
    */
   tsCounter: number;
+  /**
+   * globalVars keys that correspond to named Figma styles (vs. auto-generated
+   * content-hash ids). The finalize pass keeps these hoisted even at a single
+   * use, because a named style encodes design-system intent worth surfacing.
+   * Collected during the walk because the post-walk pass can't otherwise tell a
+   * named-style key apart from an auto-generated one by inspection.
+   */
+  namedStyleKeys: Set<string>;
 }
 
 export interface TraversalOptions {
@@ -100,34 +108,56 @@ export interface SimplifiedDesign {
   components: Record<string, SimplifiedComponentDefinition>;
   componentSets: Record<string, SimplifiedComponentSetDefinition>;
   globalVars: GlobalVars;
+  /**
+   * Deduplicated element bodies, keyed by content hash (`EL-xxxxxxxx`). Populated
+   * by the finalize pass: when a node body (everything except id/name/children)
+   * appears 2+ times, it is emitted here once and each occurrence is replaced by
+   * a compact `template` reference. Empty when nothing repeats.
+   */
+  elements: Record<string, ElementDefinition>;
 }
+
+/**
+ * A node body with the per-instance keys removed. This is what gets hoisted into
+ * `SimplifiedDesign.elements` and referenced by `SimplifiedNode.template`. `type`
+ * is part of the body (it's intrinsic to the element), so a template reference
+ * carries no `type` of its own — consumers resolve it via the element entry.
+ */
+export type ElementDefinition = Omit<SimplifiedNode, "id" | "name" | "children" | "template">;
 
 export interface SimplifiedNode {
   id: string;
   name: string;
-  type: string; // e.g. FRAME, TEXT, INSTANCE, RECTANGLE, etc.
+  type?: string; // e.g. FRAME, TEXT, INSTANCE, RECTANGLE, etc. Absent on template refs (type lives in the element).
+  /**
+   * Reference into `SimplifiedDesign.elements`. When set, the node's body lives
+   * in the shared element and only id/name/children/template are kept here.
+   */
+  template?: string;
   // text
   text?: string;
-  textStyle?: string;
+  textStyle?: string | SimplifiedTextStyle;
   /**
    * The numeric font weight that `**bold**` inside `text` maps to. Only emitted
    * when a text node has per-character bold overrides heavier than its base
    * `style.fontWeight`, so the consumer knows how to realize markdown bold.
    */
   boldWeight?: number;
-  // appearance
-  fills?: string;
+  // appearance — each style field holds either a globalVars reference (when the
+  // value is shared by 2+ nodes or is a named Figma style) or the inline value
+  // itself (single-use values, after the finalize pass).
+  fills?: string | SimplifiedFill[];
   styles?: string;
-  strokes?: string;
+  strokes?: string | SimplifiedFill[];
   // Non-stylable stroke properties are kept on the node when stroke uses a named color style
   strokeWeight?: string;
   strokeDashes?: number[];
   strokeWeights?: string;
-  effects?: string;
+  effects?: string | SimplifiedEffects;
   opacity?: number;
   borderRadius?: string;
   // layout & alignment
-  layout?: string;
+  layout?: string | SimplifiedLayout;
   componentId?: string;
   componentProperties?: Record<string, boolean | string>;
   componentPropertyReferences?: Record<string, string>;

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -114,7 +114,7 @@ export interface SimplifiedDesign {
    * appears 2+ times, it is emitted here once and each occurrence is replaced by
    * a compact `template` reference. Empty when nothing repeats.
    */
-  elements: Record<string, ElementDefinition>;
+  elements: Record<string, ElementBody>;
 }
 
 /**
@@ -123,7 +123,7 @@ export interface SimplifiedDesign {
  * is part of the body (it's intrinsic to the element), so a template reference
  * carries no `type` of its own — consumers resolve it via the element entry.
  */
-export type ElementDefinition = Omit<SimplifiedNode, "id" | "name" | "children" | "template">;
+export type ElementBody = Omit<SimplifiedNode, "id" | "name" | "children" | "template">;
 
 export interface SimplifiedNode {
   id: string;

--- a/src/services/get-figma-data-metrics.ts
+++ b/src/services/get-figma-data-metrics.ts
@@ -54,15 +54,17 @@ export type GetFigmaDataMetrics = {
  * whose `colors` array holds fills. Used to classify simplified nodes as
  * "image nodes" via their `fills`/`strokes` key references.
  */
+function hasImageFill(fills: SimplifiedFill[]): boolean {
+  return fills.some(
+    (fill) =>
+      typeof fill === "object" &&
+      fill !== null &&
+      (fill.type === "IMAGE" || fill.type === "PATTERN"),
+  );
+}
+
 function collectImageStyleKeys(design: SimplifiedDesign): Set<string> {
   const keys = new Set<string>();
-  const hasImageFill = (fills: SimplifiedFill[]): boolean =>
-    fills.some(
-      (fill) =>
-        typeof fill === "object" &&
-        fill !== null &&
-        (fill.type === "IMAGE" || fill.type === "PATTERN"),
-    );
 
   for (const [key, value] of Object.entries(design.globalVars.styles)) {
     if (Array.isArray(value)) {
@@ -102,15 +104,21 @@ export function measureSimplifiedDesign(design: SimplifiedDesign): {
   let imageNodeCount = 0;
   let componentPropertyCount = 0;
 
+  // A template reference keeps no body of its own — type, fills, and strokes
+  // live in the shared element. Resolve through it so metrics stay accurate
+  // whether or not a node was deduplicated.
+  const isImageStyle = (value: SimplifiedNode["fills"]): boolean =>
+    typeof value === "string"
+      ? imageStyleKeys.has(value)
+      : Array.isArray(value) && hasImageFill(value);
+
   const walk = (node: SimplifiedNode, depth: number): void => {
     simplifiedNodeCount++;
     if (depth > maxDepth) maxDepth = depth;
-    if (node.type === "INSTANCE") instanceCount++;
-    if (node.type === "TEXT") textNodeCount++;
-    if (
-      (node.fills && imageStyleKeys.has(node.fills)) ||
-      (node.strokes && imageStyleKeys.has(node.strokes))
-    ) {
+    const body = node.template ? design.elements[node.template] : node;
+    if (body?.type === "INSTANCE") instanceCount++;
+    if (body?.type === "TEXT") textNodeCount++;
+    if (isImageStyle(body?.fills) || isImageStyle(body?.strokes)) {
       imageNodeCount++;
     }
     if (node.componentProperties) {

--- a/src/services/get-figma-data-metrics.ts
+++ b/src/services/get-figma-data-metrics.ts
@@ -121,8 +121,10 @@ export function measureSimplifiedDesign(design: SimplifiedDesign): {
     if (isImageStyle(body?.fills) || isImageStyle(body?.strokes)) {
       imageNodeCount++;
     }
-    if (node.componentProperties) {
-      componentPropertyCount += Object.keys(node.componentProperties).length;
+    // Read through `body`: a deduplicated instance keeps only id/name/template,
+    // so its componentProperties live in the shared element, not on the node.
+    if (body?.componentProperties) {
+      componentPropertyCount += Object.keys(body.componentProperties).length;
     }
     if (node.children) {
       for (const child of node.children) walk(child, depth + 1);

--- a/src/tests/finalize.test.ts
+++ b/src/tests/finalize.test.ts
@@ -9,6 +9,7 @@ import type { GlobalVars, SimplifiedNode, StyleTypes } from "~/extractors/types.
 
 // Solid fills serialize to hex-string arrays in real output (see style.ts).
 const RED: StyleTypes = ["#FF0000"];
+const BLUE: StyleTypes = ["#0000FF"];
 
 function node(overrides: Partial<SimplifiedNode> & { id: string }): SimplifiedNode {
   return { name: overrides.id, type: "FRAME", ...overrides };
@@ -58,5 +59,90 @@ describe("count-gated style hoisting", () => {
     const result = finalizeDesign(nodes, globalVars, new Set());
 
     expect(result.globalVars.styles).toEqual({ ts1: { fontWeight: 700 } });
+  });
+});
+
+describe("element templates", () => {
+  it("dedupes two identical subtrees into one element entry + two template refs", () => {
+    // Both cards share fill_red (count 2 → stays a ref), so their post-gating
+    // bodies are byte-identical and hash to the same template.
+    const nodes = [
+      node({ id: "1", name: "Card A", fills: "fill_red" }),
+      node({ id: "2", name: "Card B", fills: "fill_red" }),
+    ];
+    const globalVars: GlobalVars = { styles: { fill_red: RED } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    const templates = Object.keys(result.elements);
+    expect(templates).toHaveLength(1);
+    const [hash] = templates;
+    expect(result.elements[hash]).toEqual({ type: "FRAME", fills: "fill_red" });
+
+    // Each occurrence keeps its per-instance id/name, body replaced by the ref.
+    expect(result.nodes[0]).toEqual({ id: "1", name: "Card A", template: hash });
+    expect(result.nodes[1]).toEqual({ id: "2", name: "Card B", template: hash });
+    // The shared style stays hoisted (referenced from the element body).
+    expect(result.globalVars.styles).toEqual({ fill_red: RED });
+  });
+
+  it("leaves a unique subtree inline (no template)", () => {
+    const nodes = [
+      node({ id: "1", name: "Card A", fills: "fill_red" }),
+      node({ id: "2", name: "Card B", fills: "fill_red" }),
+      node({ id: "3", name: "Solo", fills: "fill_blue" }),
+    ];
+    const globalVars: GlobalVars = { styles: { fill_red: RED, fill_blue: BLUE } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    // The solo card's body is unique → no template, and its single-use fill
+    // inlines onto the node.
+    expect(result.nodes[2].template).toBeUndefined();
+    expect(result.nodes[2].fills).toEqual(BLUE);
+    expect(result.nodes[2].type).toBe("FRAME");
+  });
+
+  it("dedupes repeated children while keeping per-instance ids", () => {
+    // A grid of two identical cards, each wrapping an identical icon.
+    const card = (id: string): SimplifiedNode =>
+      node({
+        id,
+        name: `Card ${id}`,
+        fills: "fill_red",
+        children: [node({ id: `${id}-icon`, name: "Icon", type: "IMAGE-SVG", opacity: 0.5 })],
+      });
+    const nodes = [card("1"), card("2")];
+    const globalVars: GlobalVars = { styles: { fill_red: RED } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    // Two distinct templates: the card body and the icon body.
+    expect(Object.keys(result.elements)).toHaveLength(2);
+    expect(result.nodes[0].template).toBe(result.nodes[1].template);
+    expect(result.nodes[0].children?.[0].template).toBe(result.nodes[1].children?.[0].template);
+    expect(result.nodes[0].children?.[0].id).toBe("1-icon");
+    expect(result.nodes[1].children?.[0].id).toBe("2-icon");
+  });
+
+  it("does not dedupe type-only bodies (a template would grow the payload)", () => {
+    const nodes = [node({ id: "1" }), node({ id: "2" })];
+
+    const result = finalizeDesign(nodes, { styles: {} }, new Set());
+
+    expect(result.elements).toEqual({});
+    expect(result.nodes[0].template).toBeUndefined();
+    expect(result.nodes[0].type).toBe("FRAME");
+  });
+
+  it("is deterministic: identical input yields identical template hashes", () => {
+    const build = (): SimplifiedNode[] => [
+      node({ id: "1", fills: "fill_red" }),
+      node({ id: "2", fills: "fill_red" }),
+    ];
+    const a = finalizeDesign(build(), { styles: { fill_red: RED } }, new Set());
+    const b = finalizeDesign(build(), { styles: { fill_red: RED } }, new Set());
+
+    expect(Object.keys(a.elements)).toEqual(Object.keys(b.elements));
   });
 });

--- a/src/tests/finalize.test.ts
+++ b/src/tests/finalize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { finalizeDesign } from "~/extractors/finalize.js";
+import type { GlobalVars, SimplifiedNode, StyleTypes } from "~/extractors/types.js";
+
+// finalizeDesign is the pure functional core of the dedup features: given the
+// already-walked node tree + globalVars (style fields hold globalVars refs, as
+// the walker emits them), it gates single-use styles inline. Testing it directly
+// keeps these fast and free of Figma-fixture noise.
+
+// Solid fills serialize to hex-string arrays in real output (see style.ts).
+const RED: StyleTypes = ["#FF0000"];
+
+function node(overrides: Partial<SimplifiedNode> & { id: string }): SimplifiedNode {
+  return { name: overrides.id, type: "FRAME", ...overrides };
+}
+
+describe("count-gated style hoisting", () => {
+  it("inlines a single-use style onto its node and drops it from globalVars", () => {
+    const nodes = [node({ id: "1", fills: "fill_red" })];
+    const globalVars: GlobalVars = { styles: { fill_red: RED } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    expect(result.nodes[0].fills).toEqual(RED);
+    expect(result.globalVars.styles).toEqual({});
+  });
+
+  it("keeps a 2+-use style hoisted and referenced by id", () => {
+    // Distinct bodies (FRAME vs RECTANGLE) so element dedup doesn't fold them —
+    // this isolates style gating: the shared fill is referenced, not inlined.
+    const nodes = [
+      node({ id: "1", type: "FRAME", fills: "fill_red" }),
+      node({ id: "2", type: "RECTANGLE", fills: "fill_red" }),
+    ];
+    const globalVars: GlobalVars = { styles: { fill_red: RED } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    expect(result.nodes[0].fills).toBe("fill_red");
+    expect(result.nodes[1].fills).toBe("fill_red");
+    expect(result.globalVars.styles).toEqual({ fill_red: RED });
+  });
+
+  it("keeps a single-use named Figma style hoisted (design-system intent)", () => {
+    const nodes = [node({ id: "1", type: "TEXT", textStyle: "Heading / Large" })];
+    const globalVars: GlobalVars = { styles: { "Heading / Large": { fontSize: 24 } } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set(["Heading / Large"]));
+
+    expect(result.nodes[0].textStyle).toBe("Heading / Large");
+    expect(result.globalVars.styles).toEqual({ "Heading / Large": { fontSize: 24 } });
+  });
+
+  it("never inlines or drops inline-text-style (ts*) entries — they're referenced from text", () => {
+    const nodes = [node({ id: "1", type: "TEXT", text: "a {ts1}b{/ts1}" })];
+    const globalVars: GlobalVars = { styles: { ts1: { fontWeight: 700 } } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    expect(result.globalVars.styles).toEqual({ ts1: { fontWeight: 700 } });
+  });
+});

--- a/src/tests/finalize.test.ts
+++ b/src/tests/finalize.test.ts
@@ -65,7 +65,33 @@ describe("count-gated style hoisting", () => {
 describe("element templates", () => {
   it("dedupes two identical subtrees into one element entry + two template refs", () => {
     // Both cards share fill_red (count 2 → stays a ref), so their post-gating
-    // bodies are byte-identical and hash to the same template.
+    // bodies are byte-identical and hash to the same template. A third node
+    // (distinct body) also uses fill_red so it stays a hoisted ref rather than
+    // being inlined by exclusive-style expansion.
+    const nodes = [
+      node({ id: "1", name: "Card A", fills: "fill_red" }),
+      node({ id: "2", name: "Card B", fills: "fill_red" }),
+      node({ id: "9", name: "Header", type: "RECTANGLE", fills: "fill_red" }),
+    ];
+    const globalVars: GlobalVars = { styles: { fill_red: RED } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set());
+
+    const [hash] = Object.keys(result.elements);
+    expect(Object.keys(result.elements)).toHaveLength(1);
+    expect(result.elements[hash]).toEqual({ type: "FRAME", fills: "fill_red" });
+
+    // Each card keeps its per-instance id/name, body replaced by the ref.
+    expect(result.nodes[0]).toEqual({ id: "1", name: "Card A", template: hash });
+    expect(result.nodes[1]).toEqual({ id: "2", name: "Card B", template: hash });
+    // The shared style stays hoisted (referenced from the element body + Header).
+    expect(result.globalVars.styles).toEqual({ fill_red: RED });
+  });
+
+  it("inlines a style used only by one deduplicated element, dropping the global entry", () => {
+    // fill_red is used by exactly the two cards (count 2) that fold into one
+    // element (2 instances). Exclusive → expanded inline, global entry removed,
+    // collapsing template → ref → value down to template → value.
     const nodes = [
       node({ id: "1", name: "Card A", fills: "fill_red" }),
       node({ id: "2", name: "Card B", fills: "fill_red" }),
@@ -74,16 +100,23 @@ describe("element templates", () => {
 
     const result = finalizeDesign(nodes, globalVars, new Set());
 
-    const templates = Object.keys(result.elements);
-    expect(templates).toHaveLength(1);
-    const [hash] = templates;
-    expect(result.elements[hash]).toEqual({ type: "FRAME", fills: "fill_red" });
+    const [hash] = Object.keys(result.elements);
+    expect(result.elements[hash]).toEqual({ type: "FRAME", fills: RED });
+    expect(result.globalVars.styles).toEqual({});
+  });
 
-    // Each occurrence keeps its per-instance id/name, body replaced by the ref.
-    expect(result.nodes[0]).toEqual({ id: "1", name: "Card A", template: hash });
-    expect(result.nodes[1]).toEqual({ id: "2", name: "Card B", template: hash });
-    // The shared style stays hoisted (referenced from the element body).
-    expect(result.globalVars.styles).toEqual({ fill_red: RED });
+  it("does not expand a named style even when exclusive to one element", () => {
+    const nodes = [
+      node({ id: "1", name: "Card A", type: "TEXT", textStyle: "Heading / Large" }),
+      node({ id: "2", name: "Card B", type: "TEXT", textStyle: "Heading / Large" }),
+    ];
+    const globalVars: GlobalVars = { styles: { "Heading / Large": { fontSize: 24 } } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set(["Heading / Large"]));
+
+    const [hash] = Object.keys(result.elements);
+    expect(result.elements[hash]).toEqual({ type: "TEXT", textStyle: "Heading / Large" });
+    expect(result.globalVars.styles).toEqual({ "Heading / Large": { fontSize: 24 } });
   });
 
   it("leaves a unique subtree inline (no template)", () => {

--- a/src/tests/finalize.test.ts
+++ b/src/tests/finalize.test.ts
@@ -52,6 +52,19 @@ describe("count-gated style hoisting", () => {
     expect(result.globalVars.styles).toEqual({ "Heading / Large": { fontSize: 24 } });
   });
 
+  it("drops a named style that no surviving node references (orphaned by node removal)", () => {
+    // A named style can reach zero references when its only node is dropped after
+    // registration — e.g. collapseSvgContainers registers a vector child's named
+    // style, then folds the child away. A hoisted entry nothing points to is just
+    // orphan noise, so it must be dropped rather than force-kept as "intent".
+    const nodes = [node({ id: "1", type: "FRAME" })]; // references no style
+    const globalVars: GlobalVars = { styles: { "Heading / Large": { fontSize: 24 } } };
+
+    const result = finalizeDesign(nodes, globalVars, new Set(["Heading / Large"]));
+
+    expect(result.globalVars.styles).toEqual({});
+  });
+
   it("never inlines or drops inline-text-style (ts*) entries — they're referenced from text", () => {
     const nodes = [node({ id: "1", type: "TEXT", text: "a {ts1}b{/ts1}" })];
     const globalVars: GlobalVars = { styles: { ts1: { fontWeight: 700 } } };

--- a/src/tests/rich-text.test.ts
+++ b/src/tests/rich-text.test.ts
@@ -572,7 +572,7 @@ describe("extractTextStyle — line height", () => {
         } as never,
       }),
     ]);
-    const styleRef = nodes[0].textStyle!;
+    const styleRef = nodes[0].textStyle as string;
     const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
     expect(style.lineHeight).toBeUndefined();
   });
@@ -590,7 +590,7 @@ describe("extractTextStyle — line height", () => {
         } as never,
       }),
     ]);
-    const styleRef = nodes[0].textStyle!;
+    const styleRef = nodes[0].textStyle as string;
     const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
     expect(style.lineHeight).toBe("16.94px");
   });
@@ -609,7 +609,7 @@ describe("extractTextStyle — line height", () => {
         } as never,
       }),
     ]);
-    const styleRef = nodes[0].textStyle!;
+    const styleRef = nodes[0].textStyle as string;
     const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
     expect(style.lineHeight).toBe("150%");
   });
@@ -630,7 +630,7 @@ describe("extractTextStyle — broadened base style capture", () => {
         },
       }),
     ]);
-    const styleRef = nodes[0].textStyle!;
+    const styleRef = nodes[0].textStyle as string;
     const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
     expect(style.italic).toBe(true);
     expect(style.textDecoration).toBe("UNDERLINE");

--- a/src/tests/serialization.test.ts
+++ b/src/tests/serialization.test.ts
@@ -105,6 +105,7 @@ describe("result serialization", () => {
         components: {},
         componentSets: {},
         globalVars: { styles: {} },
+        elements: {},
         nodes: [
           {
             id: "1:1",
@@ -131,6 +132,7 @@ describe("result serialization", () => {
         components: {},
         componentSets: {},
         globalVars: { styles: {} },
+        elements: {},
         nodes: [
           {
             id: "1:1",
@@ -145,6 +147,55 @@ describe("result serialization", () => {
       const output = serializeResult(wrapForSerialization(design), "tree");
 
       expect(output).toContain('componentProperties={"On Sale":true,"Size":"md"}');
+    });
+
+    // After count-gating, single-use style values live inline on the node rather
+    // than as a globalVars ref. The tree renderer must emit them as compact JSON.
+    it("renders inline (non-reference) style values as JSON", () => {
+      const design: SimplifiedDesign = {
+        name: "Test",
+        components: {},
+        componentSets: {},
+        globalVars: { styles: {} },
+        elements: {},
+        nodes: [
+          {
+            id: "1:1",
+            name: "Box",
+            type: "FRAME",
+            fills: ["#FF0000"],
+          },
+        ],
+      };
+
+      const output = serializeResult(wrapForSerialization(design), "tree");
+
+      expect(output).toContain('fills=["#FF0000"]');
+    });
+
+    // Deduplicated nodes carry only id/name/template/children; the type and
+    // styling live in the ELEMENTS block. The renderer resolves the type label
+    // from the element so the line keeps its `[TYPE] "name" #id` shape.
+    it("renders an ELEMENTS block and template-reference nodes", () => {
+      const design: SimplifiedDesign = {
+        name: "Test",
+        components: {},
+        componentSets: {},
+        globalVars: { styles: { fill_red: ["#FF0000"] } },
+        elements: {
+          "EL-abc12345": { type: "FRAME", fills: "fill_red" },
+        },
+        nodes: [
+          { id: "1:1", name: "Card A", template: "EL-abc12345" },
+          { id: "1:2", name: "Card B", template: "EL-abc12345" },
+        ],
+      };
+
+      const output = serializeResult(wrapForSerialization(design), "tree");
+
+      expect(output).toContain("ELEMENTS:");
+      expect(output).toContain('[FRAME] "Card A" #1:1 template=EL-abc12345');
+      expect(output).toContain('[FRAME] "Card B" #1:2 template=EL-abc12345');
     });
   });
 });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -3,8 +3,6 @@ import path from "path";
 import { tagError } from "~/utils/error-meta.js";
 import { isWithin } from "~/utils/local-path.js";
 
-export type StyleId = `${string}_${string}` & { __brand: "StyleId" };
-
 /**
  * Download Figma image and save it locally
  * @param fileName - The filename to save as
@@ -130,23 +128,6 @@ export function removeEmptyKeys<T>(input: T): T {
   }
 
   return result;
-}
-
-/**
- * Generate a 6-character random variable ID
- * @param prefix - ID prefix
- * @returns A 6-character random ID string with prefix
- */
-export function generateVarId(prefix: string = "var"): StyleId {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  let result = "";
-
-  for (let i = 0; i < 6; i++) {
-    const randomIndex = Math.floor(Math.random() * chars.length);
-    result += chars[randomIndex];
-  }
-
-  return `${prefix}_${result}` as StyleId;
 }
 
 /**

--- a/src/utils/serializable-design.ts
+++ b/src/utils/serializable-design.ts
@@ -1,8 +1,8 @@
 import type { SimplifiedDesign } from "~/extractors/types.js";
 
 export function wrapForSerialization(design: SimplifiedDesign) {
-  const { nodes, globalVars, ...metadata } = design;
-  return { metadata, nodes, globalVars };
+  const { nodes, globalVars, elements, ...metadata } = design;
+  return { metadata, nodes, globalVars, elements };
 }
 
 export type SerializableDesign = ReturnType<typeof wrapForSerialization>;

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -27,6 +27,11 @@ export function serializeAsTree(design: SerializableDesign): string {
     sections.push(`\nGLOBAL_VARS:\n${dumpYaml(design.globalVars.styles)}`);
   }
 
+  // Deduplicated element bodies referenced by node `template=` fields below.
+  if (design.elements && Object.keys(design.elements).length > 0) {
+    sections.push(`ELEMENTS:\n${dumpYaml(design.elements)}`);
+  }
+
   if (Object.keys(design.metadata.components).length > 0) {
     sections.push(`COMPONENTS:\n${dumpYaml(design.metadata.components)}`);
   }
@@ -37,31 +42,41 @@ export function serializeAsTree(design: SerializableDesign): string {
 
   const lines: string[] = ["NODES:"];
   for (const node of design.nodes) {
-    renderNode(node, 0, lines);
+    renderNode(node, 0, lines, design.elements);
   }
   sections.push(lines.join("\n"));
 
   return sections.join("\n");
 }
 
-function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {
+function renderNode(
+  node: SimplifiedNode,
+  depth: number,
+  out: string[],
+  elements: SerializableDesign["elements"],
+): void {
   const indent = "  ".repeat(depth);
   const parts: string[] = [];
 
-  parts.push(`[${node.type}]`);
+  // A template reference carries no body of its own — its type and styling live
+  // in the shared element. Render the type label from there so the line keeps the
+  // familiar `[TYPE] "name" #id` shape, then point at the template.
+  const element = node.template ? elements?.[node.template] : undefined;
+  parts.push(`[${element?.type ?? node.type}]`);
   parts.push(quote(node.name));
   parts.push(`#${node.id}`);
+  if (node.template !== undefined) parts.push(`template=${node.template}`);
 
   // Order chosen to put high-signal properties first
-  if (node.layout !== undefined) parts.push(`layout=${node.layout}`);
-  if (node.fills !== undefined) parts.push(`fills=${maybeQuote(node.fills)}`);
-  if (node.strokes !== undefined) parts.push(`strokes=${maybeQuote(node.strokes)}`);
+  if (node.layout !== undefined) parts.push(`layout=${renderStyleValue(node.layout)}`);
+  if (node.fills !== undefined) parts.push(`fills=${renderStyleValue(node.fills)}`);
+  if (node.strokes !== undefined) parts.push(`strokes=${renderStyleValue(node.strokes)}`);
   if (node.strokeWeight !== undefined) parts.push(`strokeWeight=${maybeQuote(node.strokeWeight)}`);
   if (node.strokeWeights !== undefined) {
     parts.push(`strokeWeights=${maybeQuote(node.strokeWeights)}`);
   }
   if (node.strokeDashes !== undefined) parts.push(`strokeDashes=${node.strokeDashes.join(",")}`);
-  if (node.effects !== undefined) parts.push(`effects=${maybeQuote(node.effects)}`);
+  if (node.effects !== undefined) parts.push(`effects=${renderStyleValue(node.effects)}`);
   if (node.opacity !== undefined) parts.push(`opacity=${node.opacity}`);
   if (node.borderRadius !== undefined) parts.push(`borderRadius=${maybeQuote(node.borderRadius)}`);
   if (node.styles !== undefined) parts.push(`styles=${maybeQuote(node.styles)}`);
@@ -72,7 +87,7 @@ function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {
   if (node.componentPropertyReferences !== undefined) {
     parts.push(`componentPropertyReferences=${JSON.stringify(node.componentPropertyReferences)}`);
   }
-  if (node.textStyle !== undefined) parts.push(`textStyle=${node.textStyle}`);
+  if (node.textStyle !== undefined) parts.push(`textStyle=${renderStyleValue(node.textStyle)}`);
   if (node.boldWeight !== undefined) parts.push(`boldWeight=${node.boldWeight}`);
   if (node.text !== undefined) parts.push(`text=${quote(node.text)}`);
 
@@ -80,9 +95,17 @@ function renderNode(node: SimplifiedNode, depth: number, out: string[]): void {
 
   if (node.children) {
     for (const child of node.children) {
-      renderNode(child, depth + 1, out);
+      renderNode(child, depth + 1, out, elements);
     }
   }
+}
+
+// Style fields hold either a globalVars reference (a short scalar id) or, for
+// single-use values after the finalize pass, the inline value itself. Refs render
+// bare; inline objects/arrays render as compact JSON (consistent with how
+// componentProperties is rendered), keeping the whole node on one line.
+function renderStyleValue(value: unknown): string {
+  return typeof value === "string" ? maybeQuote(value) : JSON.stringify(value);
 }
 
 // Always JSON-quote name and text so embedded whitespace, quotes, or newlines


### PR DESCRIPTION
## What this does

Shrinks the `get_figma_data` payload AI clients consume, and the win **grows with design repetition** — biggest exactly where payloads hurt most. Measured on four real Figma files (bytes, all three output formats):

| design | yaml | json | tree |
|---|---:|---:|---:|
| small frame | −3% | −3% | −20% |
| medium | −9% | −8% | −11% |
| large, low-repeat | −4% | −2% | −15% |
| massive, multi-page | **−29%** | **−23%** | **−20%** |

Three always-on transforms run in a post-walk finalize pass (it needs whole-tree usage counts the single-pass extractors can't see):

1. **Single-use style inlining** — a style referenced by one node is inlined back onto it; `globalVars` keeps only shared (2+) and named Figma styles, dropping the indirection tax for one-offs.
2. **Element templates** — node bodies (everything except `id`/`name`/`children`) that repeat 2+ times are emitted once into a new `elements` table; each occurrence becomes a compact `{ id, name, template, children? }` ref. Repeated UI — list rows, icon grids, card decks — stops re-serializing identical styling on every instance.
3. **Exclusive-style inlining** — a surviving style used only by the instances of one template is folded into that template body, collapsing `template → ref → value` to `template → value`.

## Reviewer notes

- **Output shape changes (always on):** responses gain a top-level `elements` table and `template` refs on nodes. This is additive — no existing field is removed or renamed — but consumers that parse output rigidly will see new keys.
- **Not a uniform shrink.** Savings concentrate in the compact `tree` format and in repetitive files; low-repetition designs net low-single-digits on yaml/json, and single-use inlining alone can *grow* those formats a few percent (pretty-printing re-indents relocated values) before templating offsets it. The net is favorable on every fixture measured, but it is not a guaranteed shrink on every file.
- **Collision-safe IDs.** Content-addressed style and element IDs use an 8-hex SHA-1 slice to keep refs short; a guard lengthens the ID on the rare truncation clash so two distinct values can never merge silently. Byte-neutral when no collision occurs.
- **Pass ordering is for simplicity, not correctness** — content-addressing already makes identical subtrees share byte-identical refs, so gating before hashing is an implementation choice rather than a correctness gate (rationale in `finalize.ts`).
- Coverage in `finalize.test.ts` and `serialization.test.ts`; full suite green (207 passing), type-check clean.
