### PR TITLE
fix(effects): halve Figma blur radius for CSS and omit zero-radius blur

### DIFF
--- a/src/tests/effects.test.ts
+++ b/src/tests/effects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildSimplifiedEffects } from "~/transformers/effects.js";
+import type { Node as FigmaNode } from "@figma/rest-api-spec";
+
+// Only the effects array is read; cast through unknown like the other walker tests.
+function nodeWithEffects(effects: unknown[]): FigmaNode {
+  return { type: "FRAME", effects } as unknown as FigmaNode;
+}
+
+describe("buildSimplifiedEffects — blur", () => {
+  // Figma's blur radius is ~2x the CSS blur() radius, so a Figma 32 must render
+  // as blur(16px). Covers both the layer-blur (filter) and background-blur
+  // (backdrop-filter) paths.
+  it("halves a layer blur radius onto the CSS filter property", () => {
+    const result = buildSimplifiedEffects(
+      nodeWithEffects([{ type: "LAYER_BLUR", radius: 32, visible: true }]),
+    );
+    expect(result.filter).toBe("blur(16px)");
+  });
+
+  it("halves a background blur radius onto the CSS backdrop-filter property", () => {
+    const result = buildSimplifiedEffects(
+      nodeWithEffects([{ type: "BACKGROUND_BLUR", radius: 32, visible: true }]),
+    );
+    expect(result.backdropFilter).toBe("blur(16px)");
+  });
+
+  // A zero-radius blur is a no-op; emitting blur(0px) is dead output.
+  it("omits a zero-radius blur entirely", () => {
+    const result = buildSimplifiedEffects(
+      nodeWithEffects([
+        { type: "LAYER_BLUR", radius: 0, visible: true },
+        { type: "BACKGROUND_BLUR", radius: 0, visible: true },
+      ]),
+    );
+    expect(result.filter).toBeUndefined();
+    expect(result.backdropFilter).toBeUndefined();
+  });
+});

--- a/src/transformers/effects.ts
+++ b/src/transformers/effects.ts
@@ -6,6 +6,7 @@ import type {
 } from "@figma/rest-api-spec";
 import { formatRGBAColor } from "~/transformers/style.js";
 import { hasValue } from "~/utils/identity.js";
+import { pixelRound } from "~/utils/common.js";
 
 export type SimplifiedEffects = {
   boxShadow?: string;
@@ -29,16 +30,17 @@ export function buildSimplifiedEffects(n: FigmaDocumentNode): SimplifiedEffects 
 
   const boxShadow = [...dropShadows, ...innerShadows].join(", ");
 
-  // Handle blur effects - separate by CSS property
+  // Handle blur effects - separate by CSS property. A zero-radius blur is a
+  // no-op, so drop it entirely rather than emit a dead `blur(0px)`.
   // Layer blurs use the CSS 'filter' property
   const filterBlurValues = effects
-    .filter((e): e is BlurEffect => e.type === "LAYER_BLUR")
+    .filter((e): e is BlurEffect => e.type === "LAYER_BLUR" && e.radius > 0)
     .map(simplifyBlur)
     .join(" ");
 
   // Background blurs use the CSS 'backdrop-filter' property
   const backdropFilterValues = effects
-    .filter((e): e is BlurEffect => e.type === "BACKGROUND_BLUR")
+    .filter((e): e is BlurEffect => e.type === "BACKGROUND_BLUR" && e.radius > 0)
     .map(simplifyBlur)
     .join(" ");
 
@@ -66,5 +68,8 @@ function simplifyInnerShadow(effect: InnerShadowEffect) {
 }
 
 function simplifyBlur(effect: BlurEffect) {
-  return `blur(${effect.radius}px)`;
+  // Figma's blur radius is ~2x the CSS blur() radius — verified by direct CSS
+  // test and corroborated by Figma's own Dev Mode output (a Figma blur of 32
+  // renders as CSS blur(16px)). Halve it so the emitted value matches CSS.
+  return `blur(${pixelRound(effect.radius / 2)}px)`;
 }


### PR DESCRIPTION
## What changes for consumers

Blur effects in `get_figma_data` output now match what the design actually renders. Figma's blur radius is **~2× the CSS `blur()` radius**, but the transformer emitted the raw value — so a Figma blur of 32 came out as `blur(32px)`, twice as strong as the design. It now emits `blur(16px)`.

Verified two ways: a direct CSS test, and Figma's own Dev Mode output (the same node Figma exports as `backdrop-blur-[16px]` we were emitting as `blur(32px)`).

Applies to **both** blur paths: layer blur (`filter`) and background blur (`backdrop-filter`).

## Also

Zero-radius blurs are now dropped entirely instead of emitting a dead `blur(0px)`.

## Notes for reviewers

- Halving uses the existing `pixelRound` so no float noise leaks through (e.g. an odd radius → `16.5px`).
- The `radius > 0` guard lives in the effect filter, so a node whose only blur is zero-radius omits `filter`/`backdrop-filter` rather than emitting an empty value.
- Reviewed by Codex (no findings).