### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you need more information on how to configure the Framelink MCP for Figma, se
 
 ## Star History
 
-<a href="https://star-history.com/#GLips/Figma-Context-MCP"><img src="https://api.star-history.com/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="Star History Chart" width="600" /></a>
+<a href="https://star-history.dera.page/#GLips/Figma-Context-MCP"><img src="https://star-history.dera.page/svg?repos=GLips/Figma-Context-MCP&type=Date" alt="Star History Chart" width="600" /></a>
 
 ## Learn More
 


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub stargazer API restrictions prevent the original service from rendering. This updates the chart to a working mirror so visitors can still see the project's growth at a glance.