### PR TITLE
fix(common): validate image URLs against allowlist to prevent SSRF

### DIFF
--- a/src/tests/url-validation-bypass.test.ts
+++ b/src/tests/url-validation-bypass.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { assertSafeImageUrl } from "~/utils/url-validation.js";
+
+/**
+ * Supplemental adversarial tests for assertSafeImageUrl covering common
+ * SSRF bypass classes not exercised by the primary test file. These are
+ * derived from the SSRF skill checklist (IP encodings, IPv6 loopback,
+ * userinfo tricks, private ranges, additional cloud metadata endpoints).
+ */
+describe("assertSafeImageUrl - SSRF bypass classes", () => {
+  const shouldBlock = [
+    // Decimal / hex / octal encodings of 127.0.0.1 — WHATWG URL normalises
+    // most of these to 127.0.0.1 (loopback) which then fails the allowlist.
+    "https://2130706433/",
+    "https://0x7f000001/",
+    "https://017700000001/",
+
+    // 127.x shorthand — normalises to 127.0.0.1 or otherwise fails allowlist
+    "https://127.1/",
+    "https://127.0.1/",
+
+    // IPv6 loopback variants
+    "https://[::1]/",
+    "https://[0:0:0:0:0:0:0:1]/",
+
+    // Private ranges — must fail the allowlist even if the loopback check
+    // doesn't cover them explicitly
+    "https://10.0.0.1/",
+    "https://192.168.1.1/",
+    "https://172.16.0.1/",
+
+    // Link-local + additional cloud metadata endpoints
+    "https://169.254.169.254/latest/meta-data/",
+    "https://169.254.169.254.nip.io/",
+    "https://100.100.100.200/latest/meta-data/",
+    "https://metadata.google.internal/computeMetadata/v1/",
+
+    // Non-HTTPS schemes
+    "gopher://127.0.0.1:6379/_",
+    "dict://127.0.0.1:11211/stats",
+    "ftp://s3-alpha-sig.figma.com/x",
+    "javascript:alert(1)",
+    "data:text/html,evil",
+
+    // Userinfo trick — hostname is evil.com, not figma.com
+    "https://s3-alpha-sig.figma.com@evil.com/",
+    "https://evil.com#@s3-alpha-sig.figma.com/",
+
+    // Look-alike / homograph attempts
+    "https://figma.com.evil.com/",
+    "https://evilfigma.com/",
+    "https://figmausercontent.com.evil.tld/",
+  ];
+
+  for (const url of shouldBlock) {
+    it(`blocks ${url}`, () => {
+      expect(() => assertSafeImageUrl(url)).toThrow();
+    });
+  }
+
+  it("still allows legitimate Figma CDN URLs", () => {
+    expect(() =>
+      assertSafeImageUrl("https://s3-alpha-sig.figma.com/img/abc/123/image.png"),
+    ).not.toThrow();
+    expect(() =>
+      assertSafeImageUrl("https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/abc"),
+    ).not.toThrow();
+    expect(() => assertSafeImageUrl("https://cdn.figmausercontent.com/asset.png")).not.toThrow();
+  });
+});

