### PR TITLE
fix: sync server manifest package version

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GLips/Figma-Context-MCP",
     "source": "github"
   },
-  "version": "0.6.4",
+  "version": "0.13.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "figma-developer-mcp",
-      "version": "0.6.4",
+      "version": "0.13.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- update `server.json` to match the current `figma-developer-mcp` package version
- keep the top-level server manifest and npm package entry in sync with `package.json`

## Validation
- node -e "JSON.parse(require('fs').readFileSync('server.json','utf8'))"
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm type-check
- pnpm test
- git diff --check