### PR TITLE
feat(format): default output to tree instead of yaml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ FIGMA_NODE_ID=your_figma_node_id_here
 # Server configuration
 PORT=3333
 
-# Output format can either be "yaml" or "json". Is YAML by default since it's
-# smaller, but JSON is understood by most LLMs better.
+# Output format: "tree", "yaml", or "json". Defaults to "tree" — it's the most
+# compact (~half the size of yaml) and best for LLM consumers. Use "json" if a
+# consumer parses it more reliably, or "yaml" for a more human-readable middle.
 #
-# OUTPUT_FORMAT="json"
+# OUTPUT_FORMAT="yaml"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ The server supports two transports (configured in `src/server.ts`):
 - `FIGMA_API_KEY` or `--figma-api-key` — Personal Access Token
 - `FIGMA_OAUTH_TOKEN` or `--figma-oauth-token` — OAuth Bearer token
 - `PORT` or `--port` — HTTP server port (default: 3333)
-- `--json` — Output JSON instead of YAML
+- `OUTPUT_FORMAT` or `--format` — Output format: `tree` (default), `yaml`, or `json`
+- `--json` — Back-compat alias for `--format=json`
 - `--skip-image-downloads` — Disable image download tool
 
 ### Path Alias

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -31,13 +31,11 @@ const argv = cli({
     },
     json: {
       type: Boolean,
-      description:
-        "Output data from tools in JSON format instead of YAML. Back-compat alias for --format=json.",
+      description: "Output data from tools in JSON format. Back-compat alias for --format=json.",
     },
     format: {
       type: String,
-      description:
-        "Output format for design data: yaml (default), json, or tree (experimental compact format).",
+      description: "Output format for design data: tree (default, compact), yaml, or json.",
     },
     skipImageDownloads: {
       type: Boolean,

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -36,7 +36,7 @@ export const fetchCommand: Command = command(
       },
       format: {
         type: String,
-        description: "Output format: yaml (default), json, or tree (experimental).",
+        description: "Output format: yaml (default), json, or tree.",
       },
       figmaApiKey: {
         type: String,
@@ -115,6 +115,10 @@ async function run(
   });
 
   const mode = authMode(auth);
+  // The fetch CLI stays yaml-by-default (unlike the MCP server, which defaults
+  // to tree): its output is piped into standard tooling (`> out.yaml`, `| jq`),
+  // where tree's bespoke indented format isn't parseable. Tree's token-efficiency
+  // win is for LLM consumers, not shell pipelines.
   const outputFormat: OutputFormat =
     parseOutputFormat(flags.format, "--format") ?? (flags.json ? "json" : "yaml");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,7 @@ export function getServerConfig(flags: ServerFlags): ServerConfig {
   const formatFromFlag =
     parseOutputFormat(flags.format, "--format") ?? (flags.json ? "json" : undefined);
   const formatFromEnv = parseOutputFormat(envStr("OUTPUT_FORMAT"), "OUTPUT_FORMAT");
-  const outputFormat = resolve<OutputFormat>(formatFromFlag, formatFromEnv, "yaml");
+  const outputFormat = resolve<OutputFormat>(formatFromFlag, formatFromEnv, "tree");
 
   const isStdioMode = flags.stdio === true;
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -30,7 +30,7 @@ export type CreateServerOptions = {
 
 function createServer(
   authOptions: FigmaAuthOptions,
-  { transport, outputFormat = "yaml", skipImageDownloads = false, imageDir }: CreateServerOptions,
+  { transport, outputFormat = "tree", skipImageDownloads = false, imageDir }: CreateServerOptions,
 ) {
   const server = new McpServer(serverInfo);
   const figmaService = new FigmaService(authOptions);

--- a/src/telemetry/capture.ts
+++ b/src/telemetry/capture.ts
@@ -138,7 +138,7 @@ export function captureValidationReject(
     captureToolCall({
       ...common,
       tool: "get_figma_data",
-      output_format: input.outputFormat ?? "yaml",
+      output_format: input.outputFormat ?? "tree",
       depth: null,
       has_node_id: false,
     });

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -26,7 +26,7 @@ describeOrSkip("Figma MCP Server Tests", () => {
         figmaOAuthToken: "",
         useOAuth: false,
       },
-      { transport: "stdio" },
+      { transport: "stdio", outputFormat: "yaml" },
     );
 
     client = new Client({


### PR DESCRIPTION
## What changes for consumers

`get_figma_data` (and the MCP server generally) now returns the **tree** format by default instead of yaml. Tree is consistently the most compact serialization and benefits most from the style/element dedup pass — it's been live long enough to trust as the default.

### Size comparison on real Figma files

Measured on cached real API responses (raw → simplified-as-yaml → simplified-as-tree):

| file | raw | yaml | tree | tree vs yaml |
|---|--:|--:|--:|--:|
| fix1 | 45,937 | 14,428 | 7,571 | **−47.5%** |
| fix2 | 12,317,016 | 176,593 | 90,278 | **−48.9%** |
| fix3 | 213,536 | 41,027 | 22,669 | **−44.7%** |
| fix4 | 2,734,937 | 522,826 | 259,997 | **−50.3%** |

Tree is roughly **half the size of yaml** across files spanning 45 KB to 12 MB of raw response. (Byte counts, not tokens, but the ratio is representative.)

## Scope — flipped only the LLM-facing defaults

The default is changed coherently across the surfaces an LLM consumer hits: the server config fallback (`config.ts`), `createServer`'s library default (`mcp/index.ts`), and the telemetry fallback that records the default (`capture.ts`). Explicit `--format` / `OUTPUT_FORMAT` / `--json` overrides are untouched and still win.

**The `fetch` CLI deliberately stays yaml-by-default.** Its output is piped into standard tooling (`> out.yaml`, `| jq`), where tree's bespoke indented format isn't parseable — tree's token-efficiency win is for LLM consumers, not shell pipelines. (Happy to flip it too if we'd rather have one default everywhere, but I think principled-different beats consistent-but-wrong here.)

## Notes for reviewers

- Docs updated: CLI help text in `bin.ts`/`fetch.ts` (tree no longer "experimental"), `CLAUDE.md`, and `.env.example`. README has no format docs to update (defers to framelink.ai).
- The opt-in integration test (`RUN_FIGMA_INTEGRATION=1`) is pinned to `outputFormat: "yaml"` so its `yaml.load` assertion keeps validating shape.
- Reviewed by Codex (caught the `.env.example` and integration-test misses, both fixed here).