### PR TITLE
fix: preserve node rotation, true size, ink bounds, and explicit line breaks

### DIFF
--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -310,7 +310,7 @@ export class FigmaService {
     fileKey: string,
     depth?: number | null,
   ): Promise<{ data: GetFileResponse; rawSize: number }> {
-    const endpoint = `/files/${fileKey}${depth ? `?depth=${depth}` : ""}`;
+    const endpoint = `/files/${fileKey}?geometry=paths${depth ? `&depth=${depth}` : ""}`;
     Logger.log(`Retrieving raw Figma file: ${fileKey} (depth: ${depth ?? "default"})`);
 
     const result = await this.requestWithSize<GetFileResponse>(endpoint);
@@ -330,7 +330,7 @@ export class FigmaService {
     nodeId: string,
     depth?: number | null,
   ): Promise<{ data: GetFileNodesResponse; rawSize: number }> {
-    const endpoint = `/files/${fileKey}/nodes?ids=${nodeId}${depth ? `&depth=${depth}` : ""}`;
+    const endpoint = `/files/${fileKey}/nodes?ids=${nodeId}&geometry=paths${depth ? `&depth=${depth}` : ""}`;
     Logger.log(
       `Retrieving raw Figma node: ${nodeId} from ${fileKey} (depth: ${depth ?? "default"})`,
     );

--- a/src/tests/rotation-transform.test.ts
+++ b/src/tests/rotation-transform.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect } from "vitest";
+import { buildSimplifiedLayout } from "~/transformers/layout.js";
+import type { Node as FigmaDocumentNode } from "@figma/rest-api-spec";
+
+// Values from a real production design (a marketing collage of tilted book
+// covers), cross-checked against Figma plugin-API measurements of the same
+// nodes. A 100x148.75 rectangle rotated -18.3° (Figma sign, CCW-positive)
+// whose relativeTransform translation is (111.43, 40).
+const CSS_PHI = (18.3 * Math.PI) / 180; // CSS clockwise angle for Figma -18.3
+const COS = Math.cos(CSS_PHI);
+const SIN = Math.sin(CSS_PHI);
+
+function makeParent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "1:1",
+    type: "FRAME",
+    clipsContent: false,
+    children: [],
+    absoluteBoundingBox: { x: 100, y: 200, width: 1440, height: 750 },
+    relativeTransform: [
+      [1, 0, 100],
+      [0, 1, 200],
+    ],
+    size: { x: 1440, y: 750 },
+    ...overrides,
+  } as unknown as FigmaDocumentNode;
+}
+
+function makeRotatedChild(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "1:2",
+    type: "RECTANGLE",
+    layoutSizingHorizontal: "FIXED",
+    layoutSizingVertical: "FIXED",
+    relativeTransform: [
+      [COS, -SIN, 111.43],
+      [SIN, COS, 40],
+    ],
+    size: { x: 100, y: 148.75 },
+    absoluteBoundingBox: {
+      x: 100 + 111.43 - 148.75 * SIN,
+      y: 200 + 40,
+      width: 100 * COS + 148.75 * SIN,
+      height: 100 * SIN + 148.75 * COS,
+    },
+    ...overrides,
+  } as unknown as FigmaDocumentNode;
+}
+
+describe("rotated-node transforms (geometry=paths)", () => {
+  test("rotated child emits rotation, true size, and pre-rotation top-left", () => {
+    const layout = buildSimplifiedLayout(makeRotatedChild(), makeParent());
+    expect(layout.rotation).toBeCloseTo(-18.3, 1);
+    expect(layout.dimensions?.width).toBeCloseTo(100, 1);
+    expect(layout.dimensions?.height).toBeCloseTo(148.75, 1);
+    expect(layout.locationRelativeToParent?.x).toBeCloseTo(111.43, 1);
+    expect(layout.locationRelativeToParent?.y).toBeCloseTo(40, 1);
+  });
+
+  test("unrotated child under an unrotated parent is unchanged (no rotation field, AABB location)", () => {
+    const child = {
+      id: "1:3",
+      type: "RECTANGLE",
+      layoutSizingHorizontal: "FIXED",
+      layoutSizingVertical: "FIXED",
+      relativeTransform: [
+        [1, 0, 1270.99],
+        [0, 1, 313],
+      ],
+      size: { x: 100, y: 150 },
+      absoluteBoundingBox: { x: 100 + 1270.99, y: 200 + 313, width: 100, height: 150 },
+    } as unknown as FigmaDocumentNode;
+    const layout = buildSimplifiedLayout(child, makeParent());
+    expect(layout.rotation).toBeUndefined();
+    expect(layout.locationRelativeToParent?.x).toBeCloseTo(1270.99, 1);
+    expect(layout.locationRelativeToParent?.y).toBeCloseTo(313, 1);
+  });
+
+  test("unrotated child of a ROTATED group still takes the transform path so nesting composes", () => {
+    const rotatedGroup = makeParent({
+      type: "GROUP",
+      relativeTransform: [
+        [COS, -SIN, 500],
+        [SIN, COS, 300],
+      ],
+    });
+    const child = {
+      id: "1:4",
+      type: "RECTANGLE",
+      layoutSizingHorizontal: "FIXED",
+      layoutSizingVertical: "FIXED",
+      relativeTransform: [
+        [1, 0, 30],
+        [0, 1, 10],
+      ],
+      size: { x: 64, y: 64 },
+      absoluteBoundingBox: { x: 0, y: 0, width: 90, height: 90 },
+    } as unknown as FigmaDocumentNode;
+    const layout = buildSimplifiedLayout(child, rotatedGroup);
+    // Local rotation ~0 → no rotation field, but location/size must come from
+    // the transform (the AABB delta would be in a different, mixed frame).
+    expect(layout.rotation).toBeUndefined();
+    expect(layout.dimensions?.width).toBeCloseTo(64, 1);
+    expect(layout.locationRelativeToParent?.x).toBeCloseTo(30, 1);
+    expect(layout.locationRelativeToParent?.y).toBeCloseTo(10, 1);
+  });
+
+  test("vector-class node with ink bounds away from its layout box emits parent-relative renderBounds", () => {
+    const textPath = {
+      id: "1:5",
+      type: "TEXT_PATH",
+      layoutSizingHorizontal: "FIXED",
+      layoutSizingVertical: "FIXED",
+      relativeTransform: [
+        [1, 0, -149],
+        [0, 1, 44],
+      ],
+      size: { x: 1481, y: 933 },
+      absoluteBoundingBox: { x: 100 - 149, y: 200 + 44, width: 1481, height: 933 },
+      absoluteRenderBounds: { x: 100, y: 200 + 300, width: 1380, height: 576 },
+    } as unknown as FigmaDocumentNode;
+    const layout = buildSimplifiedLayout(textPath, makeParent());
+    expect(layout.renderBounds).toEqual({ x: 0, y: 300, width: 1380, height: 576 });
+  });
+
+  test("renderBounds is not emitted when ink matches the layout box", () => {
+    const vector = {
+      id: "1:6",
+      type: "VECTOR",
+      layoutSizingHorizontal: "FIXED",
+      layoutSizingVertical: "FIXED",
+      absoluteBoundingBox: { x: 150, y: 250, width: 40, height: 40 },
+      absoluteRenderBounds: { x: 150.2, y: 250.2, width: 39.8, height: 39.8 },
+    } as unknown as FigmaDocumentNode;
+    const layout = buildSimplifiedLayout(vector, makeParent());
+    expect(layout.renderBounds).toBeUndefined();
+  });
+});

