### PR TITLE
feat: fetch multiple Figma nodes in one get_figma_data call

### DIFF
--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -26,8 +26,9 @@ export async function simplifyRawFigmaObject(
     parseAPIResponse(apiResponse);
 
   // Partial miss: some requested ids didn't resolve but others did. We proceed
-  // with what we have (see parseAPIResponse) and surface the gap here rather than
-  // failing the whole call — the caller asked for several roots and most came back.
+  // with what we have (see parseAPIResponse) rather than failing the whole call —
+  // the caller asked for several roots and most came back. The gap is logged for
+  // operators and carried into the result below so the LLM caller sees it too.
   if (missingNodeIds.length > 0) {
     Logger.log(
       `Skipped ${missingNodeIds.length} unresolved node id(s): ${missingNodeIds.join(", ")}`,
@@ -60,6 +61,8 @@ export async function simplifyRawFigmaObject(
       componentSets,
       traversalState.componentPropertyDefinitions,
     ),
+    // Only present on a partial miss, so the common case pays no tokens for it.
+    ...(missingNodeIds.length > 0 ? { missingNodeIds } : {}),
     globalVars,
     elements,
   };

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -63,12 +63,32 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
   let nodesToParse: Array<FigmaDocumentNode>;
 
   if ("nodes" in data) {
-    // GetFileNodesResponse
-    const [nodeId, nodeData] = Object.entries(data.nodes)[0];
-    if (nodeData === null) {
+    // GetFileNodesResponse — may contain multiple requested nodes when the
+    // caller passed comma-separated ids. Aggregate every node the API returned;
+    // a null entry is a node the API couldn't resolve (deleted/inaccessible/
+    // wrong file) and is skipped. Only error if NONE resolved — that's the
+    // "not found" case the single-node path used to handle.
+    const documents: FigmaDocumentNode[] = [];
+    const missingNodeIds: string[] = [];
+    for (const [nodeId, nodeData] of Object.entries(data.nodes)) {
+      if (nodeData === null) {
+        missingNodeIds.push(nodeId);
+        continue;
+      }
+      Object.assign(aggregatedComponents, nodeData.components);
+      Object.assign(aggregatedComponentSets, nodeData.componentSets);
+      if (nodeData.styles) {
+        Object.assign(extraStyles, nodeData.styles);
+      }
+      documents.push(nodeData.document);
+    }
+
+    if (documents.length === 0) {
+      const requested = Object.keys(data.nodes);
+      const idList = (requested.length ? requested : ["(none returned)"]).join(", ");
       tagError(
         new Error(
-          `Node ${nodeId} was not found in the Figma file. Likely causes: ` +
+          `No requested nodes were found in the Figma file (${idList}). Likely causes: ` +
             `(1) The source URL was a /proto/, /figjam/, /slides/, /board/, or /deck/ link — ` +
             `only /design/ and /file/ URLs are supported by the Figma REST API. ` +
             `(2) The node is inside a Figma branch — branches have their own fileKey ` +
@@ -80,12 +100,7 @@ function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
       );
     }
 
-    Object.assign(aggregatedComponents, nodeData.components);
-    Object.assign(aggregatedComponentSets, nodeData.componentSets);
-    if (nodeData.styles) {
-      Object.assign(extraStyles, nodeData.styles);
-    }
-    nodesToParse = [nodeData.document];
+    nodesToParse = documents;
   } else {
     // GetFileResponse
     Object.assign(aggregatedComponents, data.components);

--- a/src/extractors/design-extractor.ts
+++ b/src/extractors/design-extractor.ts
@@ -8,6 +8,7 @@ import type {
 } from "@figma/rest-api-spec";
 import { simplifyComponents, simplifyComponentSets } from "~/transformers/component.js";
 import { tagError } from "~/utils/error-meta.js";
+import { Logger } from "~/utils/logger.js";
 import type { ExtractorFn, TraversalOptions, SimplifiedDesign } from "./types.js";
 import { extractFromDesign } from "./node-walker.js";
 import { finalizeDesign } from "./finalize.js";
@@ -21,10 +22,21 @@ export async function simplifyRawFigmaObject(
   options: TraversalOptions = {},
 ): Promise<SimplifiedDesign> {
   // Extract components, componentSets, and raw nodes from API response
-  const { metadata, rawNodes, components, componentSets, extraStyles } =
+  const { name, rawNodes, components, componentSets, extraStyles, missingNodeIds } =
     parseAPIResponse(apiResponse);
 
-  // Process nodes using the flexible extractor system
+  // Partial miss: some requested ids didn't resolve but others did. We proceed
+  // with what we have (see parseAPIResponse) and surface the gap here rather than
+  // failing the whole call — the caller asked for several roots and most came back.
+  if (missingNodeIds.length > 0) {
+    Logger.log(
+      `Skipped ${missingNodeIds.length} unresolved node id(s): ${missingNodeIds.join(", ")}`,
+    );
+  }
+
+  // Process nodes using the flexible extractor system. The walk shares one
+  // globalVars + traversalState across every root, so style/element dedup spans
+  // all requested nodes — a value used once in either root is still seen twice.
   const {
     nodes: extractedNodes,
     globalVars: walkedGlobalVars,
@@ -41,7 +53,7 @@ export async function simplifyRawFigmaObject(
   );
 
   return {
-    ...metadata,
+    name,
     nodes,
     components: simplifyComponents(components, traversalState.componentPropertyDefinitions),
     componentSets: simplifyComponentSets(
@@ -54,72 +66,111 @@ export async function simplifyRawFigmaObject(
 }
 
 /**
- * Parse the raw Figma API response to extract metadata, nodes, and components.
+ * One requested-or-whole-file unit of raw design data: a set of root nodes plus
+ * the component/style dictionaries that came alongside them. Both API response
+ * shapes normalize to a list of these, so the rest of parsing is shape-agnostic.
  */
-function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse) {
-  const aggregatedComponents: Record<string, Component> = {};
-  const aggregatedComponentSets: Record<string, ComponentSet> = {};
-  let extraStyles: Record<string, Style> = {};
-  let nodesToParse: Array<FigmaDocumentNode>;
+type RawSlice = {
+  roots: FigmaDocumentNode[];
+  components?: Record<string, Component>;
+  componentSets?: Record<string, ComponentSet>;
+  styles?: Record<string, Style>;
+};
 
-  if ("nodes" in data) {
-    // GetFileNodesResponse — may contain multiple requested nodes when the
-    // caller passed comma-separated ids. Aggregate every node the API returned;
-    // a null entry is a node the API couldn't resolve (deleted/inaccessible/
-    // wrong file) and is skipped. Only error if NONE resolved — that's the
-    // "not found" case the single-node path used to handle.
-    const documents: FigmaDocumentNode[] = [];
-    const missingNodeIds: string[] = [];
-    for (const [nodeId, nodeData] of Object.entries(data.nodes)) {
-      if (nodeData === null) {
-        missingNodeIds.push(nodeId);
-        continue;
-      }
-      Object.assign(aggregatedComponents, nodeData.components);
-      Object.assign(aggregatedComponentSets, nodeData.componentSets);
-      if (nodeData.styles) {
-        Object.assign(extraStyles, nodeData.styles);
-      }
-      documents.push(nodeData.document);
-    }
+type ParsedAPIResponse = {
+  name: string;
+  rawNodes: FigmaDocumentNode[];
+  components: Record<string, Component>;
+  componentSets: Record<string, ComponentSet>;
+  extraStyles: Record<string, Style>;
+  /** Requested node ids the API returned as null (deleted/inaccessible/wrong file). */
+  missingNodeIds: string[];
+};
 
-    if (documents.length === 0) {
-      const requested = Object.keys(data.nodes);
-      const idList = (requested.length ? requested : ["(none returned)"]).join(", ");
-      tagError(
-        new Error(
-          `No requested nodes were found in the Figma file (${idList}). Likely causes: ` +
-            `(1) The source URL was a /proto/, /figjam/, /slides/, /board/, or /deck/ link — ` +
-            `only /design/ and /file/ URLs are supported by the Figma REST API. ` +
-            `(2) The node is inside a Figma branch — branches have their own fileKey ` +
-            `(the value after /branch/ in the URL), use that instead of the parent file's key. ` +
-            `(3) The link is stale or the node was deleted. ` +
-            `Ask the user for a fresh /design/ URL pointing to the specific frame.`,
-        ),
-        { category: "not_found" },
-      );
-    }
+/** Shallow-merge a list of dictionaries; `undefined` sources are skipped. */
+function mergeRecords<T>(records: Array<Record<string, T> | undefined>): Record<string, T> {
+  return Object.assign({}, ...records);
+}
 
-    nodesToParse = documents;
-  } else {
-    // GetFileResponse
-    Object.assign(aggregatedComponents, data.components);
-    Object.assign(aggregatedComponentSets, data.componentSets);
-    if (data.styles) {
-      extraStyles = data.styles;
-    }
-    nodesToParse = data.document.children;
-  }
-
-  const { name } = data;
+/**
+ * Parse the raw Figma API response into a flat, shape-agnostic bag of roots and
+ * their associated dictionaries. The two API shapes differ only in how they
+ * package roots; normalizing them up front (see normalizeResponse) lets the
+ * aggregation below treat the full-file fetch and a multi-node fetch identically.
+ */
+function parseAPIResponse(data: GetFileResponse | GetFileNodesResponse): ParsedAPIResponse {
+  const { slices, missingNodeIds } = normalizeResponse(data);
 
   return {
-    metadata: {
-      name,
-    },
-    rawNodes: nodesToParse,
-    extraStyles,
-    components: aggregatedComponents,
-    componentSets: aggregatedComponentSets,
+    name: data.name,
+    rawNodes: slices.flatMap((slice) => slice.roots),
+    components: mergeRecords(slices.map((slice) => slice.components)),
+    componentSets: mergeRecords(slices.map((slice) => slice.componentSets)),
+    extraStyles: mergeRecords(slices.map((slice) => slice.styles)),
+    missingNodeIds,
   };
+}
+
+/**
+ * Collapse either API response shape into a list of {@link RawSlice}s. The only
+ * branch the rest of the pipeline can't avoid lives here:
+ *   - GetFileResponse: one slice whose roots are the document's children.
+ *   - GetFileNodesResponse: one slice per resolved node (the caller may have
+ *     passed comma-separated ids). A null entry is a node the API couldn't
+ *     resolve and is recorded in missingNodeIds, not turned into a slice. Only
+ *     when NOTHING resolves do we raise the "not found" error — the case the
+ *     single-node path used to handle, and the one that previously crashed with a
+ *     raw TypeError on an empty `nodes` object.
+ */
+function normalizeResponse(data: GetFileResponse | GetFileNodesResponse): {
+  slices: RawSlice[];
+  missingNodeIds: string[];
+} {
+  if ("document" in data) {
+    return {
+      slices: [
+        {
+          roots: data.document.children,
+          components: data.components,
+          componentSets: data.componentSets,
+          styles: data.styles,
+        },
+      ],
+      missingNodeIds: [],
+    };
+  }
+
+  const entries = Object.entries(data.nodes);
+  const missingNodeIds = entries.flatMap(([id, node]) => (node === null ? [id] : []));
+  const slices: RawSlice[] = entries.flatMap(([, node]) =>
+    node === null
+      ? []
+      : [
+          {
+            roots: [node.document],
+            components: node.components,
+            componentSets: node.componentSets,
+            styles: node.styles,
+          },
+        ],
+  );
+
+  if (slices.length === 0) {
+    const requested = entries.map(([id]) => id);
+    const idList = (requested.length ? requested : ["(none returned)"]).join(", ");
+    tagError(
+      new Error(
+        `No requested nodes were found in the Figma file (${idList}). Likely causes: ` +
+          `(1) The source URL was a /proto/, /figjam/, /slides/, /board/, or /deck/ link — ` +
+          `only /design/ and /file/ URLs are supported by the Figma REST API. ` +
+          `(2) The node is inside a Figma branch — branches have their own fileKey ` +
+          `(the value after /branch/ in the URL), use that instead of the parent file's key. ` +
+          `(3) The link is stale or the node was deleted. ` +
+          `Ask the user for a fresh /design/ URL pointing to the specific frame.`,
+      ),
+      { category: "not_found" },
+    );
+  }
+
+  return { slices, missingNodeIds };
 }

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -107,6 +107,13 @@ export interface SimplifiedDesign {
   nodes: SimplifiedNode[];
   components: Record<string, SimplifiedComponentDefinition>;
   componentSets: Record<string, SimplifiedComponentSetDefinition>;
+  /**
+   * Requested node ids the Figma API returned as null (deleted/inaccessible/
+   * wrong file) on a multi-node fetch where at least one other node resolved.
+   * Surfaced so the LLM caller knows the result is partial rather than silently
+   * acting on an incomplete design. Omitted entirely when nothing was missing.
+   */
+  missingNodeIds?: string[];
   globalVars: GlobalVars;
   /**
    * Deduplicated element bodies, keyed by content hash (`EL-xxxxxxxx`). Populated

--- a/src/mcp/tools/get-figma-data-tool.ts
+++ b/src/mcp/tools/get-figma-data-tool.ts
@@ -11,6 +11,13 @@ import {
 import { getFigmaData as runGetFigmaData } from "~/services/get-figma-data.js";
 import type { OutputFormat } from "~/utils/serialize.js";
 
+// One Figma node id: the API colon form "1234:5678", the URL dash form
+// "1234-5678", or a semicolon-joined instance-override path
+// "I5666:180910;1:10515;1:10336" (still a SINGLE node). Built from a single-id
+// sub-pattern so the comma-separated list grammar below stays readable.
+const SINGLE_NODE_ID = String.raw`I?\d+(?::|-)\d+(?:;\d+(?::|-)\d+)*`;
+const NODE_ID_LIST = new RegExp(String.raw`^${SINGLE_NODE_ID}(?:,${SINGLE_NODE_ID})*$`);
+
 const parameters = {
   fileKey: z
     .string()
@@ -21,7 +28,7 @@ const parameters = {
   nodeId: z
     .string()
     .regex(
-      /^I?\d+[:|-]\d+(?:;\d+[:|-]\d+)*(?:,I?\d+[:|-]\d+(?:;\d+[:|-]\d+)*)*$/,
+      NODE_ID_LIST,
       "Node ID must be like '1234:5678', a semicolon-joined instance path, or a comma-separated list of these",
     )
     .optional()

--- a/src/mcp/tools/get-figma-data-tool.ts
+++ b/src/mcp/tools/get-figma-data-tool.ts
@@ -21,12 +21,12 @@ const parameters = {
   nodeId: z
     .string()
     .regex(
-      /^I?\d+[:|-]\d+(?:;\d+[:|-]\d+)*$/,
-      "Node ID must be like '1234:5678' or 'I5666:180910;1:10515;1:10336'",
+      /^I?\d+[:|-]\d+(?:;\d+[:|-]\d+)*(?:,I?\d+[:|-]\d+(?:;\d+[:|-]\d+)*)*$/,
+      "Node ID must be like '1234:5678', a semicolon-joined instance path, or a comma-separated list of these",
     )
     .optional()
     .describe(
-      "The ID of the node to fetch, often found as URL parameter node-id=<nodeId>, always use if provided. Use format '1234:5678' for a standard node, or 'I5666:180910;1:10515;1:10336' for a deeply nested instance node (the semicolon-joined path represents the instance override chain — it's still a single node ID, not multiple nodes).",
+      "The ID(s) of the node(s) to fetch, often found as the URL parameter node-id=<nodeId>; always use if provided. Use '1234:5678' for a standard node. A semicolon-joined value like 'I5666:180910;1:10515;1:10336' is a SINGLE deeply-nested instance node (the override chain), not multiple nodes. To fetch MULTIPLE top-level nodes in one call, comma-separate their ids, e.g. '1:2,3:4'.",
     ),
   depth: z
     .number()

--- a/src/services/get-figma-data-metrics.ts
+++ b/src/services/get-figma-data-metrics.ts
@@ -156,6 +156,9 @@ export function countNamedStyles(raw: GetFileResponse | GetFileNodesResponse): n
   }
   const seen = new Set<string>();
   for (const entry of Object.values(raw.nodes)) {
+    // A null entry is a requested node the API couldn't resolve (partial miss);
+    // it carries no styles. parseAPIResponse skips these, so metrics must too.
+    if (entry === null) continue;
     for (const id of Object.keys(entry.styles ?? {})) seen.add(id);
   }
   return seen.size;
@@ -169,8 +172,12 @@ export function countNamedStyles(raw: GetFileResponse | GetFileNodesResponse): n
  * presence signal. Walking inline Paint/effect structs would be redundant.
  */
 export function detectVariables(raw: GetFileResponse | GetFileNodesResponse): boolean {
+  // Null entries are requested nodes the API couldn't resolve (partial miss);
+  // skip them rather than dereferencing .document on null.
   const roots: Node[] =
-    "document" in raw ? [raw.document] : Object.values(raw.nodes).map((entry) => entry.document);
+    "document" in raw
+      ? [raw.document]
+      : Object.values(raw.nodes).flatMap((entry) => (entry === null ? [] : [entry.document]));
 
   const visit = (node: Node): boolean => {
     if (

--- a/src/tests/figma-service.test.ts
+++ b/src/tests/figma-service.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FigmaService } from "~/services/figma.js";
+
+/**
+ * Characterization tests for FigmaService's request/error path. These pin the
+ * CURRENT behavior of endpoint construction, auth-header selection, and the
+ * HTTP-status-to-message translation in `requestWithSize`. They mock the global
+ * `fetch` (not `fetchJSON`) so the real fetch-json + error-meta flow runs
+ * end-to-end — that's the layer that tags `http_status`, which FigmaService
+ * branches on. Modeled on `http-header-auth.test.ts`.
+ *
+ * Error-message assertions deliberately match stable substrings, not full
+ * strings: `src/services/errors/*` is designed to be reworded without a release.
+ */
+
+const figmaFileResponse = {
+  name: "Test File",
+  lastModified: "2026-01-01T00:00:00Z",
+  thumbnailUrl: "",
+  version: "1",
+  document: { id: "0:0", name: "Document", type: "DOCUMENT", children: [] },
+  components: {},
+  componentSets: {},
+  schemaVersion: 0,
+  styles: {},
+};
+
+describe("FigmaService request/error path", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  /** Configure the stubbed fetch to answer api.figma.com with a given response. */
+  function stubFigmaResponse(makeResponse: () => Response) {
+    const realFetch = globalThis.fetch;
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("https://api.figma.com")) {
+        return makeResponse();
+      }
+      return realFetch(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  }
+
+  function firstRequestUrl(): string {
+    return String(fetchMock.mock.calls[0][0]);
+  }
+
+  function firstRequestHeaders(): Record<string, string> {
+    const init = fetchMock.mock.calls[0][1] as RequestInit & { headers?: Record<string, string> };
+    return init.headers ?? {};
+  }
+
+  /** Await a promise expecting it to reject, and return the thrown Error. */
+  async function captureError(promise: Promise<unknown>): Promise<Error> {
+    try {
+      await promise;
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error("expected promise to reject, but it resolved");
+  }
+
+  beforeEach(() => {
+    stubFigmaResponse(() => Response.json(figmaFileResponse));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("endpoint construction", () => {
+    it("builds the nodes endpoint for getRawNode", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      await service.getRawNode("ABC", "1:2");
+
+      expect(firstRequestUrl()).toContain("/files/ABC/nodes?ids=1:2");
+    });
+
+    it("appends depth to the nodes endpoint when provided", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      await service.getRawNode("ABC", "1:2", 3);
+
+      expect(firstRequestUrl()).toContain("/files/ABC/nodes?ids=1:2&depth=3");
+    });
+
+    it("builds the file endpoint for getRawFile", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      await service.getRawFile("ABC");
+
+      expect(firstRequestUrl()).toMatch(/\/files\/ABC$/);
+    });
+
+    it("appends depth to the file endpoint when provided", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      await service.getRawFile("ABC", 2);
+
+      expect(firstRequestUrl()).toContain("/files/ABC?depth=2");
+    });
+  });
+
+  describe("auth headers", () => {
+    it("sends X-Figma-Token when using a personal access token", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      await service.getRawFile("ABC");
+
+      expect(firstRequestHeaders()).toMatchObject({ "X-Figma-Token": "test-key" });
+    });
+
+    it("sends Authorization Bearer when using OAuth", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "",
+        figmaOAuthToken: "tok",
+        useOAuth: true,
+      });
+
+      await service.getRawFile("ABC");
+
+      expect(firstRequestHeaders()).toMatchObject({ Authorization: "Bearer tok" });
+    });
+  });
+
+  describe("happy path return shape", () => {
+    it("returns parsed data alongside a positive rawSize", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      const { data, rawSize } = await service.getRawFile("ABC");
+
+      expect(data).toMatchObject({ name: "Test File" });
+      expect(rawSize).toBeGreaterThan(0);
+    });
+  });
+
+  describe("error translation", () => {
+    it("translates 429 into the rate-limit guidance message", async () => {
+      stubFigmaResponse(
+        () => new Response("rate limited body", { status: 429, statusText: "Too Many Requests" }),
+      );
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      const error = await captureError(service.getRawNode("ABC", "1:2"));
+
+      expect(error.message).toContain("Figma API rate limit hit (429).");
+      expect(error.message).toContain("https://developers.figma.com/docs/rest-api/rate-limits/");
+      expect(error.cause).toBeDefined();
+    });
+
+    it("translates 403 into the forbidden guidance message", async () => {
+      stubFigmaResponse(
+        () => new Response("forbidden body", { status: 403, statusText: "Forbidden" }),
+      );
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      const error = await captureError(service.getRawNode("ABC", "1:2"));
+
+      expect(error.message).toContain(
+        "https://www.framelink.ai/docs/troubleshooting#cannot-access-file",
+      );
+      expect(error.message).toContain("returned 403 Forbidden");
+      expect(error.message).toContain("forbidden body");
+      expect(error.cause).toBeDefined();
+    });
+
+    it("translates other failures into the generic endpoint message", async () => {
+      stubFigmaResponse(
+        () =>
+          new Response("server error body", { status: 500, statusText: "Internal Server Error" }),
+      );
+      const service = new FigmaService({
+        figmaApiKey: "test-key",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      const error = await captureError(service.getRawNode("ABC", "1:2"));
+
+      expect(error.message).toContain("Failed to make request to Figma API endpoint");
+      expect(error.message).toContain("/files/ABC/nodes?ids=1:2");
+      expect(error.cause).toBeDefined();
+    });
+  });
+
+  describe("missing-auth guard", () => {
+    it("rejects without making a request when no credentials are configured", async () => {
+      const service = new FigmaService({
+        figmaApiKey: "",
+        figmaOAuthToken: "",
+        useOAuth: false,
+      });
+
+      const error = await captureError(service.getRawFile("ABC"));
+
+      expect(error.message).toContain("authentication is required");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/multi-node.test.ts
+++ b/src/tests/multi-node.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
+import { allExtractors } from "~/extractors/built-in.js";
+import { getFigmaDataTool } from "~/mcp/tools/get-figma-data-tool.js";
+import { getErrorMeta } from "~/utils/error-meta.js";
+import type { GetFileNodesResponse, Node as FigmaNode } from "@figma/rest-api-spec";
+
+// Same casting strategy as tree-walker.test.ts: the walker only reads a small
+// subset of the deeply-discriminated Figma node union, so build fixtures loosely
+// and cast through unknown.
+function makeNode(overrides: Record<string, unknown>): FigmaNode {
+  return { visible: true, ...overrides } as unknown as FigmaNode;
+}
+
+// A GetFileNodesResponse entry wraps each requested node's document plus its
+// associated components/styles. A null entry means the API couldn't resolve it.
+function makeNodesResponse(
+  nodes: Record<string, { document: FigmaNode } | null>,
+): GetFileNodesResponse {
+  const wrapped: Record<string, unknown> = {};
+  for (const [id, value] of Object.entries(nodes)) {
+    wrapped[id] =
+      value === null
+        ? null
+        : { document: value.document, components: {}, componentSets: {}, styles: {} };
+  }
+  return { name: "Test File", nodes: wrapped } as unknown as GetFileNodesResponse;
+}
+
+describe("multi-node GetFileNodesResponse handling", () => {
+  it("aggregates every returned node into the top-level nodes array", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
+      "3:4": { document: makeNode({ id: "3:4", name: "Frame B", type: "FRAME" }) },
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map((n) => n.name)).toEqual(["Frame A", "Frame B"]);
+    expect(result.nodes.map((n) => n.id)).toEqual(["1:2", "3:4"]);
+  });
+
+  it("skips null entries and resolves with just the found nodes", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
+      "9:9": null,
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].name).toBe("Frame A");
+  });
+
+  it("rejects with a not_found error when every requested node is null", async () => {
+    const response = makeNodesResponse({ "1:2": null, "3:4": null });
+
+    await expect(simplifyRawFigmaObject(response, allExtractors)).rejects.toMatchObject({
+      message: expect.stringContaining("No requested nodes were found"),
+    });
+
+    const error = await simplifyRawFigmaObject(response, allExtractors).catch((e) => e);
+    expect(getErrorMeta(error).category).toBe("not_found");
+  });
+
+  it("rejects with not_found (not a TypeError) on an empty nodes object", async () => {
+    const response = makeNodesResponse({});
+
+    const error = await simplifyRawFigmaObject(response, allExtractors).catch((e) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect(getErrorMeta(error).category).toBe("not_found");
+    expect((error as Error).message).toContain("No requested nodes were found");
+  });
+});
+
+describe("get_figma_data nodeId schema", () => {
+  it("accepts a comma-separated list of node ids", () => {
+    const result = getFigmaDataTool.parametersSchema.safeParse({
+      fileKey: "abc",
+      nodeId: "1:2,3:4",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a malformed node id", () => {
+    const result = getFigmaDataTool.parametersSchema.safeParse({
+      fileKey: "abc",
+      nodeId: "not a node id",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/tests/multi-node.test.ts
+++ b/src/tests/multi-node.test.ts
@@ -3,6 +3,8 @@ import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
 import { allExtractors } from "~/extractors/built-in.js";
 import { getFigmaDataTool } from "~/mcp/tools/get-figma-data-tool.js";
 import { countNamedStyles, detectVariables } from "~/services/get-figma-data-metrics.js";
+import { wrapForSerialization } from "~/utils/serializable-design.js";
+import { serializeAsTree } from "~/utils/serialize-tree.js";
 import { getErrorMeta } from "~/utils/error-meta.js";
 import type { GetFileNodesResponse, Node as FigmaNode, Style } from "@figma/rest-api-spec";
 
@@ -49,7 +51,7 @@ describe("multi-node GetFileNodesResponse handling", () => {
     expect(result.nodes.map((n) => n.id)).toEqual(["1:2", "3:4"]);
   });
 
-  it("skips null entries and resolves with just the found nodes", async () => {
+  it("skips null entries and surfaces the missing ids on the result", async () => {
     const response = makeNodesResponse({
       "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
       "9:9": null,
@@ -59,6 +61,19 @@ describe("multi-node GetFileNodesResponse handling", () => {
 
     expect(result.nodes).toHaveLength(1);
     expect(result.nodes[0].name).toBe("Frame A");
+    // Partial miss is reported back, not swallowed — the LLM must know the
+    // result is incomplete.
+    expect(result.missingNodeIds).toEqual(["9:9"]);
+  });
+
+  it("omits missingNodeIds entirely when every requested node resolved", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    expect(result).not.toHaveProperty("missingNodeIds");
   });
 
   it("rejects with a not_found error when every requested node is null", async () => {
@@ -173,6 +188,33 @@ describe("metrics tolerate null node entries (partial miss)", () => {
   it("detectVariables ignores the null entry", () => {
     expect(() => detectVariables(response)).not.toThrow();
     expect(detectVariables(response)).toBe(true);
+  });
+});
+
+describe("partial-miss warning reaches serialized output", () => {
+  it("renders a MISSING_NODES line in the tree format on a partial miss", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
+      "9:9": null,
+    });
+
+    const tree = serializeAsTree(
+      wrapForSerialization(await simplifyRawFigmaObject(response, allExtractors)),
+    );
+
+    expect(tree).toContain("MISSING_NODES: 9:9");
+  });
+
+  it("emits no MISSING_NODES line when the fetch is complete", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME" }) },
+    });
+
+    const tree = serializeAsTree(
+      wrapForSerialization(await simplifyRawFigmaObject(response, allExtractors)),
+    );
+
+    expect(tree).not.toContain("MISSING_NODES");
   });
 });
 

--- a/src/tests/multi-node.test.ts
+++ b/src/tests/multi-node.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import { simplifyRawFigmaObject } from "~/extractors/design-extractor.js";
 import { allExtractors } from "~/extractors/built-in.js";
 import { getFigmaDataTool } from "~/mcp/tools/get-figma-data-tool.js";
+import { countNamedStyles, detectVariables } from "~/services/get-figma-data-metrics.js";
 import { getErrorMeta } from "~/utils/error-meta.js";
-import type { GetFileNodesResponse, Node as FigmaNode } from "@figma/rest-api-spec";
+import type { GetFileNodesResponse, Node as FigmaNode, Style } from "@figma/rest-api-spec";
 
 // Same casting strategy as tree-walker.test.ts: the walker only reads a small
 // subset of the deeply-discriminated Figma node union, so build fixtures loosely
@@ -12,20 +13,27 @@ function makeNode(overrides: Record<string, unknown>): FigmaNode {
   return { visible: true, ...overrides } as unknown as FigmaNode;
 }
 
+type NodeEntry = { document: FigmaNode; styles?: Record<string, Style> } | null;
+
 // A GetFileNodesResponse entry wraps each requested node's document plus its
 // associated components/styles. A null entry means the API couldn't resolve it.
-function makeNodesResponse(
-  nodes: Record<string, { document: FigmaNode } | null>,
-): GetFileNodesResponse {
+function makeNodesResponse(nodes: Record<string, NodeEntry>): GetFileNodesResponse {
   const wrapped: Record<string, unknown> = {};
   for (const [id, value] of Object.entries(nodes)) {
     wrapped[id] =
       value === null
         ? null
-        : { document: value.document, components: {}, componentSets: {}, styles: {} };
+        : {
+            document: value.document,
+            components: {},
+            componentSets: {},
+            styles: value.styles ?? {},
+          };
   }
   return { name: "Test File", nodes: wrapped } as unknown as GetFileNodesResponse;
 }
+
+const RED_FILL = [{ type: "SOLID", color: { r: 1, g: 0, b: 0, a: 1 }, visible: true }];
 
 describe("multi-node GetFileNodesResponse handling", () => {
   it("aggregates every returned node into the top-level nodes array", async () => {
@@ -73,6 +81,98 @@ describe("multi-node GetFileNodesResponse handling", () => {
     expect(error).not.toBeInstanceOf(TypeError);
     expect(getErrorMeta(error).category).toBe("not_found");
     expect((error as Error).message).toContain("No requested nodes were found");
+  });
+});
+
+// The whole point of fetching multiple roots in one call is that the clever
+// passes (style hoisting, element templating) still see the combined forest.
+// These assert dedup spans node boundaries, not just within a single root.
+describe("cross-node deduplication", () => {
+  it("hoists a style shared across two separate top-level nodes", async () => {
+    // Distinct node types so their bodies differ — this isolates STYLE dedup from
+    // ELEMENT dedup (identical bodies would template away the `fills` field).
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME", fills: RED_FILL }) },
+      "3:4": {
+        document: makeNode({ id: "3:4", name: "Box B", type: "RECTANGLE", fills: RED_FILL }),
+      },
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    // Same fill in either root → same content-addressed ref → counted twice →
+    // kept hoisted (not inlined). Both nodes point at the one shared entry.
+    const fillsA = result.nodes[0].fills;
+    const fillsB = result.nodes[1].fills;
+    expect(typeof fillsA).toBe("string");
+    expect(fillsA).toBe(fillsB);
+    expect(result.globalVars.styles[fillsA as string]).toBeDefined();
+
+    const fillEntries = Object.keys(result.globalVars.styles).filter((k) => k.startsWith("fill"));
+    expect(fillEntries).toHaveLength(1);
+  });
+
+  it("inlines a style used by only one node, even when other nodes are present", async () => {
+    const response = makeNodesResponse({
+      "1:2": { document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME", fills: RED_FILL }) },
+      "3:4": { document: makeNode({ id: "3:4", name: "Frame B", type: "FRAME" }) },
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    // Single use across the whole forest → inlined back onto the node, nothing
+    // left hoisted.
+    expect(Array.isArray(result.nodes[0].fills)).toBe(true);
+    expect(Object.keys(result.globalVars.styles)).toHaveLength(0);
+  });
+
+  it("templates structurally identical subtrees that live under different roots", async () => {
+    const child = () => makeNode({ id: "c", name: "Box", type: "RECTANGLE", fills: RED_FILL });
+    const response = makeNodesResponse({
+      "1:2": {
+        document: makeNode({ id: "1:2", name: "Frame A", type: "FRAME", children: [child()] }),
+      },
+      "3:4": {
+        document: makeNode({ id: "3:4", name: "Frame B", type: "FRAME", children: [child()] }),
+      },
+    });
+
+    const result = await simplifyRawFigmaObject(response, allExtractors);
+
+    // The identical rectangle appears once under each root → one shared element
+    // template, each occurrence reduced to a `template` ref.
+    expect(Object.keys(result.elements)).toHaveLength(1);
+    const [templateId] = Object.keys(result.elements);
+    expect(result.nodes[0].children![0].template).toBe(templateId);
+    expect(result.nodes[1].children![0].template).toBe(templateId);
+  });
+});
+
+// Regression: a partial miss (some ids resolve, some are null) used to crash the
+// metrics pass — which runs on the raw response after simplify — because it
+// dereferenced every node entry as non-null.
+describe("metrics tolerate null node entries (partial miss)", () => {
+  const response = makeNodesResponse({
+    "1:2": {
+      document: makeNode({
+        id: "1:2",
+        name: "Frame A",
+        type: "FRAME",
+        boundVariables: { fills: [{ type: "VARIABLE_ALIAS", id: "VariableID:1:1" }] },
+      }),
+      styles: { "S:1": { name: "Brand/Primary" } as Style },
+    },
+    "9:9": null,
+  });
+
+  it("countNamedStyles ignores the null entry", () => {
+    expect(() => countNamedStyles(response)).not.toThrow();
+    expect(countNamedStyles(response)).toBe(1);
+  });
+
+  it("detectVariables ignores the null entry", () => {
+    expect(() => detectVariables(response)).not.toThrow();
+    expect(detectVariables(response)).toBe(true);
   });
 });
 

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -23,6 +23,13 @@ export function serializeAsTree(design: SerializableDesign): string {
   // whitespace, which would otherwise produce a malformed `NAME: foo: bar` line.
   sections.push(`NAME: ${quote(design.metadata.name)}`);
 
+  // Partial-miss warning: requested nodes the API couldn't resolve. Present only
+  // on a multi-node fetch where some ids resolved and some didn't, so the LLM
+  // doesn't treat a partial result as complete.
+  if (design.metadata.missingNodeIds && design.metadata.missingNodeIds.length > 0) {
+    sections.push(`MISSING_NODES: ${design.metadata.missingNodeIds.join(", ")}`);
+  }
+
   if (Object.keys(design.globalVars.styles).length > 0) {
     sections.push(`\nGLOBAL_VARS:\n${dumpYaml(design.globalVars.styles)}`);
   }


### PR DESCRIPTION
## What this enables

`get_figma_data` can now fetch **several top-level nodes in a single call** by passing comma-separated ids (`nodeId: "1:2,3:4"`). Previously, assembling a multi-frame design meant one tool call per node — more round-trips, more latency, more tokens spent re-sending the file context each time. The LLM driving the tool can now grab every frame it needs at once.

Two audiences benefit:

- **Tool callers (LLMs / end users):** multi-node fetch in one request; and on a *partial* miss (some ids resolve, some don't) the result now carries a `MISSING_NODES` marker so the model knows it's working from an incomplete design instead of silently assuming it got everything.
- **Developers in this code:** `parseAPIResponse` is no longer a two-branch mutation bag — both API response shapes (full-file and by-nodes) normalize into a common slice list and aggregate declaratively. This PR also lands the FigmaService characterization tests that lock down the request/error path the feature exercises.

## Why now

The Figma REST API's `nodes?ids=` endpoint has always accepted a comma-separated list, but the parser only ever read the **first** node and dropped the rest. The same line also crashed with a raw `TypeError` when the API returned an empty `nodes` object — bypassing the friendly not-found guidance one line below it. This is a captured, grounded request (`docs/ideas/multi-node-fetch.md`), and the fix for "only reads the first node" is the same edit that removes the crash.

## What reviewers should know

- **Bundles two advisor plans:** the FigmaService request/error characterization tests (the safety net for the request layer) plus the multi-node feature itself. Squash-merges to one commit on `main`.
- **`getRawNode` is deliberately untouched** — it already passes the ids string straight through to the API, so no change was needed at the request layer.
- **Cross-node dedup was the main correctness risk and it's verified.** Style hoisting and element templating run over the combined forest (one shared `globalVars`/`traversalState`), so a style or subtree shared between two separately-requested nodes is counted across both and elevated once — the same machinery that already deduped across a full file's top-level frames. Tests cover the shared-hoist, single-use-inline, and cross-root-template cases.
- **Partial-miss handling:** unresolved ids are skipped (not fatal) as long as at least one node resolves; only an all-miss or empty response raises the tagged `not_found` error. The skipped ids are logged server-side and surfaced to the caller.
- **Out of scope (intentionally):** no change to the output wrapper shape beyond the optional `missingNodeIds`/`MISSING_NODES` field, and `download_figma_images` keeps its own single-node regex (it takes an array, not a comma scalar).

Reviewed for correctness across two independent passes (incl. a cross-model audit); full suite, type-check, and lint green.
