### PR TITLE
README: context-cost badge (946 tokens, measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://framelink.ai/discord">
     <img alt="Discord" src="https://img.shields.io/discord/1352337336913887343?color=7389D8&label&logo=discord&logoColor=ffffff" />
   </a>
+  <a href="https://athakur3.github.io/mcp-context-cost/servers/figma-context.html">
+    <img alt="context cost" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Ffigma-context.json" />
+  </a>
   <br />
   <a href="https://twitter.com/glipsman">
     <img alt="Twitter" src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fglipsman&label=%40glipsman" />


### PR DESCRIPTION
This adds one badge to the README's badge row: what figma-developer-mcp's tool schemas cost in context tokens — **946 tokens** across 2 tools (o200k_base over the canonical `tools/list` bytes), which is the "lean" band, i.e. good news for your users.

Where it comes from: the Framelink Figma MCP is one of 106 MCP servers measured on a rotation in credential-free Docker. Every number is backed by the raw capture, its SHA-256 and the exact launch command; your page has the per-tool breakdown and the history line: https://athakur3.github.io/mcp-context-cost/servers/figma-context.html · method: https://github.com/athakur3/mcp-context-cost/blob/main/docs/METHODOLOGY.md

The badge JSON is regenerated each time the server is re-measured (about every six weeks), so it follows your releases, and it links to the measurement rather than to a landing page. Anyone can re-derive the number:

    npx -y mcp-context-cost verify --remote https://raw.githubusercontent.com/athakur3/mcp-context-cost/main/results/figma-context/measurement.json

The markup matches the existing badges (an `<a>` around an `<img>`, inside the centered block). If you'd rather host the badge JSON yourselves, that's a one-line change here. Happy to adjust the placement or close this if it isn't wanted. Disclosure: I maintain mcp-context-cost.