--- a/src/transformers/layout.ts
+++ b/src/transformers/layout.ts
@@ -1,5 +1,5 @@
 import { isInAutoLayoutFlow, isFrame, isLayout, isRectangle } from "~/utils/identity.js";
-import type { Node as FigmaDocumentNode, HasLayoutTrait } from "@figma/rest-api-spec";
+import type { Node as FigmaDocumentNode, HasLayoutTrait, Transform } from "@figma/rest-api-spec";
 import { generateCSSShorthand, pixelRound } from "~/utils/common.js";
 import {
   convertSelfAlign,
@@ -178,5 +178,87 @@ function buildSimplifiedLayoutValues(
     }
   }
 
+  // When geometry=paths supplies true transforms, undo the axis-aligned
+  // flattening for rotated nodes: absoluteBoundingBox is the box AROUND a
+  // rotated node — inflated and corner-anchored — which mis-sizes and
+  // mis-places anything tilted (a 100x148.75 cover at -18.3° reads as an
+  // unrotated 141.6x172.6). Emit the unrotated size, the pre-rotation
+  // top-left (the relativeTransform translation, already parent-relative),
+  // and the angle itself. Children of rotated groups take this path even
+  // when unrotated locally, so nested transforms compose.
+  const ln = n as unknown as HasLayoutTrait;
+  const pln = parent as unknown as HasLayoutTrait | undefined;
+  if (ln.relativeTransform && ln.size) {
+    const rotation = matrixRotationDeg(ln.relativeTransform);
+    const parentRotation = pln?.relativeTransform ? matrixRotationDeg(pln.relativeTransform) : 0;
+    if (
+      Math.abs(rotation) > ROTATION_EPSILON_DEG ||
+      Math.abs(parentRotation) > ROTATION_EPSILON_DEG
+    ) {
+      if (Math.abs(rotation) > ROTATION_EPSILON_DEG) {
+        layoutValues.rotation = pixelRound(rotation);
+      }
+      layoutValues.dimensions = {
+        width: pixelRound(ln.size.x),
+        height: pixelRound(ln.size.y),
+      };
+      layoutValues.locationRelativeToParent = {
+        x: pixelRound(ln.relativeTransform[0][2]),
+        y: pixelRound(ln.relativeTransform[1][2]),
+      };
+    }
+  }
+
+  // Vector-class nodes can render ink well inside their layout box — a
+  // text-on-path node's box says nothing about where the glyphs sit, so an
+  // exported asset placed at the box lands in the wrong place. Surface the
+  // ink bounds parent-relative when they differ materially from the box.
+  const rb = (
+    n as { absoluteRenderBounds?: { x: number; y: number; width: number; height: number } | null }
+  ).absoluteRenderBounds;
+  if (
+    rb &&
+    ln.absoluteBoundingBox &&
+    pln?.absoluteBoundingBox &&
+    VECTOR_RENDER_BOUND_TYPES.has(n.type)
+  ) {
+    const bb = ln.absoluteBoundingBox;
+    const differs =
+      Math.abs(rb.x - bb.x) > 1 ||
+      Math.abs(rb.y - bb.y) > 1 ||
+      Math.abs(rb.width - bb.width) > 1 ||
+      Math.abs(rb.height - bb.height) > 1;
+    if (differs) {
+      layoutValues.renderBounds = {
+        x: pixelRound(rb.x - pln.absoluteBoundingBox.x),
+        y: pixelRound(rb.y - pln.absoluteBoundingBox.y),
+        width: pixelRound(rb.width),
+        height: pixelRound(rb.height),
+      };
+    }
+  }
+
   return layoutValues;