--- a/src/tests/url-validation.test.ts
+++ b/src/tests/url-validation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { assertSafeImageUrl } from "~/utils/url-validation.js";
+
+describe("assertSafeImageUrl", () => {
+  it("allows Figma CDN URLs", () => {
+    expect(() =>
+      assertSafeImageUrl("https://s3-alpha-sig.figma.com/img/abc/123/image.png"),
+    ).not.toThrow();
+    expect(() =>
+      assertSafeImageUrl("https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/abc"),
+    ).not.toThrow();
+  });
+
+  it("blocks localhost", () => {
+    expect(() => assertSafeImageUrl("https://localhost/secret")).toThrow(/internal address/);
+    expect(() => assertSafeImageUrl("https://127.0.0.1/secret")).toThrow(/internal address/);
+  });
+
+  it("blocks cloud metadata endpoints", () => {
+    expect(() => assertSafeImageUrl("http://169.254.169.254/latest/meta-data/")).toThrow(
+      /insecure protocol/,
+    );
+    expect(() => assertSafeImageUrl("https://169.254.169.254/latest/meta-data/")).toThrow(
+      /internal address/,
+    );
+    expect(() => assertSafeImageUrl("https://metadata.google.internal/")).toThrow(
+      /internal address/,
+    );
+  });
+
+  it("blocks non-HTTPS", () => {
+    expect(() => assertSafeImageUrl("http://s3-alpha-sig.figma.com/img/abc.png")).toThrow(
+      /insecure protocol/,
+    );
+    expect(() => assertSafeImageUrl("file:///etc/passwd")).toThrow(/insecure protocol/);
+  });
+
+  it("blocks unknown hostnames", () => {
+    expect(() => assertSafeImageUrl("https://evil.com/image.png")).toThrow(/not in allowlist/);
+    expect(() => assertSafeImageUrl("https://attacker.com/redirect")).toThrow(/not in allowlist/);
+  });
+
+  it("blocks invalid URLs", () => {
+    expect(() => assertSafeImageUrl("not-a-url")).toThrow(/Invalid image URL/);
+  });
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { tagError } from "~/utils/error-meta.js";
+import { assertSafeImageUrl } from "~/utils/url-validation.js";
 import { isWithin } from "~/utils/local-path.js";
 
 export type StyleId = `${string}_${string}` & { __brand: "StyleId" };
@@ -30,6 +31,9 @@ export async function downloadFigmaImage(
         category: "invalid_input",
       });
     }
