### PR TITLE
fix: emit valid CSS for text shadows

### DIFF
--- a/src/tests/effects.test.ts
+++ b/src/tests/effects.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildSimplifiedEffects } from "~/transformers/effects.js";
-import type { Node as FigmaNode } from "@figma/rest-api-spec";
+import type { DropShadowEffect, InnerShadowEffect, Node as FigmaNode } from "@figma/rest-api-spec";
 
 // Only the effects array is read; cast through unknown like the other walker tests.
 function nodeWithEffects(effects: unknown[]): FigmaNode {
@@ -35,5 +35,66 @@ describe("buildSimplifiedEffects — blur", () => {
     );
     expect(result.filter).toBeUndefined();
     expect(result.backdropFilter).toBeUndefined();
+  });
+});
+
+describe("buildSimplifiedEffects — shadows", () => {
+  const dropShadow: DropShadowEffect = {
+    type: "DROP_SHADOW",
+    showShadowBehindNode: false,
+    visible: true,
+    blendMode: "NORMAL",
+    color: { r: 0, g: 0, b: 0, a: 0.5 },
+    offset: { x: 2, y: 3 },
+    radius: 4,
+  };
+  const innerShadow: InnerShadowEffect = {
+    ...dropShadow,
+    type: "INNER_SHADOW",
+    spread: 2,
+  };
+
+  it.each([undefined, 0, 5])("omits spread %s from CSS text-shadow", (spread) => {
+    const node = {
+      ...nodeWithEffects([{ ...dropShadow, spread }]),
+      type: "TEXT",
+    } as FigmaNode;
+
+    expect(buildSimplifiedEffects(node)).toEqual({
+      textShadow: "2px 3px 4px rgba(0, 0, 0, 0.5)",
+    });
+  });
+
+  it("keeps visible text drop shadows without an unsupported inset entry", () => {
+    const node = {
+      ...nodeWithEffects([
+        dropShadow,
+        innerShadow,
+        { ...dropShadow, visible: false },
+        { ...dropShadow, offset: { x: -2, y: -3 }, radius: 0 },
+      ]),
+      type: "TEXT",
+    } as FigmaNode;
+
+    expect(buildSimplifiedEffects(node)).toEqual({
+      textShadow: "2px 3px 4px rgba(0, 0, 0, 0.5), -2px -3px 0px rgba(0, 0, 0, 0.5)",
+    });
+  });
+
+  it("omits unsupported text inner shadows without dropping blur effects", () => {
+    const node = {
+      ...nodeWithEffects([innerShadow, { type: "LAYER_BLUR", radius: 8, visible: true }]),
+      type: "TEXT",
+    } as FigmaNode;
+
+    expect(buildSimplifiedEffects(node)).toEqual({ filter: "blur(4px)" });
+  });
+
+  it("preserves spread and inset for non-text box shadows", () => {
+    expect(
+      buildSimplifiedEffects(nodeWithEffects([{ ...dropShadow, spread: 5 }, innerShadow])),
+    ).toEqual({
+      boxShadow: "2px 3px 4px 5px rgba(0, 0, 0, 0.5), inset 2px 3px 4px 2px rgba(0, 0, 0, 0.5)",
+    });
   });
 });

--- a/src/transformers/effects.ts
+++ b/src/transformers/effects.ts
@@ -18,17 +18,19 @@ export type SimplifiedEffects = {
 export function buildSimplifiedEffects(n: FigmaDocumentNode): SimplifiedEffects {
   if (!hasValue("effects", n)) return {};
   const effects = n.effects.filter((e) => e.visible);
+  const isText = n.type === "TEXT";
 
-  // Handle drop and inner shadows (both go into CSS box-shadow)
+  // CSS text-shadow supports neither spread nor inset; an unsupported entry
+  // would invalidate the entire shadow list, including valid drop shadows.
   const dropShadows = effects
     .filter((e): e is DropShadowEffect => e.type === "DROP_SHADOW")
-    .map(simplifyDropShadow);
+    .map((effect) => (isText ? simplifyTextShadow(effect) : simplifyDropShadow(effect)));
 
   const innerShadows = effects
-    .filter((e): e is InnerShadowEffect => e.type === "INNER_SHADOW")
+    .filter((e): e is InnerShadowEffect => !isText && e.type === "INNER_SHADOW")
     .map(simplifyInnerShadow);
 
-  const boxShadow = [...dropShadows, ...innerShadows].join(", ");
+  const shadow = [...dropShadows, ...innerShadows].join(", ");
 
   // Handle blur effects - separate by CSS property. A zero-radius blur is a
   // no-op, so drop it entirely rather than emit a dead `blur(0px)`.
@@ -46,17 +48,21 @@ export function buildSimplifiedEffects(n: FigmaDocumentNode): SimplifiedEffects 
 
   const result: SimplifiedEffects = {};
 
-  if (boxShadow) {
-    if (n.type === "TEXT") {
-      result.textShadow = boxShadow;
+  if (shadow) {
+    if (isText) {
+      result.textShadow = shadow;
     } else {
-      result.boxShadow = boxShadow;
+      result.boxShadow = shadow;
     }
   }
   if (filterBlurValues) result.filter = filterBlurValues;
   if (backdropFilterValues) result.backdropFilter = backdropFilterValues;
 
   return result;
+}
+
+function simplifyTextShadow(effect: DropShadowEffect) {
+  return `${effect.offset.x}px ${effect.offset.y}px ${effect.radius}px ${formatRGBAColor(effect.color)}`;
 }
 
 function simplifyDropShadow(effect: DropShadowEffect) {


### PR DESCRIPTION
A Figma TEXT node with a drop shadow currently emits `2px 3px 4px 0px rgba(0, 0, 0, 0.5)` as `textShadow`. Browsers reject the fourth length and compute `text-shadow: none`, so even an ordinary text drop shadow disappears when the returned CSS is used.

Text shadows now use the supported three-length form, `2px 3px 4px rgba(0, 0, 0, 0.5)`. Inner-shadow entries are omitted for TEXT nodes because `inset` invalidates the entire list, including otherwise valid drop shadows. Non-TEXT box shadows retain their spread and inset values; blur output is unchanged.

CSS text-shadow cannot represent Figma spread or inner shadows; this fix does not attempt to emulate either. The grammar is defined in [CSS Text Decoration §4](https://www.w3.org/TR/css-text-decor-3/#text-shadow-property).

Validation:
- Same regression tests on base `c083d65c7e002923e7cb98f4e3bdafb105e90f6d`: 5 failures before, all 9 effects tests pass after. Covers absent/zero/nonzero spread, mixed and inner-only shadows, hidden effects, multiple shadows, blur preservation, and box-shadow compatibility.
- `pnpm test`: 256 passed, 1 skipped. The skipped test is the repository's opt-in live Figma integration test; no Figma account or design file was used.
- `pnpm type-check`, `pnpm lint`, `pnpm build`, `pnpm exec prettier --check "src/**/*.ts"`, and `node scripts/scan-hidden-chars.mjs` pass (Node 26.0.0, pnpm 10.10.0).
- Chrome 147: `CSS.supports("text-shadow", before)` is false and the computed value is `none`; the actual transformed output after this fix is supported and renders a shadow. The non-TEXT computed box shadow is identical before and after.

Only the effects transformer and its tests change. No dependencies or generated files change.
