### PR TITLE
fix(text): emit letterSpacing and relative lineHeight as em, not %

### DIFF
--- a/src/tests/rich-text.test.ts
+++ b/src/tests/rich-text.test.ts
@@ -595,7 +595,7 @@ describe("extractTextStyle — line height", () => {
     expect(style.lineHeight).toBe("16.94px");
   });
 
-  it("emits explicit percentage line heights as % using lineHeightPercentFontSize", async () => {
+  it("emits font-size-relative line heights as em (one canonical relative form)", async () => {
     const { nodes, globalVars } = await extract([
       makeText({
         characters: "pct",
@@ -611,7 +611,24 @@ describe("extractTextStyle — line height", () => {
     ]);
     const styleRef = nodes[0].textStyle as string;
     const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
-    expect(style.lineHeight).toBe("150%");
+    expect(style.lineHeight).toBe("1.5em");
+  });
+
+  it("emits letterSpacing as em so it pastes straight into CSS", async () => {
+    const { nodes, globalVars } = await extract([
+      makeText({
+        characters: "tracking",
+        style: {
+          fontFamily: "Inter",
+          fontWeight: 400,
+          fontSize: 16,
+          letterSpacing: -0.32, // -0.32px / 16px = -0.02em
+        } as never,
+      }),
+    ]);
+    const styleRef = nodes[0].textStyle as string;
+    const style = globalVars.styles[styleRef] as SimplifiedTextStyle;
+    expect(style.letterSpacing).toBe("-0.02em");
   });
 });
 

--- a/src/transformers/text.ts
+++ b/src/transformers/text.ts
@@ -45,6 +45,16 @@ export function hasTextStyle(
   return hasValue("style", n) && Object.keys(n.style).length > 0;
 }
 
+// Letter-spacing is emitted as a font-size-relative `em` so it pastes straight
+// into CSS and lets native targets (iOS/Flutter) resolve to absolute units by
+// multiplying the fontSize in the same textStyle. We round to 4 decimals rather
+// than reuse `pixelRound` (2 dp): letter-spacing fractions are O(0.01), where
+// 0.01em is ~0.16px at a 16px font — coarse enough to visibly shift tracking.
+// 4 dp preserves the precision the old "%" form carried (0.01% = 0.0001em).
+function emRound(value: number): number {
+  return Number(value.toFixed(4));
+}
+
 export function extractTextStyle(n: FigmaDocumentNode) {
   if (hasTextStyle(n)) {
     const style = n.style;
@@ -56,7 +66,7 @@ export function extractTextStyle(n: FigmaDocumentNode) {
       lineHeight: formatLineHeight(style as LineHeightSource, style.fontSize),
       letterSpacing:
         style.letterSpacing && style.letterSpacing !== 0 && style.fontSize
-          ? `${pixelRound((style.letterSpacing / style.fontSize) * 100)}%`
+          ? `${emRound(style.letterSpacing / style.fontSize)}em`
           : undefined,
       textCase: style.textCase,
       textAlignHorizontal: style.textAlignHorizontal,
@@ -105,12 +115,15 @@ function pickNonZeroFlags(
  *                 `lineHeightPx` is just the computed value for whichever
  *                 font the node happens to use, not user intent)
  *   PIXELS      → "24px"  from `lineHeightPx`
- *   FONT_SIZE_% → "150%"  from `lineHeightPercentFontSize`
+ *   FONT_SIZE_% → "1.5em" from `lineHeightPercentFontSize`
  *
- * Falls back to an em conversion when the unit is missing (older API
- * responses) so the output is never worse than before. All numeric values
- * are rounded via `pixelRound` so floating-point noise like Figma's
- * `16.94318199157715` doesn't leak through.
+ * Relative line-height is emitted as `em` (not `%`) to match letterSpacing and
+ * give one canonical font-size-relative form: it pastes straight into CSS and
+ * native targets resolve it by multiplying the fontSize in the same textStyle.
+ * Absolute line-height stays `px`. Falls back to an em conversion when the unit
+ * is missing (older API responses) so the output is never worse than before.
+ * All numeric values are rounded via `pixelRound` so floating-point noise like
+ * Figma's `16.94318199157715` doesn't leak through.
  */
 type LineHeightSource = {
   lineHeightPx?: number;
@@ -131,7 +144,7 @@ function formatLineHeight(
   }
 
   if (lineHeightUnit === "FONT_SIZE_%" && lineHeightPercentFontSize) {
-    return `${pixelRound(lineHeightPercentFontSize)}%`;
+    return `${pixelRound(lineHeightPercentFontSize / 100)}em`;
   }
 
   if (lineHeightPx && fontSize) {
@@ -607,7 +620,7 @@ function classifyRun(
       case "letterSpacing": {
         const ls = value as number;
         if (ls && effectiveFontSize) {
-          refDelta.letterSpacing = `${pixelRound((ls / effectiveFontSize) * 100)}%`;
+          refDelta.letterSpacing = `${emRound(ls / effectiveFontSize)}em`;
           hasRefProps = true;
         }
         break;


### PR DESCRIPTION
## What changes for consumers

`get_figma_data` now emits **`letterSpacing` as `em`** (e.g. `-0.02em`) instead of a percentage (`-2%`).

`%` isn't a valid CSS `letter-spacing` value, so consumers had to hand-convert it to px — and got it wrong: a trial render turned `-2%` into `-1.12px` by hand. `em` removes that footgun. It's the canonical font-size-relative form: web (CSS) and Android (View/Compose) consume it directly, while iOS (kern) and Flutter/RN resolve it by multiplying the `fontSize` already present in the same `textStyle`. One relative form, every target resolves it correctly.

## lineHeight made consistent

Relative line-height was emitted inconsistently — `150%` in the `FONT_SIZE_%` branch but `em` in the unitless fallback. This converges on **`em`** so the policy is uniform:

- relative line-height → `em` (`1.5em`)
- absolute line-height → `px` (`24px`)

Chose `em` over unitless (`1.5`) because `em` is the explicit-multiplier form already established in this file, and over `%` for the same paste-into-CSS reasoning as letterSpacing.

`paragraphSpacing` / `paragraphIndent` / `listSpacing` are left as **absolute px** — they're not font-relative, so an em conversion would be wrong.

## Notes for reviewers

- Both emission sites are updated: the base `textStyle` and the rich-text inline-override delta.
- `letterSpacing` rounds to 4 decimals (not the codebase's usual 2-dp `pixelRound`): letter-spacing fractions are O(0.01), where `0.01em` ≈ 0.16px at 16px — coarse enough to visibly shift tracking. 4 dp preserves the precision the old 2-decimal `%` form carried. lineHeight stays at 2 dp (its float-noise rounding is intentional).