### PR TITLE
feat(layout): emit the requested root as contextual sizing with a designed reference

### DIFF
--- a/src/tests/layout-alignment.test.ts
+++ b/src/tests/layout-alignment.test.ts
@@ -265,6 +265,58 @@ describe("layout alignment", () => {
     });
   });
 
+  // The requested root has no parent in the payload, so Figma reports it as
+  // FIXED at its artboard size — an artifact of being top-level. Honoring that
+  // as a hard width/height would pin the whole design and kill responsiveness,
+  // so the root marks such axes "contextual" and keeps the size as a non-binding
+  // designed* reference. Descendants (real parent) keep their fixed semantics.
+  describe("root node contextual sizing", () => {
+    test("rewrites FIXED axes as contextual + designed reference on a top-level node", () => {
+      const root = makeFrame({
+        layoutSizingHorizontal: "FIXED",
+        layoutSizingVertical: "FIXED",
+        absoluteBoundingBox: { x: 0, y: 0, width: 1440, height: 900 },
+      });
+      const layout = buildSimplifiedLayout(root);
+      expect(layout.sizing).toEqual({ horizontal: "contextual", vertical: "contextual" });
+      expect(layout.designedWidth).toBe("1440px");
+      expect(layout.designedHeight).toBe("900px");
+      // No binding dimensions on the root.
+      expect(layout.dimensions).toBeUndefined();
+    });
+
+    test("keeps the same FIXED sizing and dimensions on a non-root child", () => {
+      const parent = makeFrame({
+        layoutMode: "NONE",
+        absoluteBoundingBox: { x: 0, y: 0, width: 1440, height: 900 },
+      });
+      const child = makeFrame({
+        layoutMode: "NONE",
+        layoutSizingHorizontal: "FIXED",
+        layoutSizingVertical: "FIXED",
+        absoluteBoundingBox: { x: 0, y: 0, width: 200, height: 100 },
+      });
+      const layout = buildSimplifiedLayout(child, parent);
+      expect(layout.sizing).toEqual({ horizontal: "fixed", vertical: "fixed" });
+      expect(layout.dimensions).toEqual({ width: 200, height: 100 });
+      expect(layout.designedWidth).toBeUndefined();
+    });
+
+    test("only the FIXED axis becomes contextual; a real HUG axis is left alone", () => {
+      const root = makeFrame({
+        layoutSizingHorizontal: "FIXED",
+        layoutSizingVertical: "HUG",
+        absoluteBoundingBox: { x: 0, y: 0, width: 1440, height: 900 },
+      });
+      const layout = buildSimplifiedLayout(root);
+      // Canonical desktop root: fluid width, content-sized height.
+      expect(layout.sizing).toEqual({ horizontal: "contextual", vertical: "hug" });
+      expect(layout.designedWidth).toBe("1440px");
+      // HUG needs no anchor — height is determined by content.
+      expect(layout.designedHeight).toBeUndefined();
+    });
+  });
+
   describe("locationRelativeToParent", () => {
     // SECTION holds children but has no frame properties (no clipsContent, no
     // layoutMode), so it can never auto-layout — children are always positioned

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -94,12 +94,34 @@ function buildSimplifiedLayoutValues(
 ): SimplifiedLayout | undefined {
   if (!isLayout(n)) return undefined;
 
+  // The requested root has no parent in the payload, so Figma reports its sizing
+  // FIXED relative to an absent container — an artifact of being top-level, not
+  // design intent. Honoring it as a hard width/height pins the whole design to
+  // its artboard and kills responsiveness. Descendants (which have a real parent)
+  // keep their fill/hug/fixed semantics. See fig-ovmi.
+  const isRoot = parent === undefined;
+
   const layoutValues: SimplifiedLayout = { mode };
 
   layoutValues.sizing = {
     horizontal: convertSizing(n.layoutSizingHorizontal),
     vertical: convertSizing(n.layoutSizingVertical),
   };
+
+  // For the root, rewrite each spurious FIXED axis as "contextual" (it fills
+  // whatever it's placed in) and surface the designed size as a non-binding
+  // reference — absolutely-positioned children and the fill-chain still need a
+  // concrete size to anchor against. Real FILL/HUG axes are intent; leave them.
+  if (isRoot && n.absoluteBoundingBox) {
+    if (layoutValues.sizing.horizontal === "fixed") {
+      layoutValues.sizing.horizontal = "contextual";
+      layoutValues.designedWidth = `${pixelRound(n.absoluteBoundingBox.width)}px`;
+    }
+    if (layoutValues.sizing.vertical === "fixed") {
+      layoutValues.sizing.vertical = "contextual";
+      layoutValues.designedHeight = `${pixelRound(n.absoluteBoundingBox.height)}px`;
+    }
+  }
 
   // Emit positioning relative to parent unless the parent's auto-layout already
   // places this child. `isLayout(parent)` also screens out top-level nodes
@@ -127,7 +149,7 @@ function buildSimplifiedLayoutValues(
   // sizing flag permits it. Stretch detection and the "is FIXED?" rule both
   // depend on whether the parent is flex, grid, or non-auto-layout — see the
   // helpers in ./layout/common.ts for the per-axis vocabulary mapping.
-  if (isRectangle("absoluteBoundingBox", n)) {
+  if (!isRoot && isRectangle("absoluteBoundingBox", n)) {
     const dimensions: { width?: number; height?: number; aspectRatio?: number } = {};
     const axis = resolveChildAxis(n, parent, mode, parentIsGrid);
     const stretch = getChildStretch(n, axis);

--- a/src/transformers/layout/common.ts
+++ b/src/transformers/layout/common.ts
@@ -34,10 +34,19 @@ export interface SimplifiedLayout {
     height?: number;
     aspectRatio?: number;
   };
+  // The size the requested root was designed at, surfaced as a non-binding
+  // reference (not a hard width/height). The root's own dimensions are
+  // "contextual" — it fills whatever it's placed in — but absolutely-positioned
+  // children and the fill-chain still need a concrete size to anchor against, so
+  // we keep the designed value here, named so it can't be mistaken for a pin.
+  designedWidth?: string;
+  designedHeight?: string;
   padding?: string;
   sizing?: {
-    horizontal?: "fixed" | "fill" | "hug";
-    vertical?: "fixed" | "fill" | "hug";
+    // "contextual": size is determined by wherever the element is placed (used
+    // for the requested root, whose FIXED size is an artifact of being top-level).
+    horizontal?: "fixed" | "fill" | "hug" | "contextual";
+    vertical?: "fixed" | "fill" | "hug" | "contextual";
   };
   overflowScroll?: ("x" | "y")[];
   position?: "absolute";


### PR DESCRIPTION
## What changes for consumers

The requested root node is now **responsive AND anchorable**. It previously emitted a binding fixed `width`/`height` (e.g. `1440 × 900`), pinning the whole design to its artboard. The fix surfaces the root's size without pinning it:

```
mode: row
sizing: { horizontal: contextual, vertical: hug }
designedWidth: "1440px"
```

- **`contextual`** sizing = "this dimension is determined by wherever the element is placed" — don't hardcode it. (The root's `FIXED` is an artifact: its `layoutSizing` is reported against a parent that isn't in the payload.)
- **`designedWidth` / `designedHeight`** = the size the design was authored at, as a *non-binding reference*. Named so it can't be mistaken for a hard pin, but present so absolutely-positioned children and the fill-chain have a concrete size to anchor against.

## Why not just drop the size

An earlier cut suppressed the root's dimensions entirely. But `fill` is relative — every responsive child defers its width up to the root, so deleting the root's size left the chain with nothing to resolve against, and a faithful renderer had to **fabricate** a width. Keeping it as a clearly-named reference fixes that while staying responsive. (This mirrors Figma Dev Mode, which renders the root `size-full` but still surfaces the absolute size separately.)

## Scope

- Applies only to the requested root (`parent === undefined`) — both single-node and whole-file (page-children) requests. Descendants have a real parent and are completely untouched.
- Per-axis and symmetric: only a `FIXED` axis becomes `contextual` + gets a `designed*` value. A real `FILL`/`HUG` axis passes through and gets no designed reference (`HUG` sizes to content — no anchor needed).
- No `fixed` is ever emitted on the root.

## Notes for reviewers

- `contextual` / `designed*` are intentionally **not** documented in the tool description — testing whether LLMs infer the contract from the field names alone.
- Verified against both request modes + the walker (the root-detection signal). Full suite: 226 tests (3 new).