### PR TITLE
feat(fills): flatten all-solid fill stacks into a single resolved color

### DIFF
--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -6,7 +6,7 @@ import type {
   SimplifiedNode,
 } from "./types.js";
 import { buildSimplifiedLayout } from "~/transformers/layout.js";
-import { buildSimplifiedStrokes, parsePaint } from "~/transformers/style.js";
+import { buildSimplifiedStrokes, flattenSolidFills, parsePaint } from "~/transformers/style.js";
 import { buildSimplifiedEffects } from "~/transformers/effects.js";
 import {
   buildFormattedText,
@@ -178,10 +178,15 @@ export const visualsExtractor: ExtractorFn = (node, result, context) => {
 
   // fills
   if (hasValue("fills", node) && Array.isArray(node.fills) && node.fills.length) {
-    const fills = node.fills
-      .filter(isVisible)
-      .map((fill) => parsePaint(fill, hasChildren))
-      .reverse();
+    const visibleFills = node.fills.filter(isVisible);
+    // An all-solid stack collapses to the single resolved color a viewer sees,
+    // removing the layer-order ambiguity that misleads LLM consumers. Mixed
+    // stacks (gradient/image/pattern or a non-normal blend) can't be folded and
+    // fall back to the per-paint array, reversed into CSS top-first order.
+    const flattened = flattenSolidFills(visibleFills);
+    const fills = flattened
+      ? [flattened]
+      : visibleFills.map((fill) => parsePaint(fill, hasChildren)).reverse();
     result.fills = registerStyle(node, context, fills, ["fill", "fills"], "fill");
   }
 

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -224,6 +224,180 @@ describe("extractFromDesign", () => {
   });
 });
 
