### PR TITLE
fix: envInt returns NaN for non-numeric env vars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,10 @@ export function envStr(name: string): string | undefined {
 export function envInt(...names: string[]): number | undefined {
   for (const name of names) {
     const val = process.env[name];
-    if (val) return parseInt(val, 10);
+    if (val) {
+      const n = parseInt(val, 10);
+      if (!isNaN(n)) return n;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
\`envInt\` was calling \`parseInt(val, 10)\` and returning the result directly, but \`parseInt("abc", 10)\` returns \`NaN\`. That \`NaN\` would propagate through the config as a valid number — setting \`PORT=abc\` would cause the HTTP server to try to listen on port \`NaN\`, producing a confusing error deep in Node's net module instead of a clear validation message.

Added an \`isNaN\` check so non-numeric environment variables are skipped and the default value is used instead.