### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-glips-figma-context-mcp)](https://mcpindex.ai/server/io-github-glips-figma-context-mcp)
+
 <a href="https://www.framelink.ai/?utm_source=github&utm_medium=referral&utm_campaign=readme" target="_blank" rel="noopener">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://www.framelink.ai/github/HeaderDark.png" />


### PR DESCRIPTION
Hey, Figma-Context-MCP is one of the more widely used MCP servers we see in Cursor/agent setups, so figured it was worth a proper check rather than assuming. Came back clean on mcpindex's description-level screen (injection/manipulation check, nothing deeper). Added the badge to your README. Advisory only, feel free to close if not useful.