### PR TITLE
feat: extract and surface Dev Mode annotations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,7 +113,7 @@ _Investigate feasibility / value_
   - [ ] Component dependency graphs
 - [ ] **Figma File Metadata**
   - [ ] Investigate how we can use frames that are marked "Ready for Dev"
-  - [ ] Investigate feasibility of pulling in annotations via the Figma API
+  - [x] Investigate feasibility of pulling in annotations via the Figma API — done, see `annotationExtractor`
   - [ ] Investigate feasibility/value of using—and even modifying—"Dev Resources" links via Figma API
 
 ## Contributing

--- a/src/extractors/README.md
+++ b/src/extractors/README.md
@@ -37,6 +37,7 @@ const textData = extractFromDesign(nodes, contentOnly, {
 - `textExtractor` - Text content and typography styles
 - `visualsExtractor` - Visual appearance (fills, strokes, effects, opacity, borders)
 - `componentExtractor` - Component instance data
+- `annotationExtractor` - Dev Mode annotations (designer notes and pinned properties)
 
 ### Convenience Combinations
 

--- a/src/extractors/built-in.ts
+++ b/src/extractors/built-in.ts
@@ -20,6 +20,7 @@ import {
   simplifyPropertyDefinitions,
   simplifyPropertyReferences,
 } from "~/transformers/component.js";
+import { isAnnotationArray, simplifyAnnotations } from "~/transformers/annotation.js";
 import { hasAutoLayout, hasValue, isRectangleCornerRadii } from "~/utils/identity.js";
 import { isVisible, stableStringify } from "~/utils/common.js";
 import { createHash } from "node:crypto";
@@ -277,6 +278,22 @@ export const componentExtractor: ExtractorFn = (node, result, context) => {
   }
 };
 
+/**
+ * Extracts Dev Mode annotations (designer notes and pinned properties) from a node.
+ *
+ * `@figma/rest-api-spec` doesn't type the `annotations` field — its
+ * `AnnotationsTrait` is published as an empty `object` — so this reads it via
+ * `hasValue`'s runtime guard rather than a static field access.
+ */
+export const annotationExtractor: ExtractorFn = (node, result, _context) => {
+  if (!hasValue("annotations", node, isAnnotationArray) || node.annotations.length === 0) return;
+
+  const simplified = simplifyAnnotations(node.annotations);
+  if (simplified.length > 0) {
+    result.annotations = simplified;
+  }
+};
+
 type StyleMatch = { name: string; id: string };
 
 // Helper to fetch a Figma style name for specific style keys on a node
@@ -317,7 +334,13 @@ function resolveStyleKey(
 /**
  * All extractors - replicates the current parseNode behavior.
  */
-export const allExtractors = [layoutExtractor, textExtractor, visualsExtractor, componentExtractor];
+export const allExtractors = [
+  layoutExtractor,
+  textExtractor,
+  visualsExtractor,
+  componentExtractor,
+  annotationExtractor,
+];
 
 /**
  * Layout and text only - useful for content analysis and layout planning.

--- a/src/extractors/index.ts
+++ b/src/extractors/index.ts
@@ -22,6 +22,7 @@ export {
   textExtractor,
   visualsExtractor,
   componentExtractor,
+  annotationExtractor,
   // Convenience combinations
   allExtractors,
   layoutAndText,

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -8,6 +8,7 @@ import type {
   SimplifiedComponentSetDefinition,
   SimplifiedPropertyDefinition,
 } from "~/transformers/component.js";
+import type { SimplifiedAnnotation } from "~/transformers/annotation.js";
 
 export type StyleTypes =
   | SimplifiedTextStyle
@@ -165,6 +166,8 @@ export interface SimplifiedNode {
   componentId?: string;
   componentProperties?: Record<string, boolean | string>;
   componentPropertyReferences?: Record<string, string>;
+  // Dev Mode annotations — designer notes and pinned properties left on the node.
+  annotations?: SimplifiedAnnotation[];
   // children
   children?: SimplifiedNode[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
   textExtractor,
   visualsExtractor,
   componentExtractor,
+  annotationExtractor,
   allExtractors,
   layoutAndText,
   contentOnly,

--- a/src/tests/serialization.test.ts
+++ b/src/tests/serialization.test.ts
@@ -149,6 +149,34 @@ describe("result serialization", () => {
       expect(output).toContain('componentProperties={"On Sale":true,"Size":"md"}');
     });
 
+    // Regression: annotations were added to SimplifiedNode and the extractor
+    // but the tree renderer's field whitelist wasn't updated, so Dev Mode
+    // annotations silently vanished from the default (tree) output format
+    // despite being present on the SimplifiedNode object.
+    it("emits annotations", () => {
+      const design: SimplifiedDesign = {
+        name: "Test",
+        components: {},
+        componentSets: {},
+        globalVars: { styles: {} },
+        elements: {},
+        nodes: [
+          {
+            id: "1:1",
+            name: "Label",
+            type: "TEXT",
+            annotations: [{ label: "Needs i18n string", properties: ["fills"] }],
+          },
+        ],
+      };
+
+      const output = serializeResult(wrapForSerialization(design), "tree");
+
+      expect(output).toContain(
+        'annotations=[{"label":"Needs i18n string","properties":["fills"]}]',
+      );
+    });
+
     // After count-gating, single-use style values live inline on the node rather
     // than as a globalVars ref. The tree renderer must emit them as compact JSON.
     it("renders inline (non-reference) style values as JSON", () => {

--- a/src/tests/tree-walker.test.ts
+++ b/src/tests/tree-walker.test.ts
@@ -671,6 +671,54 @@ describe("component property support", () => {
   });
 });
 
+describe("annotationExtractor", () => {
+  it("simplifies a Dev Mode annotation to label + pinned property names", async () => {
+    const node = makeNode({
+      id: "20:1",
+      name: "Card",
+      type: "FRAME",
+      annotations: [
+        {
+          labelMarkdown: "Use the **primary** token here",
+          properties: [{ type: "fills" }, { type: "cornerRadius" }],
+          categoryId: "a1",
+        },
+      ],
+    });
+
+    const { nodes } = await extractFromDesign([node], allExtractors);
+
+    expect(nodes[0].annotations).toEqual([
+      {
+        label: "Use the **primary** token here",
+        properties: ["fills", "cornerRadius"],
+        categoryId: "a1",
+      },
+    ]);
+  });
+
+  it("prefers plain label when labelMarkdown is absent", async () => {
+    const node = makeNode({
+      id: "20:2",
+      name: "Icon",
+      type: "VECTOR",
+      annotations: [{ label: "Export at 2x" }],
+    });
+
+    const { nodes } = await extractFromDesign([node], allExtractors);
+
+    expect(nodes[0].annotations).toEqual([{ label: "Export at 2x" }]);
+  });
+
+  it("omits annotations when the node has none", async () => {
+    const node = makeNode({ id: "20:3", name: "Plain", type: "FRAME" });
+
+    const { nodes } = await extractFromDesign([node], allExtractors);
+
+    expect(nodes[0].annotations).toBeUndefined();
+  });
+});
+
 describe("simplifyRawFigmaObject", () => {
   it("produces a complete SimplifiedDesign from a mock API response", async () => {
     const mockResponse = {

--- a/src/transformers/annotation.ts
+++ b/src/transformers/annotation.ts
@@ -1,0 +1,46 @@
+/**
+ * Raw shape of a Dev Mode annotation as actually returned by the Figma REST
+ * API. `@figma/rest-api-spec` publishes `AnnotationsTrait` as an empty
+ * `object` (the field is undocumented in its generated types even though the
+ * live API returns it), so we model the wire shape ourselves rather than
+ * import it.
+ */
+export interface RawAnnotation {
+  label?: string;
+  labelMarkdown?: string;
+  properties?: { type: string }[];
+  categoryId?: string;
+}
+
+export function isAnnotationArray(val: unknown): val is RawAnnotation[] {
+  return Array.isArray(val);
+}
+
+export interface SimplifiedAnnotation {
+  // `labelMarkdown` supersedes `label` when both are present — same note,
+  // richer formatting — so only one survives simplification.
+  label?: string;
+  properties?: string[];
+  categoryId?: string;
+}
+
+/**
+ * Simplify Dev Mode annotations to the note text (preferring the markdown
+ * variant) plus the list of pinned property names. Drops entries that carry
+ * neither, which the API shouldn't produce but costs nothing to guard.
+ */
+export function simplifyAnnotations(annotations: RawAnnotation[]): SimplifiedAnnotation[] {
+  const result: SimplifiedAnnotation[] = [];
+  for (const annotation of annotations) {
+    const label = annotation.labelMarkdown ?? annotation.label;
+    const properties = annotation.properties?.map((p) => p.type);
+    if (!label && !properties?.length) continue;
+
+    result.push({
+      ...(label && { label }),
+      ...(properties?.length && { properties }),
+      ...(annotation.categoryId && { categoryId: annotation.categoryId }),
+    });
+  }
+  return result;
+}

--- a/src/utils/serialize-tree.ts
+++ b/src/utils/serialize-tree.ts
@@ -92,6 +92,9 @@ function renderNode(
   if (node.textStyle !== undefined) parts.push(`textStyle=${renderStyleValue(node.textStyle)}`);
   if (node.boldWeight !== undefined) parts.push(`boldWeight=${node.boldWeight}`);
   if (node.text !== undefined) parts.push(`text=${quote(node.text)}`);
+  if (node.annotations !== undefined) {
+    parts.push(`annotations=${JSON.stringify(node.annotations)}`);
+  }
 
   out.push(indent + parts.join(" "));
 


### PR DESCRIPTION
## Motivation

`ROADMAP.md` already listed this as an open item: "Investigate feasibility of pulling in annotations via the Figma API." This PR implements it.

## Background

`@figma/rest-api-spec` (v0.37.0) publishes `AnnotationsTrait` as an empty `object` — the `annotations` field on nodes isn't typed at all in the generated spec. However, the live Figma REST API does return it on nodes that carry a Dev Mode annotation. I verified this against a real Figma file with an existing annotation — the raw `GET /v1/files/:key/nodes` response actually contains `"annotations": [{ "label": "..." }]` on the relevant node — so this isn't based on documentation alone, it's confirmed against live API responses.

## What changed

- `src/transformers/annotation.ts` (new): models the real wire shape (`label`, `labelMarkdown`, `properties[].type`, `categoryId`) since the spec package doesn't, and simplifies it to `{ label?, properties?: string[], categoryId? }` — preferring `labelMarkdown` over `label` when both are present, and dropping the property wrapper objects for token efficiency.
- `src/extractors/built-in.ts`: new `annotationExtractor`, added to `allExtractors` so it's included by default in `get_figma_data` output.
- `src/extractors/types.ts`: added `annotations?: SimplifiedAnnotation[]` to `SimplifiedNode`.
- `src/utils/serialize-tree.ts`: added `annotations=` rendering to the default tree output format.
- Wired through the `src/extractors/index.ts` / `src/index.ts` export barrels, updated `src/extractors/README.md`, and checked off the corresponding `ROADMAP.md` item.

## Testing

- Added unit tests for `annotationExtractor` (label/labelMarkdown precedence, pinned properties, omission when absent) in `src/tests/tree-walker.test.ts`.
- Added a regression test in `src/tests/serialization.test.ts` for the tree-format serializer — the field is easy to add to the extractor/type and forget to wire into the tree renderer's field whitelist, which is exactly what happened during my own testing before I caught it.
- Manually validated end-to-end against a live Figma file with an existing Dev Mode annotation: raw REST API response → `simplifyRawFigmaObject` → `serializeResult(..., "tree")`, confirming the annotation text survives all the way to the actual string the `get_figma_data` tool returns.
- `pnpm test`, `pnpm type-check`, `pnpm lint`, `pnpm prettier --check`, and `node scripts/scan-hidden-chars.mjs` all pass.

## Scope note

This only covers reading annotations (surfacing them in `get_figma_data` output), matching this project's read-only REST API architecture. There's no REST endpoint to write annotations back — only the Figma plugin API supports that — so this PR doesn't attempt it.
