### PR TITLE
fix(images): report real SVG dimensions instead of 0x0

### DIFF
--- a/src/tests/image-processing.test.ts
+++ b/src/tests/image-processing.test.ts
@@ -7,7 +7,11 @@ import jpeg from "@jimp/js-jpeg";
 import * as crop from "@jimp/plugin-crop";
 
 const Jimp = createJimp({ formats: [png, jpeg], plugins: [crop.methods] });
-import { getImageDimensions, applyCropTransform } from "../utils/image-processing.js";
+import {
+  getImageDimensions,
+  applyCropTransform,
+  parseSvgDimensions,
+} from "../utils/image-processing.js";
 import type { Transform } from "@figma/rest-api-spec";
 
 describe("image processing", () => {
@@ -39,6 +43,30 @@ describe("image processing", () => {
       const filePath = await createTemp("test-300x150.jpg", 300, 150);
       const dims = await getImageDimensions(filePath);
       expect(dims).toEqual({ width: 300, height: 150 });
+    });
+  });
+
+  describe("parseSvgDimensions", () => {
+    it("reads width/height attributes (Figma's typical export shape)", () => {
+      const svg = `<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h52v52H0z"/></svg>`;
+      expect(parseSvgDimensions(svg)).toEqual({ width: 52, height: 52 });
+    });
+
+    it("falls back to viewBox when width/height are percentages", () => {
+      const svg = `<svg width="100%" height="100%" viewBox="0 0 24 16"><rect/></svg>`;
+      expect(parseSvgDimensions(svg)).toEqual({ width: 24, height: 16 });
+    });
+
+    it("falls back to viewBox when width/height are absent", () => {
+      const svg = `<svg viewBox="0 0 120 80" xmlns="http://www.w3.org/2000/svg"></svg>`;
+      expect(parseSvgDimensions(svg)).toEqual({ width: 120, height: 80 });
+    });
+
+    it("returns 0x0 when no usable size is declared", () => {
+      expect(parseSvgDimensions(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`)).toEqual({
+        width: 0,
+        height: 0,
+      });
     });
   });
 

--- a/src/utils/image-processing.ts
+++ b/src/utils/image-processing.ts
@@ -75,6 +75,50 @@ export async function getImageDimensions(imagePath: string): Promise<{
   return { width: image.width, height: image.height };
 }
 
+/**
+ * Read an SVG's intrinsic dimensions from its markup.
+ *
+ * jimp only decodes rasters, so the SVG branch can't measure files the way the
+ * raster path does — but an SVG already declares its own size as text. Prefer the
+ * `width`/`height` attributes (Figma exports them as plain user units, e.g.
+ * `width="52"`); fall back to the viewBox's width/height when they're missing or
+ * non-absolute (percentages aren't an intrinsic pixel size). Returns {0,0} only
+ * when the markup carries no usable size at all.
+ */
+export function parseSvgDimensions(svg: string): { width: number; height: number } {
+  const openTag = svg.match(/<svg\b[^>]*>/i)?.[0] ?? "";
+
+  const attr = (name: string): string | undefined =>
+    openTag.match(new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`, "i"))?.[1];
+
+  const parseLength = (raw: string | undefined): number | undefined => {
+    // Percentages (and other relative units) aren't an intrinsic pixel size.
+    if (!raw || raw.includes("%")) return undefined;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+
+  const width = parseLength(attr("width"));
+  const height = parseLength(attr("height"));
+  if (width !== undefined && height !== undefined) {
+    return { width, height };
+  }
+
+  // viewBox is "min-x min-y width height" — the last two are the intrinsic size.
+  const viewBox = attr("viewBox");
+  if (viewBox) {
+    const [, , vbWidth, vbHeight] = viewBox
+      .trim()
+      .split(/[\s,]+/)
+      .map(Number);
+    if (vbWidth > 0 && vbHeight > 0) {
+      return { width: vbWidth, height: vbHeight };
+    }
+  }
+
+  return { width: 0, height: 0 };
+}
+
 export type ImageProcessingResult = {
   filePath: string;
   originalDimensions: { width: number; height: number };
@@ -111,14 +155,20 @@ export async function downloadAndProcessImage(
   const originalPath = await downloadFigmaImage(fileName, localPath, imageUrl);
   Logger.log(`Downloaded original image: ${originalPath}`);
 
-  // SVGs are vector — jimp can't read them and cropping/dimensions don't apply
+  // SVGs are vector — jimp can't read them and cropping doesn't apply. Their
+  // intrinsic size is declared in the markup, so read it from there rather than
+  // reporting a misleading 0x0 (which reads like a download failure).
   const isSvg = fileName.toLowerCase().endsWith(".svg");
   if (isSvg) {
+    const { readFile } = await import("node:fs/promises");
+    const dimensions = parseSvgDimensions(await readFile(originalPath, "utf-8"));
+    Logger.log(`SVG dimensions: ${dimensions.width}x${dimensions.height}`);
     return {
       filePath: originalPath,
-      originalDimensions: { width: 0, height: 0 },
-      finalDimensions: { width: 0, height: 0 },
+      originalDimensions: dimensions,
+      finalDimensions: dimensions,
       wasCropped: false,
+      cssVariables: requiresImageDimensions ? generateImageCSSVariables(dimensions) : undefined,
       processingLog,
     };
   }


### PR DESCRIPTION
## What changes for users

`download_figma_images` reported every SVG as `0x0`:

```
- icon.svg: 0x0
```

The file downloaded fine, but the report read like a failure, and any caller relying on the reported size (e.g. generating CSS dimension variables for tiled fills) got nothing usable. Now it reports the real intrinsic size:

```
- icon.svg: 52x52
```

## Why it was 0x0

The SVG branch in `image-processing.ts` short-circuited with hardcoded zeros because jimp (the raster decoder used for PNG/JPEG/GIF) can't read vectors. But an SVG already declares its own size as text — no decoder needed.

## How it's measured

New `parseSvgDimensions()` reads the size straight from the markup:
1. Prefer the `width`/`height` attributes (Figma exports plain user units, e.g. `width="52"`).
2. Fall back to the `viewBox`'s width/height when those are absent or non-absolute (a `%` width isn't an intrinsic pixel size).
3. Only then `0x0`.

SVGs now also emit CSS dimension variables when `requiresImageDimensions` is requested — the `0x0` path couldn't.

## Notes for reviewers

- It's a string parse, so no new dependency and no async decode.
- Known limitation (out of scope, not seen in Figma exports): `width`/`height` attributes carrying `pt` units or scientific notation parse imperfectly. Plain user units and `px` work; `viewBox` handles all numeric forms via `Number()`.
- 4 unit tests cover the attribute path, both fallbacks, and the no-size case.
- Reviewed by Codex — no findings.

type-check ✅, 230 tests ✅, lint clean ✅.