### PR TITLE
fix: pass unknown paint types through marked instead of throwing

### DIFF
--- a/src/tests/unknown-paint.test.ts
+++ b/src/tests/unknown-paint.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { parsePaint, buildSimplifiedStrokes } from "~/transformers/style.js";
+import type { Paint, Node as FigmaDocumentNode } from "@figma/rest-api-spec";
+
+// Paint types outside the REST spec reach real files: Figma code-component
+// CUSTOM paints (customEffectId + componentPropAssignments) were observed live
+// on 2026-08-22. The spec's Paint union cannot express them, so the fixture
+// casts through unknown exactly the way the API payload arrives at runtime.
+const customPaint = {
+  type: "CUSTOM",
+  visible: true,
+  blendMode: "NORMAL",
+  customEffectId: "CodeComponentId:20e41e41-fixture",
+  componentPropAssignments: [{ defId: "1:2", value: "fixture" }],
+} as unknown as Paint;
+
+const solidRed: Paint = {
+  type: "SOLID",
+  blendMode: "NORMAL",
+  color: { r: 1, g: 0, b: 0, a: 1 },
+};
+
+describe("unknown paint types", () => {
+  it("degrades to a marked passthrough instead of throwing", () => {
+    const fill = parsePaint(customPaint);
+    expect(fill).toEqual({ type: "CUSTOM", unknownPaint: true, raw: customPaint });
+  });
+
+  it("preserves the raw Figma fields for later consumers", () => {
+    const fill = parsePaint(customPaint) as { raw: Record<string, unknown> };
+    expect(fill.raw).toBe(customPaint);
+    expect(fill.raw.customEffectId).toBe("CodeComponentId:20e41e41-fixture");
+    expect(fill.raw.componentPropAssignments).toEqual([{ defId: "1:2", value: "fixture" }]);
+  });
+
+  it("leaves known paints untouched", () => {
+    expect(parsePaint(solidRed)).toMatch(/^#ff0000$/i);
+  });
+
+  it("does not abort stroke parsing when one stroke paint is unknown", () => {
+    const node = {
+      id: "1:1",
+      name: "mixed-strokes",
+      type: "RECTANGLE",
+      strokes: [solidRed, customPaint],
+      strokeWeight: 2,
+    } as unknown as FigmaDocumentNode;
+    const strokes = buildSimplifiedStrokes(node);
+    expect(strokes.colors).toHaveLength(2);
+    // Reversed to CSS stacking order: the unknown top paint leads, marked.
+    expect(strokes.colors[0]).toEqual({ type: "CUSTOM", unknownPaint: true, raw: customPaint });
+    expect(strokes.colors[1]).toMatch(/^#ff0000$/i);
+    expect(strokes.strokeWeight).toBe("2px");
+  });
+});

--- a/src/transformers/style.ts
+++ b/src/transformers/style.ts
@@ -1,7 +1,7 @@
 import type { Node as FigmaDocumentNode, Paint } from "@figma/rest-api-spec";
 import { generateCSSShorthand, isVisible } from "~/utils/common.js";
-import { tagError } from "~/utils/error-meta.js";
 import { hasValue, isStrokeWeights } from "~/utils/identity.js";
+import { Logger } from "~/utils/logger.js";
 
 import { convertColor, formatRGBAColor } from "./style/color.js";
 import { translateScaleMode, handleImageTransform, parsePatternPaint } from "./style/image.js";
@@ -21,10 +21,22 @@ import type { CSSRGBAColor, CSSHexColor } from "./style/color.js";
 import type { SimplifiedPatternFill } from "./style/image.js";
 import type { SimplifiedGradientFill } from "./style/gradient.js";
 
+/**
+ * A paint whose type this transformer does not recognize, passed through
+ * marked instead of dropped or thrown on. `raw` is the untouched Figma paint,
+ * so consumers that learn a new type later lose nothing in the meantime.
+ */
+export type SimplifiedUnknownFill = {
+  type: string;
+  unknownPaint: true;
+  raw: Paint;
+};
+
 export type SimplifiedFill =
   | SimplifiedImageFill
   | SimplifiedGradientFill
   | SimplifiedPatternFill
+  | SimplifiedUnknownFill
   | CSSRGBAColor
   | CSSHexColor;
 
@@ -148,6 +160,12 @@ export function parsePaint(raw: Paint, hasChildren: boolean = false): Simplified
       gradient: convertGradientToCss(raw),
     };
   } else {
-    tagError(new Error(`Unknown paint type: ${raw.type}`), { category: "internal" });
+    // Figma ships paint types faster than this transformer learns them (live
+    // example: code-component CUSTOM paints, which are absent from the REST
+    // spec). Throwing here failed an entire get_figma_data response over one
+    // paint on one node, so unknown types degrade instead: marked, with the
+    // raw paint preserved, and the rest of the simplification stays usable.
+    Logger.error(`Unknown paint type "${raw.type}" passed through unparsed.`);
+    return { type: raw.type, unknownPaint: true, raw };
   }
 }


### PR DESCRIPTION
## Problem

`parsePaint` throws on any paint type outside its known set (SOLID, IMAGE, PATTERN, the four gradients), and the throw fails the entire `get_figma_data` request. Paint types absent from the REST spec do reach real files: on 2026-08-22 we hit Figma code-component `CUSTOM` paints (`customEffectId: "CodeComponentId:..."` plus `componentPropAssignments`) on several nodes of a production file, and each one made its whole subtree uncapturable with `Error fetching file: Unknown paint type: CUSTOM`. Any future paint type Figma ships has the same effect until the transformer learns it.

## Change

Unknown paint types degrade instead of throwing: `parsePaint` returns `{ type, unknownPaint: true, raw }`, where `raw` is the untouched Figma paint object, and logs an error line. The fill is marked rather than silently dropped, so consumers can detect it (and still read the raw paint), while the rest of the simplification is unaffected. Adds `SimplifiedUnknownFill` to the `SimplifiedFill` union.

## Backward compatibility

- Output for all recognized paint types is unchanged.
- Requests that previously failed outright now succeed with a marked fill entry; nothing that previously succeeded changes shape.
- Downstream code that switches on fill `type` (e.g. image download collection matching `"IMAGE"`) skips the unknown entry naturally.

## Validation

- 4 new vitest cases (`src/tests/unknown-paint.test.ts`): marked passthrough, raw-field preservation, known paints untouched, and stroke parsing surviving a mixed known/unknown paint list. Against the current code, 3 of 4 fail with the exact production error (`Unknown paint type: CUSTOM`); with the change, the full suite passes (254 passed / 1 skipped).
- `tsc --noEmit` clean.

## Relation to #420

Independent of #420 (different files, no overlap); both come out of the same production usage. Happy to rebase either if both are accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