+}
+
+// Below this, rounding noise in exported files produces spurious sub-pixel
+// "rotations"; at or under it a node is treated as upright.
+const ROTATION_EPSILON_DEG = 0.05;
+
+// Node types whose ink routinely diverges from their layout box. TEXT_PATH is
+// compared as a string because @figma/rest-api-spec predates it.
+const VECTOR_RENDER_BOUND_TYPES = new Set<string>([
+  "TEXT_PATH",
+  "VECTOR",
+  "BOOLEAN_OPERATION",
+  "STAR",
+  "LINE",
+  "POLYGON",
+]);
+
+// Rotation angle encoded in a Figma transform, in degrees with Figma's sign
+// convention (counter-clockwise positive). For a rotation by θ the matrix rows
+// are [[cos θ, sin θ, tx], [-sin θ, cos θ, ty]].
+function matrixRotationDeg(t: Transform): number {
+  return (Math.atan2(t[0][1], t[0][0]) * 180) / Math.PI;
 }

--- a/src/transformers/layout/common.ts
+++ b/src/transformers/layout/common.ts
@@ -50,6 +50,22 @@ export interface SimplifiedLayout {
   };
   overflowScroll?: ("x" | "y")[];
   position?: "absolute";
+  // Present only when the node is rotated (or sits inside a rotated group,
+  // so nested transforms compose). Degrees, Figma sign convention:
+  // counter-clockwise positive — the CSS equivalent is
+  // `transform: rotate(-<rotation>deg)` with `transform-origin: top left`.
+  // When the rotated path is taken, `dimensions` and
+  // `locationRelativeToParent` describe the UNROTATED box and its
+  // pre-rotation top-left in the parent's coordinate space, not the
+  // axis-aligned bounds (which are inflated and corner-anchored for any
+  // tilted node). Requires `relativeTransform`/`size` in the REST payload
+  // (`geometry=paths`).
+  rotation?: number;
+  // Ink bounds (absoluteRenderBounds) relative to the parent's bounding box,
+  // emitted for vector-class nodes whose rendered ink differs from their
+  // layout box (e.g. text-on-path, where the box says nothing about where
+  // the glyphs sit). Lets an exported derivative be placed exactly.
+  renderBounds?: { x: number; y: number; width: number; height: number };
 }
 
 export function convertSizing(

--- a/src/transformers/text.ts
+++ b/src/transformers/text.ts
@@ -310,8 +310,9 @@ export function buildFormattedText(
 }
 
 /**
- * Split characters into lines at `\n` / `\u2029` (paragraph separator — the
- * Figma API allows both). Each line carries its slice of the overrides
+ * Split characters into lines at `\n` / `\u2028` (line separator — what
+ * Shift+Return inserts) / `\u2029` (paragraph separator — the Figma API
+ * allows all three). Each line carries its slice of the overrides
  * array. The newline character itself is discarded along with its override.
  *
  * The returned line count matches what Figma's `lineTypes` /
@@ -326,7 +327,7 @@ function splitLines(
   let lineStart = 0;
   for (let i = 0; i <= codePoints.length; i++) {
     const ch = i < codePoints.length ? codePoints[i] : null;
-    if (ch === "\n" || ch === "\u2029" || ch === null) {
+    if (ch === "\n" || ch === "\u2028" || ch === "\u2029" || ch === null) {
       lines.push({
         codePoints: codePoints.slice(lineStart, i),
         overrides: overrides.slice(lineStart, i),
@@ -735,7 +736,7 @@ function classifyRun(
 const MARKDOWN_ESCAPE_CHARS = /[\\*_~[\](){}]/g;
 
 function escapeMarkdown(text: string): string {
-  return text.replace(MARKDOWN_ESCAPE_CHARS, "\\$&").replace(/[\n\u2029]/g, "\\n");
+  return text.replace(MARKDOWN_ESCAPE_CHARS, "\\$&").replace(/[\n\u2028\u2029]/g, "\\n");
 }
 
 /**


### PR DESCRIPTION
## Problem

The simplifier currently loses three classes of design facts:

1. **Rotation.** `absoluteBoundingBox` is the axis-aligned box *around* a rotated node — inflated and corner-anchored. A 100x148.75 rectangle at -18.3° is reported as an unrotated 141.6x172.6 box at the wrong position, and the angle is unrecoverable from the output. Any design with tilted elements (photo collages, decorative scatter, badges) cannot be implemented faithfully from the simplified data: consumers render everything upright and oversized.
2. **Ink bounds.** For text-on-path and vector nodes, the layout box says nothing about where the rendered ink sits, so an exported asset placed at the reported box lands in the wrong place.
3. **Explicit line breaks.** Figma's ` ` (what Shift+Return inserts) passes through unescaped while `\n`/` ` are escaped to `\n` markers, so a designer's manual break silently collapses into a space in HTML and the text re-wraps differently from the design.

Root cause for 1–2: the REST requests never pass `geometry=paths`, so Figma never sends `relativeTransform`/`size`, and the transformer only reads bounding boxes.

## Change

- Request `geometry=paths` on `getRawFile`/`getRawNode`.
- When a node (or its parent group) is rotated beyond a 0.05° epsilon, emit `rotation` (degrees, Figma sign: counter-clockwise positive; CSS equivalent is `rotate(-<rotation>deg)` with `transform-origin: top left`), and switch `dimensions`/`locationRelativeToParent` to the true unrotated size and the pre-rotation top-left from `relativeTransform` (already parent-relative). Children of rotated groups take this path even when locally unrotated so nested transforms compose.
- Emit `renderBounds` (parent-relative `absoluteRenderBounds`) for vector-class nodes (`TEXT_PATH`, `VECTOR`, `BOOLEAN_OPERATION`, `STAR`, `LINE`, `POLYGON`) when ink differs from the layout box by more than 1px.
- Treat ` ` like `\n`/` ` in both the line splitter and the markdown escaper.

## Backward compatibility

- Unrotated nodes under unrotated parents produce byte-identical output (covered by a test).
- New fields are optional additions to `SimplifiedLayout`.
- `geometry=paths` increases the raw REST payload server-side; the simplified output only grows by the new fields on affected nodes.

## Validation

- 5 new vitest cases (`src/tests/rotation-transform.test.ts`); full suite passes (255 tests).
- Validated against a production Figma file: 30 rotated nodes (a marketing collage, including nested book+icon groups) cross-checked against independent Figma plugin-API measurements of the same nodes — rotation matched within 0.12°, sizes and positions exactly, and nested groups composed to the correct absolute angles (-30° / 17.73° / 2.77°).