+
+    // Validate URL before fetching — defense-in-depth against SSRF
+    assertSafeImageUrl(imageUrl);
 
     // Use fetch to download the image
     const response = await fetch(imageUrl, {

--- a/src/utils/url-validation.ts
+++ b/src/utils/url-validation.ts
@@ -1,0 +1,56 @@
+/**
+ * Validates that a URL is safe to fetch — defense-in-depth against SSRF
+ * if the Figma API ever returns a crafted or unexpected URL.
+ *
+ * Allowed:
+ *  - HTTPS scheme only
+ *  - Hostnames matching known Figma CDN domains
+ *
+ * Blocked:
+ *  - Private/internal IPs, localhost, link-local, metadata endpoints
+ *  - Non-HTTPS schemes (http, file, ftp, etc.)
+ *  - Unknown hostnames
+ */
+
+const ALLOWED_HOST_PATTERNS: RegExp[] = [
+  // Figma's own domains (CDN, API, assets)
+  /^(.+\.)?figma\.com$/,
+  // Amazon S3 buckets used by Figma (e.g. s3-alpha-sig.figma.com is already
+  // covered above, but Figma has historically used raw S3 URLs too)
+  /^[\w.-]+\.amazonaws\.com$/,
+  // Figma image CDN
+  /^(.+\.)?figmausercontent\.com$/,
+];
+
+export function assertSafeImageUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid image URL: ${url}`);
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Refusing to fetch image over insecure protocol: ${parsed.protocol}`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Block obvious internal targets even if they somehow match a pattern
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname.startsWith("169.254.") ||
+    hostname === "metadata.google.internal"
+  ) {
+    throw new Error(`Refusing to fetch image from internal address: ${hostname}`);
+  }
+
+  const allowed = ALLOWED_HOST_PATTERNS.some((pattern) => pattern.test(hostname));
+  if (!allowed) {
+    throw new Error(
+      `Image URL hostname not in allowlist: ${hostname}. Expected a Figma CDN domain.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds an allowlist check on image URLs before the server fetches them in `downloadFigmaImage` (`src/utils/common.ts`). Today the URL is passed straight to `fetch()` after coming out of a Figma API response (`GetImageFillsResponse.meta.images` / `GetImagesResponse.images`). If the returned URL is ever crafted — e.g. a compromised Figma account/file, a malicious workspace shared with the caller, or a MITM against `api.figma.com` — the server-side `fetch()` would happily hit any host, including `127.0.0.1`, `10.0.0.0/8`, or cloud metadata endpoints like `http://169.254.169.254/latest/meta-data/`. This is a classic CWE-918 (Server-Side Request Forgery) pattern.

The change is small and defence-in-depth: it does not weaken the current happy path. Trusted Figma CDN URLs (`*.figma.com`, `figma-alpha-api.s3.*.amazonaws.com`, `*.figmausercontent.com`) still pass, but the server refuses to fetch anything else, refuses non-HTTPS schemes (`http://`, `file://`, `gopher://`, `dict://`, `javascript:`, `data:`), and explicitly blocks loopback / link-local / GCP metadata hosts even if they somehow matched a pattern.

## Vulnerability details

- **CWE:** CWE-918 (Server-Side Request Forgery)
- **File:** `src/utils/common.ts`, `downloadFigmaImage()`
- **Sink:** `fetch(imageUrl, { method: "GET" })` on line 39 (pre-fix line 32)
- **Data flow:** Figma API JSON response → `services/figma.ts` → passed as `imageUrl` argument → `fetch()`

The `imageUrl` string is trusted implicitly because it comes back from `api.figma.com`. It is not sanitised, not scheme-restricted, and not host-restricted. The MCP tool `download_figma_images` will reach this code path whenever a client asks for image downloads.

## Fix

New helper `src/utils/url-validation.ts` exports `assertSafeImageUrl(url)`:

- Parses the URL via WHATWG `URL` (throws on syntactically invalid input).
- Requires `protocol === "https:"`.
- Rejects `localhost`, `127.0.0.1`, `[::1]`, `169.254.*`, `metadata.google.internal` explicitly.
- Requires the hostname to match one of: `*.figma.com`, `*.amazonaws.com`, `*.figmausercontent.com`.

Called once, immediately before `fetch()` in `downloadFigmaImage`.

## Test results

Two new test files, 31 assertions in total, all passing under the existing `pnpm test` suite (16 files, 203 passed, 1 skipped — same skipped integration test as before):

- `src/tests/url-validation.test.ts` — 6 tests covering the primary allow/deny matrix.
- `src/tests/url-validation-bypass.test.ts` — 25 adversarial cases from the SSRF checklist:
  - Decimal / hex / octal encodings of `127.0.0.1` (`2130706433`, `0x7f000001`, `017700000001`)
  - Short-form loopback (`127.1`, `127.0.1`)
  - IPv6 loopback variants (`[::1]`, `[0:0:0:0:0:0:0:1]`)
  - RFC1918 ranges (`10.0.0.1`, `192.168.1.1`, `172.16.0.1`)
  - Cloud metadata endpoints (AWS `169.254.169.254`, Alibaba `100.100.100.200`, GCP `metadata.google.internal`)
  - `nip.io`-style resolvers
  - Non-HTTPS schemes (`gopher://`, `dict://`, `ftp://`, `javascript:`, `data:`)
  - Userinfo tricks (`https://figma.com@evil.com/`, `https://evil.com#@figma.com/`)
  - Look-alike hostnames (`figma.com.evil.com`, `evilfigma.com`, `figmausercontent.com.evil.tld`)

Legitimate Figma URLs (`s3-alpha-sig.figma.com`, `figma-alpha-api.s3.us-west-2.amazonaws.com`, `cdn.figmausercontent.com`) are asserted to still pass, so the fix is non-breaking for the intended flow.

Full test run:

```
Test Files  16 passed | 1 skipped (17)
     Tests  203 passed | 1 skipped (204)
```

`pnpm type-check`, `pnpm lint`, and the lefthook pre-commit chain (scan-hidden-chars / format / lint / type-check) also pass.

## Proof of concept

The minimum harness needed to demonstrate the pre-patch behaviour is a direct call to the exported `downloadFigmaImage`, since that is the exact entry point exercised by the `download_figma_images` MCP tool via `src/utils/image-processing.ts:111`.

Save as `poc-ssrf.mjs` at the repo root and run against `main` (pre-patch) vs. this branch:

```js
// poc-ssrf.mjs
import http from "node:http";
import { downloadFigmaImage } from "./dist/utils/common.js"; // after `pnpm build`

// Stand up a local "internal service" the server has no business reaching.
const internal = http.createServer((req, res) => {
  console.log("[internal] hit by SSRF:", req.url);
  res.writeHead(200, { "content-type": "image/png" });
  res.end("SECRET_INTERNAL_DATA");
}).listen(18080, "127.0.0.1");

// Simulates a crafted URL that reaches downloadFigmaImage — this is what
// would happen if the Figma API response were tampered with (compromised
// account, malicious shared file, MITM on api.figma.com).
try {
  const out = await downloadFigmaImage(
    "leak.png",
    "/tmp/ssrf-poc",
    "http://127.0.0.1:18080/etc/passwd",
  );
  console.log("[poc] SSRF succeeded — wrote", out);
} catch (e) {
  console.log("[poc] blocked:", e.message);
} finally {
  internal.close();
}
```

- **Before this patch:** `[internal] hit by SSRF: /etc/passwd` is logged and `/tmp/ssrf-poc/leak.png` contains `SECRET_INTERNAL_DATA`. The same PoC works against `http://169.254.169.254/latest/meta-data/iam/security-credentials/` on any EC2 host that runs the server.
- **After this patch:** `[poc] blocked: Refusing to fetch image over insecure protocol: http:`. Swapping to `https://127.0.0.1:18080/...` yields `Refusing to fetch image from internal address: 127.0.0.1`; swapping to `https://evil.com/x.png` yields `Image URL hostname not in allowlist: evil.com. Expected a Figma CDN domain.`

## Security analysis and adversarial review

Before submitting we deliberately tried to disprove this finding. Two things could have made it a non-issue:

1. **"The URL isn't attacker-controlled."** True in the direct sense — a random MCP client can't just pass an arbitrary URL to `fetch()`; the URL has to come back inside a Figma API JSON body. But the trust boundary is still wrong. Reaching this sink requires one of (a) a compromised Figma account or malicious shared file whose image references point at attacker-chosen URLs, (b) a MITM on the TLS connection to `api.figma.com` (rogue CA / corporate proxy), or (c) supply-chain compromise on the Figma side. None of those are hypothetical for a tool that runs inside developer environments and CI. Treating any `fetch()` of an externally-influenced URL as needing an allowlist is standard SSRF hygiene.
2. **"The server is only bound to `127.0.0.1` so nobody can reach it anyway."** This finding is about outbound requests the server itself makes, not inbound reachability. The default HTTP bind (`127.0.0.1`) and stdio mode don't change the SSRF surface — the server still initiates the internal fetch on behalf of whatever caller is on the box.

Given that, the fix is scoped intentionally: it does not try to be a general egress filter, only a guard on this one image-download path where the URL comes from a third-party API. Known limitations we considered:

- The patch does not set `redirect: "error"` on the underlying `fetch()`. Undici's default is `redirect: "follow"`, so a compromised Figma-hosted URL that returns a 302 to an internal target would still bypass validation at redirect time. That is a follow-up worth doing but felt out-of-scope for this PR — happy to add it here if you'd prefer a single change.
- `^[\w.-]+\.amazonaws\.com$` allows any AWS-hosted bucket, not just Figma's. Tightening to `figma-alpha-api.s3.*.amazonaws.com` is possible; we kept the broader pattern to avoid breaking if Figma rotates buckets/regions. Open to narrowing if you have a canonical list.
- No behavioural change for stdio-mode single-user-local usage; the guard is purely additive.

Nothing else in the tree calls `fetch()` on a URL that originates from a Figma API response, so a single call-site is sufficient. `assertSafeImageUrl` is a pure function with no side effects, making it easy to reason about and to extend later.