+describe("fill flattening", () => {
+  // Resolve a node's registered fills var back to its concrete value.
+  type Extracted = Awaited<ReturnType<typeof extractFromDesign>>;
+  function fillsValue(nodes: Extracted["nodes"], globalVars: Extracted["globalVars"]) {
+    return globalVars.styles[nodes[0].fills as string];
+  }
+
+  // Figma orders the fills array bottom-first, so index 0 is the backdrop and
+  // the last entry is the topmost layer.
+  it("composites an all-solid stack into a single resolved color", async () => {
+    const node = makeNode({
+      id: "f:1",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 1, g: 1, b: 1, a: 1 }, visible: true }, // white backdrop
+        { type: "SOLID", color: { r: 0, g: 0, b: 0, a: 1 }, opacity: 0.2, visible: true }, // black @ 20%
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    expect(fillsValue(nodes, globalVars)).toEqual(["#CCCCCC"]);
+  });
+
+  it("culls layers fully occluded by an opaque paint above them", async () => {
+    const node = makeNode({
+      id: "f:2",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 0, g: 0, b: 1, a: 1 }, visible: true }, // blue backdrop
+        { type: "SOLID", color: { r: 1, g: 0, b: 0, a: 1 }, visible: true }, // opaque red on top
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    // Only the opaque top color survives; the blue beneath contributes nothing.
+    expect(fillsValue(nodes, globalVars)).toEqual(["#FF0000"]);
+  });
+
+  it("folds both color.a and paint.opacity into the effective alpha", async () => {
+    const node = makeNode({
+      id: "f:6",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 1, g: 1, b: 1, a: 1 }, visible: true }, // white backdrop
+        // black at color.a 0.5 × opacity 0.5 = 0.25 effective → 0.75 of white shows through
+        { type: "SOLID", color: { r: 0, g: 0, b: 0, a: 0.5 }, opacity: 0.5, visible: true },
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    expect(fillsValue(nodes, globalVars)).toEqual(["#BFBFBF"]);
+  });
+
+  it("culls everything below a fully-opaque mid-stack paint, compositing only what's above", async () => {
+    const node = makeNode({
+      id: "f:7",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 1, g: 0, b: 0, a: 1 }, visible: true }, // red (culled)
+        { type: "SOLID", color: { r: 0, g: 1, b: 0, a: 1 }, visible: true }, // opaque green
+        { type: "SOLID", color: { r: 0, g: 0, b: 1, a: 1 }, opacity: 0.5, visible: true }, // blue @ 50% on top
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    // Red contributes nothing (opaque green above it); blue@50% blends over green → teal.
+    expect(fillsValue(nodes, globalVars)).toEqual(["#008080"]);
+  });
+
+  it("treats PASS_THROUGH blend as flattenable", async () => {
+    const node = makeNode({
+      id: "f:8",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        {
+          type: "SOLID",
+          color: { r: 1, g: 1, b: 1, a: 1 },
+          blendMode: "PASS_THROUGH",
+          visible: true,
+        },
+        {
+          type: "SOLID",
+          color: { r: 0, g: 0, b: 0, a: 1 },
+          opacity: 0.2,
+          blendMode: "PASS_THROUGH",
+          visible: true,
+        },
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    expect(fillsValue(nodes, globalVars)).toEqual(["#CCCCCC"]);
+  });
+
+  it("emits rgba() when the composited stack is still translucent", async () => {
+    const node = makeNode({
+      id: "f:3",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 1, g: 1, b: 1, a: 0.5 }, visible: true },
+        { type: "SOLID", color: { r: 0, g: 0, b: 0, a: 0.5 }, visible: true },
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    expect(fillsValue(nodes, globalVars)).toEqual(["rgba(85, 85, 85, 0.75)"]);
+  });
+
+  it("leaves a stack untouched when it contains a gradient", async () => {
+    const node = makeNode({
+      id: "f:4",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        {
+          type: "GRADIENT_LINEAR",
+          visible: true,
+          gradientHandlePositions: [
+            { x: 0, y: 0 },
+            { x: 1, y: 1 },
+            { x: 0, y: 1 },
+          ],
+          gradientStops: [
+            { position: 0, color: { r: 1, g: 0, b: 0, a: 1 } },
+            { position: 1, color: { r: 0, g: 0, b: 1, a: 1 } },
+          ],
+        },
+        { type: "SOLID", color: { r: 0, g: 0, b: 0, a: 1 }, opacity: 0.2, visible: true },
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    // Both layers survive, reversed into CSS top-first order: solid first, gradient last.
+    const value = fillsValue(nodes, globalVars) as unknown[];
+    expect(value).toHaveLength(2);
+    expect(value[0]).toBe("rgba(0, 0, 0, 0.2)");
+    expect((value[1] as { type: string }).type).toBe("GRADIENT_LINEAR");
+  });
+
+  it("leaves a stack untouched when any solid uses a non-normal blend mode", async () => {
+    const node = makeNode({
+      id: "f:5",
+      name: "Swatch",
+      type: "FRAME",
+      fills: [
+        { type: "SOLID", color: { r: 1, g: 1, b: 1, a: 1 }, visible: true },
+        {
+          type: "SOLID",
+          color: { r: 0, g: 0, b: 0, a: 0.2 },
+          blendMode: "MULTIPLY",
+          visible: true,
+        },
+      ],
+    });
+
+    const { nodes, globalVars } = await extractFromDesign([node], allExtractors);
+
+    expect(fillsValue(nodes, globalVars)).toHaveLength(2);
+  });
+});
+
 describe("collapseSvgContainers", () => {
   it("collapses BOOLEAN_OPERATION nodes to IMAGE-SVG", async () => {
     const booleanOpNode = makeNode({

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -347,6 +347,71 @@ export function parsePaint(raw: Paint, hasChildren: boolean = false): Simplified
 }
 
 /**
+ * A solid paint participates in flattening only when it blends normally with
+ * what's behind it. PASS_THROUGH (groups) and NORMAL both composite with plain
+ * source-over; every other blend mode (MULTIPLY, SCREEN, …) needs the backdrop
+ * to compute, which a flattened stack has thrown away — so its presence anywhere
+ * disqualifies the whole stack. A missing blendMode is treated as NORMAL (its
+ * Figma default).
+ */
+function isFlattenableSolid(paint: Paint): paint is Extract<Paint, { type: "SOLID" }> {
+  return (
+    paint.type === "SOLID" &&
+    (paint.blendMode === undefined ||
+      paint.blendMode === "NORMAL" ||
+      paint.blendMode === "PASS_THROUGH")
+  );
+}
+
+type StraightColor = { r: number; g: number; b: number; a: number };
+
+/** Source-over composite of `top` (foreground) onto `bottom` (backdrop), straight alpha, channels 0..1. */
+function compositeOver(top: StraightColor, bottom: StraightColor): StraightColor {
+  const a = top.a + bottom.a * (1 - top.a);
+  if (a === 0) return { r: 0, g: 0, b: 0, a: 0 };
+  const blend = (cT: number, cB: number) => (cT * top.a + cB * bottom.a * (1 - top.a)) / a;
+  return { r: blend(top.r, bottom.r), g: blend(top.g, bottom.g), b: blend(top.b, bottom.b), a };
+}
+
+/**
+ * Collapse an all-solid paint stack into the single color a viewer actually sees.
+ *
+ * The emitted fills array carries layer order as a silent positional contract,
+ * and LLM consumers misread it — picking the wrong layer's color, or emitting a
+ * layer that's fully occluded by an opaque paint above it. When every visible
+ * paint is a normally-blended SOLID we can resolve that ambiguity outright:
+ * source-over composite the stack into one resolved color (hex when the result
+ * is fully opaque, else rgba()). Compositing inherently culls dead layers —
+ * anything beneath a fully-opaque paint contributes nothing to the result.
+ *
+ * Returns null when the stack contains a gradient, image, pattern, or any
+ * non-normal blend mode: those have their own output syntax and can't be folded,
+ * so the caller falls back to emitting the per-paint array untouched.
+ *
+ * `paints` must be in Figma order (index 0 = bottom layer).
+ */
+export function flattenSolidFills(paints: Paint[]): SimplifiedFill | null {
+  if (!paints.length || !paints.every(isFlattenableSolid)) return null;
+
+  // Fold effective alpha (color.a * paint.opacity) before compositing, bottom to top.
+  const toStraight = (p: Extract<Paint, { type: "SOLID" }>): StraightColor => ({
+    r: p.color.r,
+    g: p.color.g,
+    b: p.color.b,
+    a: p.color.a * (p.opacity ?? 1),
+  });
+
+  let acc = toStraight(paints[0]);
+  for (let i = 1; i < paints.length; i++) {
+    acc = compositeOver(toStraight(paints[i]), acc);
+  }
+
+  const composited: RGBA = acc;
+  const { hex, opacity } = convertColor(composited);
+  return opacity === 1 ? hex : formatRGBAColor(composited);
+}
+
+/**
  * Convert a Figma PatternPaint to a CSS-like pattern fill.
  *
  * Ignores `tileType` and `spacing` from the Figma API currently as there's


### PR DESCRIPTION
## What changes

Nodes with multiple solid fills now emit a **single resolved color** instead of the raw layer stack. LLM consumers of `get_figma_data` were misreading the fills array — its layer order is a silent positional contract, so models picked the wrong layer's color, or faithfully reproduced a layer that's fully hidden behind an opaque paint above it. (Surfaced in a trial render that dropped a visible-but-occluded layer and used the wrong color.)

When every visible paint on a node is a normally-blended `SOLID`, the stack is composited via source-over alpha blending into one color:

- Fully opaque result → hex (`#CCCCCC`)
- Still translucent → `rgba(...)`
- Layers fully occluded by an opaque paint above them contribute nothing and disappear for free.

## What stays the same

Stacks that contain a gradient, image, or pattern — or any paint with a non-normal blend mode (`MULTIPLY`, `SCREEN`, …) — can't be folded into a flat color, so they keep their existing per-paint array, untouched. A single non-solid/non-normal paint anywhere in the stack disables flattening for that whole stack.

Strokes are intentionally left alone; this targets the fills extractor only.

## Notes for reviewers

- Effective alpha folds `color.a * (paint.opacity ?? 1)` before compositing, matching Figma's model.
- A missing `blendMode` is treated as `NORMAL` (its Figma default) for robustness, though real API responses always include it.
- While writing tests I noticed a latent quirk in `parsePaint`: when a solid's `color.a < 1` *and* it falls through to `formatRGBAColor`, the alpha is applied twice. It only bites the unusual `color.a < 1` form (real Figma carries transparency in `opacity` with `color.a == 1`), so it's out of scope here — flagging for a possible follow-up.